### PR TITLE
Add distinct max_len and max_tokens parameters

### DIFF
--- a/openjury/evaluate.py
+++ b/openjury/evaluate.py
@@ -72,7 +72,7 @@ def evaluate_completions(
     method_B: str = "llama-2-70b-chat-hf",
     num_annotations: int | None = 50,
     use_tqdm: bool = False,
-    max_len: int | None = 8192,
+    truncate_input_chars: int | None = 8192,
     provide_explanation: bool = False,
 ):
     """
@@ -84,8 +84,8 @@ def evaluate_completions(
     :param method_B: another method to evaluate against `method_A`
     :param num_annotations: if specified will do at most `num_annotations` annotations
     :param use_tqdm:
-    :param max_len: if specified, truncates the length of completion, useful to save cost and avoid exceeding context
-    limit
+    :param truncate_input_chars: if specified, truncates the length of completion, useful to save cost and avoid
+    exceeding context limit
     :return:
     """
     local_path_tables = data_root / "tables"
@@ -144,7 +144,7 @@ def evaluate_completions(
         completions_A=completions_A.loc[instructions.index].tolist(),
         completions_B=completions_B.loc[instructions.index].tolist(),
         use_tqdm=use_tqdm,
-        max_len=max_len,
+        truncate_input_chars=truncate_input_chars,
         provide_explanation=provide_explanation,
     )
 
@@ -192,7 +192,7 @@ def annotate_battles(
     completions_B: list[str],
     system_prompt: str | None = None,
     user_prompt_template: str = None,
-    max_len: int | None = 8192,
+    truncate_input_chars: int | None = 8192,
     use_tqdm: bool = False,
     provide_explanation: bool = False,
 ) -> list[JudgeAnnotation]:
@@ -220,8 +220,7 @@ def annotate_battles(
     :param completions_B:
     :param system_prompt:
     :param user_prompt_template:
-    :param num_annotations:
-    :param max_len:
+    :param truncate_input_chars: Max characters to truncate completions before sending to judge.
     :param use_tqdm:
     :return:
     """
@@ -253,8 +252,8 @@ def annotate_battles(
         [
             {
                 "user_prompt": user_prompt,
-                "completion_A": truncate(completion_A, max_len=max_len),
-                "completion_B": truncate(completion_B, max_len=max_len),
+                "completion_A": truncate(completion_A, max_len=truncate_input_chars),
+                "completion_B": truncate(completion_B, max_len=truncate_input_chars),
             }
             for user_prompt, completion_A, completion_B in zip(
                 instructions, completions_A, completions_B

--- a/openjury/generate.py
+++ b/openjury/generate.py
@@ -17,7 +17,7 @@ def truncate(s: str, max_len: int | None = None):
 def generate_instructions(
     instructions: pd.Series,
     model: str,
-    max_len: int | None = 8192,
+    truncate_input_chars: int | None = 8192,
     max_tokens: int | None = 32768,
     use_tqdm: bool = True,
     system_prompt: str | None = None,
@@ -36,7 +36,7 @@ def generate_instructions(
     inputs = prompt_template.batch(
         [
             {
-                "user_prompt": truncate(user_prompt, max_len=max_len),
+                "user_prompt": truncate(user_prompt, max_len=truncate_input_chars),
             }
             for user_prompt in instructions
         ]
@@ -60,17 +60,17 @@ def generate_instructions(
 def generate_base(
     instructions: pd.Series,
     model: str,
-    max_len: int | None = 8192,
+    truncate_input_chars: int | None = 8192,
     max_tokens: int | None = 32768,
     use_tqdm: bool = False,
 ) -> pd.DataFrame:
     model = make_model(model, max_tokens=max_tokens)
 
-    inputs = [truncate(instruction, max_len=max_len) for instruction in instructions]
+    inputs = [truncate(instruction, max_len=truncate_input_chars) for instruction in instructions]
 
     completions = model.batch(
         inputs=inputs,
-        max_tokens=max_len,
+        max_tokens=max_tokens,
     )
 
     df_outputs = pd.DataFrame(


### PR DESCRIPTION
## Overview
as discussed with @geoalgo today, this PR adds CLI arguments for controlling input truncation and model generation limits:

- **`--max_len`** (default 8192): Maximum character length for truncating input text (instructions, completions) before sending to models. Prevents exceeding context limits (was previously hard-set to 200), effectively leading to judges that would notice cut-off completions and therefore base their decisions on that.

- **`--max_tokens`** (default 32768): Maximum number of tokens all models (A, B, and judge) can generate in their responses (was previously hard-coded to 32k)
- fixed minor bug:`--results_folder` parsed but never passed to the CliArgs dataclass

The first two parameters were previously hard-coded with inconsistent values (200 and 4096) and conflated together. This PR separates them as distinct concepts.

## Changes

- `generate_and_evaluate.py`: Added `--max_len` and `--max_tokens` CLI arguments, fixed `--result_folder` not being passed
- `generate.py`: Separated `max_len` (truncation) from `max_tokens` (generation) in `generate_instructions()` and `generate_base()`
- `evaluate.py`: Updated default `max_len` to 8192

## Usage

python -m openjury.generate_and_evaluate \
    --dataset alpaca-eval \
    --model_A ... \
    --model_B ... \
    --judge_model ... \
    --max_len 16384 \
    --max_tokens 8192

- Add --max_len (default 8192) for truncating input text (instructions, completions)
- Add --max_tokens (default 32768) for limiting model generation output
- Separate these concepts which were previously conflated
- Update defaults consistently across generate.py and evaluate.py
- Fix bug: --result_folder CLI arg was parsed but not passed to CliArgs