### PR TITLE
Fix ChatVLLM crash on models without a chat template

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ python openjury/generate_and_evaluate.py \
 **Note:** Ensure you have the required LangChain dependencies installed for your chosen provider.
 If you use remote endpoint, you would have to set your credentials.
 
+### Chat Templates (vLLM)
+
+When using vLLM, OpenJury automatically picks the right inference method based on the model:
+
+- **Instruct/chat models** (e.g. `swiss-ai/Apertus-8B-Instruct-2509`): the tokenizer already defines a chat template, so OpenJury uses `vllm.LLM.chat()` and the template is applied automatically.
+- **Base/pretrained models** (e.g. `swiss-ai/Apertus-8B-2509`): these typically don't ship a chat template. OpenJury detects this and falls back to `vllm.LLM.generate()` (plain text, no chat formatting). A warning is printed when this happens.
+
+If you need to force a specific chat template (for example, a base model that you know works with ChatML), pass it via `--chat_template`:
+
+```bash
+python openjury/generate_and_evaluate.py \
+  --dataset alpaca-eval \
+  --model_A VLLM/swiss-ai/Apertus-8B-2509 \
+  --model_B VLLM/swiss-ai/Apertus-8B-Instruct-2509 \
+  --judge_model VLLM/Qwen/Qwen2.5-32B-Instruct-GPTQ-Int8 \
+  --chat_template '{% for message in messages %}<|im_start|>{{ message["role"] }}\n{{ message["content"] }}<|im_end|>\n{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}'
+```
+
+This override applies to all vLLM models in the run. For remote providers (OpenAI, Together, OpenRouter), the flag is ignored since they handle templates server-side.
+
 ## 📊 Supported Datasets
 
 | Dataset               | Description                                                                                    |

--- a/openjury/generate.py
+++ b/openjury/generate.py
@@ -21,8 +21,9 @@ def generate_instructions(
     max_tokens: int | None = 32768,
     use_tqdm: bool = True,
     system_prompt: str | None = None,
+    chat_template: str | None = None,
 ) -> pd.DataFrame:
-    chat_model = make_model(model, max_tokens=max_tokens)
+    chat_model = make_model(model, max_tokens=max_tokens, chat_template=chat_template)
 
     # TODO improve prompt to generate instructions
     if system_prompt is None:
@@ -62,8 +63,9 @@ def generate_base(
     truncate_input_chars: int | None = 8192,
     max_tokens: int | None = 32768,
     use_tqdm: bool = False,
+    chat_template: str | None = None,
 ) -> pd.DataFrame:
-    model = make_model(model, max_tokens=max_tokens)
+    model = make_model(model, max_tokens=max_tokens, chat_template=chat_template)
 
     inputs = [
         truncate(instruction, max_len=truncate_input_chars)

--- a/openjury/generate_and_evaluate.py
+++ b/openjury/generate_and_evaluate.py
@@ -36,6 +36,7 @@ class CliArgs:
     truncate_all_input_chars: int = 8192
     max_out_tokens_models: int = 32768
     max_out_tokens_judge: int = 32768
+    chat_template: str | None = None
 
     result_folder: str = "results"
 
@@ -131,6 +132,14 @@ class CliArgs:
             default=32768,
             help="Max tokens the judge can generate (reasoning + scores).",
         )
+        parser.add_argument(
+            "--chat_template",
+            type=str,
+            required=False,
+            default=None,
+            help="Jinja2 chat template string to use instead of the model's tokenizer template. "
+            "If not provided, ChatML is used as fallback for models without a chat template.",
+        )
         args = parser.parse_args()
 
         return cls(
@@ -146,6 +155,7 @@ class CliArgs:
             truncate_all_input_chars=args.truncate_all_input_chars,
             max_out_tokens_models=args.max_out_tokens_models,
             max_out_tokens_judge=args.max_out_tokens_judge,
+            chat_template=args.chat_template,
             result_folder=args.result_folder,
         )
 
@@ -218,9 +228,9 @@ def main(args: CliArgs):
 
     # TODO currently we just support base models for fluency, we could also support instruction-tuned models
     gen_fun = (
-        partial(generate_base, truncate_input_chars=args.truncate_all_input_chars, max_tokens=args.max_out_tokens_models)
+        partial(generate_base, truncate_input_chars=args.truncate_all_input_chars, max_tokens=args.max_out_tokens_models, chat_template=args.chat_template)
         if is_fluency_task
-        else partial(generate_instructions, truncate_input_chars=args.truncate_all_input_chars, max_tokens=args.max_out_tokens_models)
+        else partial(generate_instructions, truncate_input_chars=args.truncate_all_input_chars, max_tokens=args.max_out_tokens_models, chat_template=args.chat_template)
     )
     completions_A = cache_function_dataframe(
         lambda: gen_fun(
@@ -254,6 +264,7 @@ def main(args: CliArgs):
     judge_chat_model = make_model(
         model=args.judge_model,
         max_tokens=args.max_out_tokens_judge,
+        chat_template=args.chat_template,
     )
     if is_fluency_task:
         system_prompt = """You are a highly efficient assistant, who evaluates and selects the best large language \

--- a/openjury/utils.py
+++ b/openjury/utils.py
@@ -1,6 +1,7 @@
 import time
 import asyncio
 import os
+import warnings
 from pathlib import Path
 from typing import Callable
 
@@ -136,14 +137,21 @@ class DummyModel:
 
 
 class ChatVLLM:
-    """VLLM wrapper using the native chat() method for proper chat template handling.
+    """VLLM wrapper that auto-detects whether to use chat() or generate().
 
-    The default LangChain VLLM wrapper uses vllm.LLM.generate() which does NOT apply
-    the model's chat template. This wrapper uses vllm.LLM.chat() instead, which
-    correctly formats prompts with <|im_start|>, <|im_end|>, <think> tags, etc.
+    Chat template handling:
+        - If ``chat_template`` is explicitly provided, always uses ``llm.chat()``
+          with that template (useful for models whose tokenizer lacks a template
+          but you know the correct one).
+        - If the tokenizer defines a chat template, uses ``llm.chat()`` and lets
+          vLLM apply the tokenizer's template automatically.
+        - If no chat template is found (typical for base/pretrained models),
+          falls back to ``llm.generate()`` and emits a warning.  This avoids the
+          ``ValueError`` raised by ``transformers >= v4.44`` which removed the
+          default chat template.
     """
 
-    def __init__(self, model: str, max_tokens: int = 8192, **vllm_kwargs):
+    def __init__(self, model: str, max_tokens: int = 8192, chat_template: str | None = None, **vllm_kwargs):
         from vllm import LLM, SamplingParams
 
         self.model_path = model
@@ -154,6 +162,29 @@ class ChatVLLM:
             temperature=0.6,
             top_p=0.95,
         )
+
+        # Resolve chat template:
+        # 1. Explicit override always wins → use chat() with that template
+        # 2. If tokenizer has one, use it → use chat() (pass None to vLLM)
+        # 3. No template found → fall back to generate() for base models
+        if chat_template:
+            self.chat_template = chat_template
+            self._use_generate = False
+            print(f"ChatVLLM: using explicit chat template for '{model}'")
+        else:
+            tokenizer = self.llm.get_tokenizer()
+            if not getattr(tokenizer, "chat_template", None):
+                warnings.warn(
+                    f"Model '{model}' tokenizer does not define a chat template. "
+                    f"Falling back to llm.generate() (no chat formatting). "
+                    f"Override with --chat_template if this model needs one.",
+                )
+                self.chat_template = None
+                self._use_generate = True
+            else:
+                self.chat_template = None  # let vLLM use the tokenizer's own
+                self._use_generate = False
+                print(f"ChatVLLM: using tokenizer's chat template for '{model}'")
 
     def _to_messages(self, input_item) -> list[dict]:
         """Convert LangChain prompt input to OpenAI-style messages."""
@@ -190,14 +221,35 @@ class ChatVLLM:
         else:
             raise ValueError(f"Unsupported input type: {type(input_item)}")
 
+    def _to_raw_text(self, input_item) -> str:
+        """Extract raw text from an input item for use with llm.generate()."""
+        if isinstance(input_item, str):
+            return input_item
+        # ChatPromptValue from LangChain
+        if hasattr(input_item, "to_string"):
+            return input_item.to_string()
+        # List of dicts (messages) - concatenate contents
+        if isinstance(input_item, list) and input_item and isinstance(input_item[0], dict):
+            return "\n".join(msg["content"] for msg in input_item)
+        raise ValueError(f"Cannot extract raw text from: {type(input_item)}")
+
     def batch(self, inputs: list, **invoke_kwargs) -> list[str]:
-        """Process a batch of inputs using vllm.LLM.chat()."""
-        messages_batch = [self._to_messages(inp) for inp in inputs]
-        outputs = self.llm.chat(
-            messages_batch,
-            self.sampling_params,
-            add_generation_prompt=True,
-        )
+        """Process a batch of inputs using vllm.LLM.chat() or llm.generate().
+
+        Uses ``llm.chat()`` when a chat template is available (instruct models),
+        and ``llm.generate()`` when no template is found (base models).
+        """
+        if self._use_generate:
+            prompts = [self._to_raw_text(inp) for inp in inputs]
+            outputs = self.llm.generate(prompts, self.sampling_params)
+        else:
+            messages_batch = [self._to_messages(inp) for inp in inputs]
+            outputs = self.llm.chat(
+                messages_batch,
+                self.sampling_params,
+                add_generation_prompt=True,
+                chat_template=self.chat_template,
+            )
         return [out.outputs[0].text for out in outputs]
 
     def invoke(self, input_item, **invoke_kwargs) -> str:
@@ -215,7 +267,16 @@ class ChatVLLM:
         )
 
 
-def make_model(model: str, max_tokens: int | None = 8192):
+def make_model(model: str, max_tokens: int | None = 8192, chat_template: str | None = None):
+    """Instantiate a model wrapper from a provider/model-name string.
+
+    Args:
+        model: Format ``{Provider}/{model_path}``, e.g.
+            ``VLLM/meta-llama/Llama-3.3-70B-Instruct``.
+        max_tokens: Maximum tokens the model may generate.
+        chat_template: Optional Jinja2 chat template override.  Only used by
+            the VLLM provider; silently ignored for other providers.
+    """
     model_provider = model.split("/")[0]
 
     if model_provider == "Dummy":
@@ -229,6 +290,7 @@ def make_model(model: str, max_tokens: int | None = 8192):
         return ChatVLLM(
             model=model_name,
             max_tokens=max_tokens if max_tokens else 8192,
+            chat_template=chat_template,
         )
 
     model_kwargs = {}


### PR DESCRIPTION
## What is the problem?

PR #8 introduced the `ChatVLLM` wrapper which switches from `vllm.LLM.generate()` to `vllm.LLM.chat()` so that chat templates get applied correctly. This works great for instruct models that ship a chat template in their tokenizer config. However, base/pretrained models like `swiss-ai/Apertus-8B-2509` don't define one. Since `transformers >= v4.44` no longer provides a default chat template, calling `vllm.LLM.chat()` on these models raises a `ValueError`. This also means we can't evaluate base models for fluency tasks anymore, which is something we need for the project.

## How do we solve it?

We detect at model load time whether a chat template is available and pick the right vLLM method accordingly. Three paths:

  1. **User passes `--chat_template`**: we use `llm.chat()` with that explicit template. Useful when you know the right format for a model whose tokenizer doesn't include one.
  2. **Tokenizer has a chat template**: we use `llm.chat()` and let vLLM apply it automatically. This is the default path for instruct models.
  3. **No chat template found**: we fall back to `llm.generate()` (plain text completion, no chat formatting) and print a warning. This is the expected path for base models used in fluency evaluation.

This way instruct models keep working as before, base models no longer crash, and users can still force a template via the CLI when needed.

## Changes

  - `openjury/utils.py`: add `warnings` import, three-path template detection in `ChatVLLM.__init__()`, new `_to_raw_text()` method for the `generate()` fallback, pass `chat_template` through `batch()` and `make_model()`
  - `openjury/generate.py`: forward `chat_template` parameter in `generate_instructions()` and `generate_base()`
  - `openjury/generate_and_evaluate.py`: add `--chat_template` CLI argument, thread it through `CliArgs`, `gen_fun` partials, and `make_model()` calls
  - `README.md`: document chat template behavior under "Model Specification"

  ## Testing

  Tested on L40S GPU with ```vllm 0.10.2``` using both Apertus 8B models:

  - `swiss-ai/Apertus-8B-2509` (base, no chat template): correctly falls back to `llm.generate()`, warning emitted, produces valid completions
  - `swiss-ai/Apertus-8B-Instruct-2509` (instruct, has chat template): correctly uses `llm.chat()` with the tokenizer's template
  - `swiss-ai/Apertus-8B-2509` + explicit ChatML template: correctly uses `llm.chat()` with the provided override
  - `make_model("VLLM/...")` end-to-end: `chat_template` parameter correctly forwarded through the full pipeline