### PR TITLE
Per-role GenerationConfig and backend plumbing

### DIFF
--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -24,6 +24,10 @@ _ACTIVE_CONFIG_PATH: str | None = None
 _ACTIVE_CLI_ARGS: list[str] | None = None
 
 
+def _drop_none(kwargs: dict[str, object]) -> dict[str, object]:
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
 class ModelArgs(BaseModel):
     """The model(s) under evaluation and their generation/engine settings."""
 
@@ -43,6 +47,20 @@ class ModelArgs(BaseModel):
     """Generation token budget for each evaluated-model answer (for vLLM, keep
     this <= ``max_model_len``)."""
 
+    temperature: float | None = None
+    """Sampling temperature for the evaluated model. Unset keeps the backend
+    default."""
+
+    top_p: float | None = None
+    """Nucleus-sampling probability for the evaluated model. Unset keeps the
+    backend default."""
+
+    top_k: int | None = None
+    """Top-k sampling cutoff for the evaluated model when supported."""
+
+    seed: int | None = None
+    """Backend sampling seed for the evaluated model when supported."""
+
     max_model_len: int | None = None
     """Optional total context window (prompt + generation) for the generation
     vLLM instance. Applies to vLLM models only."""
@@ -54,6 +72,107 @@ class ModelArgs(BaseModel):
     engine_kwargs: dict = Field(default_factory=dict)
     """JSON dict of engine-specific kwargs forwarded to the backend, e.g. for
     vLLM ``{"tensor_parallel_size": 2, "gpu_memory_utilization": 0.9}``."""
+
+    baseline_max_out_tokens: int | None = None
+    """Generation token budget for the baseline/opponent model. Unset inherits
+    ``model.max_out_tokens``."""
+
+    baseline_temperature: float | None = None
+    """Sampling temperature for the baseline/opponent model. Unset inherits
+    ``model.temperature``."""
+
+    baseline_top_p: float | None = None
+    """Nucleus-sampling probability for the baseline/opponent model. Unset
+    inherits ``model.top_p``."""
+
+    baseline_top_k: int | None = None
+    """Top-k sampling cutoff for the baseline/opponent model when supported.
+    Unset inherits ``model.top_k``."""
+
+    baseline_seed: int | None = None
+    """Backend sampling seed for the baseline/opponent model when supported.
+    Unset inherits ``model.seed``."""
+
+    baseline_max_model_len: int | None = None
+    """Optional total context window for the baseline/opponent vLLM instance.
+    Unset inherits ``model.max_model_len``."""
+
+    baseline_chat_template: str | None = None
+    """Jinja2 chat template for the baseline/opponent model. Unset inherits
+    ``model.chat_template``."""
+
+    baseline_engine_kwargs: dict | None = None
+    """JSON dict of engine-specific kwargs for the baseline/opponent model.
+    Unset inherits ``model.engine_kwargs``."""
+
+    def evaluated_generation_kwargs(self) -> dict[str, object]:
+        """Kwargs for model A / the evaluated model."""
+        kwargs: dict[str, object] = dict(self.engine_kwargs)
+        kwargs.update(
+            _drop_none(
+                {
+                    "max_tokens": self.max_out_tokens,
+                    "max_model_len": self.max_model_len,
+                    "chat_template": self.chat_template,
+                    "temperature": self.temperature,
+                    "top_p": self.top_p,
+                    "top_k": self.top_k,
+                    "seed": self.seed,
+                }
+            )
+        )
+        return kwargs
+
+    def baseline_generation_kwargs(self) -> dict[str, object]:
+        """Kwargs for model B / the baseline model."""
+        engine_kwargs = (
+            self.engine_kwargs
+            if self.baseline_engine_kwargs is None
+            else self.baseline_engine_kwargs
+        )
+        kwargs: dict[str, object] = dict(engine_kwargs)
+        kwargs.update(
+            _drop_none(
+                {
+                    "max_tokens": (
+                        self.baseline_max_out_tokens
+                        if self.baseline_max_out_tokens is not None
+                        else self.max_out_tokens
+                    ),
+                    "max_model_len": (
+                        self.baseline_max_model_len
+                        if self.baseline_max_model_len is not None
+                        else self.max_model_len
+                    ),
+                    "chat_template": (
+                        self.baseline_chat_template
+                        if self.baseline_chat_template is not None
+                        else self.chat_template
+                    ),
+                    "temperature": (
+                        self.baseline_temperature
+                        if self.baseline_temperature is not None
+                        else self.temperature
+                    ),
+                    "top_p": (
+                        self.baseline_top_p
+                        if self.baseline_top_p is not None
+                        else self.top_p
+                    ),
+                    "top_k": (
+                        self.baseline_top_k
+                        if self.baseline_top_k is not None
+                        else self.top_k
+                    ),
+                    "seed": (
+                        self.baseline_seed
+                        if self.baseline_seed is not None
+                        else self.seed
+                    ),
+                }
+            )
+        )
+        return kwargs
 
 
 class JudgeArgs(BaseModel):
@@ -68,8 +187,26 @@ class JudgeArgs(BaseModel):
     max_out_tokens: int = 32768
     """Generation token budget for the judge response (reasoning + scores)."""
 
+    temperature: float | None = None
+    """Sampling temperature for the judge model. Unset keeps the backend
+    default, except MT-Bench FastChat-compatible judging which defaults to
+    deterministic ``0.0``."""
+
+    top_p: float | None = None
+    """Nucleus-sampling probability for the judge model."""
+
+    top_k: int | None = None
+    """Top-k sampling cutoff for the judge model when supported."""
+
+    seed: int | None = None
+    """Backend sampling seed for the judge model when supported."""
+
     max_model_len: int | None = None
     """Optional total context window for the judge vLLM instance."""
+
+    chat_template: str | None = None
+    """Jinja2 chat template for the judge vLLM instance. Unset falls back to
+    ``model.chat_template`` for backward compatibility."""
 
     engine_kwargs: dict = Field(default_factory=dict)
     """JSON dict of engine kwargs applied to the judge model only (overrides
@@ -101,6 +238,34 @@ class JudgeArgs(BaseModel):
     strip_thinking_before_judging: bool = False
     """Strip ``<think>`` reasoning blocks from the battle completions before
     showing them to the judge."""
+
+    def model_kwargs(
+        self,
+        *,
+        base_engine_kwargs: dict | None = None,
+        fallback_chat_template: str | None = None,
+    ) -> dict[str, object]:
+        """Kwargs for constructing the judge model."""
+        kwargs: dict[str, object] = dict(base_engine_kwargs or {})
+        kwargs.update(self.engine_kwargs)
+        kwargs.update(
+            _drop_none(
+                {
+                    "max_tokens": self.max_out_tokens,
+                    "max_model_len": self.max_model_len,
+                    "chat_template": (
+                        self.chat_template
+                        if self.chat_template is not None
+                        else fallback_chat_template
+                    ),
+                    "temperature": self.temperature,
+                    "top_p": self.top_p,
+                    "top_k": self.top_k,
+                    "seed": self.seed,
+                }
+            )
+        )
+        return kwargs
 
 
 class GenerationArgs(BaseModel):

--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -20,7 +20,12 @@ from judgearena.evaluate import (
 from judgearena.generate import generate_instructions
 from judgearena.log import get_logger
 from judgearena.repro import _to_jsonable
-from judgearena.utils import cache_function_dataframe, compute_pref_summary, make_model
+from judgearena.utils import (
+    build_default_judge_model_kwargs,
+    cache_function_dataframe,
+    compute_pref_summary,
+    make_model,
+)
 
 if TYPE_CHECKING:
     from judgearena.config import RunConfig
@@ -300,17 +305,11 @@ def main(cfg: "RunConfig") -> dict:
     # Step 2: Generate completions for the model under evaluation
     logger.info("Step 2: Generating completions with %s", cfg.model.name)
 
-    # Only pass extra engine kwargs that are not None
-    extra_kwargs = dict(cfg.model.engine_kwargs)
-    if cfg.model.max_model_len is not None:
-        extra_kwargs["max_model_len"] = cfg.model.max_model_len
-    if cfg.model.chat_template is not None:
-        extra_kwargs["chat_template"] = cfg.model.chat_template
+    extra_kwargs = cfg.model.evaluated_generation_kwargs()
     use_tqdm = False
     gen_fun = partial(
         generate_instructions,
         truncate_input_chars=cfg.generation.truncate_all_input_chars,
-        max_tokens=cfg.model.max_out_tokens,
         use_tqdm=use_tqdm,
         **extra_kwargs,
     )
@@ -332,7 +331,7 @@ def main(cfg: "RunConfig") -> dict:
     cache_suffix = (
         f"{cfg.elo.arena}_{replace_slash(cfg.model.name)}_"
         f"{sampling_cache_token}_"
-        f"{languages_str}_{cfg.generation.truncate_all_input_chars}_{cfg.model.max_out_tokens}"
+        f"{languages_str}_{cfg.generation.truncate_all_input_chars}_{extra_kwargs['max_tokens']}"
         + (f"_{extra_kwargs_str}" if extra_kwargs_str else "")
     )
     if len(cache_suffix) > 100:
@@ -386,18 +385,17 @@ def main(cfg: "RunConfig") -> dict:
         for i in range(n)
     ]
 
-    judge_extra_kwargs = {}
-    if cfg.judge.max_model_len is not None:
-        judge_extra_kwargs["max_model_len"] = cfg.judge.max_model_len
-    if cfg.model.chat_template is not None:
-        judge_extra_kwargs["chat_template"] = cfg.model.chat_template
-    judge_extra_kwargs.update(cfg.model.engine_kwargs)
-    judge_extra_kwargs.update(cfg.judge.engine_kwargs)
+    judge_extra_kwargs = build_default_judge_model_kwargs(
+        cfg.judge.model,
+        cfg.model.engine_kwargs,
+        judge_engine_kwargs_override=cfg.judge.model_kwargs(
+            fallback_chat_template=cfg.model.chat_template,
+        ),
+    )
 
     def run_judge() -> pd.DataFrame:
         judge_chat_model = make_model(
             model=cfg.judge.model,
-            max_tokens=cfg.judge.max_out_tokens,
             **judge_extra_kwargs,
         )
         annotations, annotations_reversed, prefs = judge_and_parse_prefs(

--- a/judgearena/generate_and_evaluate.py
+++ b/judgearena/generate_and_evaluate.py
@@ -38,6 +38,7 @@ from judgearena.utils import (
     compute_pref_summary,
     data_root,
     download_hf,
+    generation_cache_token,
     is_thinking_model,
     make_model,
     read_df,
@@ -188,22 +189,28 @@ def _resolve_baseline_plan(
     raise ValueError(f"Unsupported baseline shape for dataset '{task}'.")
 
 
-def _build_generation_engine_kwargs(
-    cfg: "RunConfig", model_spec: str
+def _build_generation_kwargs(
+    cfg: "RunConfig", model_spec: str, *, role: str
 ) -> dict[str, object]:
-    """Battle-model engine kwargs, adding a thinking-token sub-budget when requested."""
-    generation_engine_kwargs = dict(cfg.model.engine_kwargs)
+    """Battle-model kwargs, adding a thinking-token sub-budget when requested."""
+    if role == "A":
+        generation_kwargs = cfg.model.evaluated_generation_kwargs()
+    elif role == "B":
+        generation_kwargs = cfg.model.baseline_generation_kwargs()
+    else:
+        raise ValueError(f"Unknown generation role: {role!r}")
     provider, _, model_name = model_spec.partition("/")
     if (
         cfg.judge.battle_thinking_token_budget is not None
         and provider == "VLLM"
         and is_thinking_model(model_name)
     ):
-        generation_engine_kwargs["thinking_token_budget"] = min(
+        max_tokens = int(generation_kwargs.get("max_tokens", cfg.model.max_out_tokens))
+        generation_kwargs["thinking_token_budget"] = min(
             int(cfg.judge.battle_thinking_token_budget),
-            int(cfg.model.max_out_tokens),
+            max_tokens,
         )
-    return generation_engine_kwargs
+    return generation_kwargs
 
 
 def load_contexts(dataset: str) -> pd.Series:
@@ -338,40 +345,49 @@ def main(cfg: "RunConfig"):
     # TODO currently we just support base models for fluency, we could also support instruction-tuned models
     generation_function = generate_base if is_fluency_task else generate_instructions
 
-    def _run_generation(model_spec: str) -> pd.DataFrame:
+    def _run_generation(
+        model_spec: str, *, generation_kwargs: dict[str, object]
+    ) -> pd.DataFrame:
         return generation_function(
             instructions=instructions,
             model=model_spec,
             truncate_input_chars=cfg.generation.truncate_all_input_chars,
-            max_tokens=cfg.model.max_out_tokens,
-            max_model_len=cfg.model.max_model_len,
-            chat_template=cfg.model.chat_template,
             use_tqdm=cfg.run.use_tqdm,
-            **_build_generation_engine_kwargs(cfg, model_spec),
+            **generation_kwargs,
         )
 
     def _align_completion_series(df: pd.DataFrame) -> pd.Series:
         return df.set_index("instruction_index").loc[instructions.index, "completion"]
 
-    def _load_or_generate_completions(model_spec: str) -> pd.Series:
+    def _load_or_generate_completions(model_spec: str, *, role: str) -> pd.Series:
         preloaded = try_load_dataset_completions(cfg.task, model_spec, n_instructions)
         if preloaded is not None:
             return _align_completion_series(preloaded)
+        # Fold the resolved generation kwargs into the cache key so that changing
+        # any sampling param (temperature, seed, top_p/k, max_tokens, ...) busts
+        # the cached completions instead of silently reusing a stale run.
+        generation_kwargs = _build_generation_kwargs(cfg, model_spec, role=role)
+        sampling_token = generation_cache_token(generation_kwargs)
         generated = cache_function_dataframe(
-            lambda: _run_generation(model_spec),
+            lambda: _run_generation(model_spec, generation_kwargs=generation_kwargs),
             ignore_cache=ignore_cache,
-            cache_name=f"{cfg.task}_{model_spec}_{cfg.generation.n_instructions}",
+            cache_name=(
+                f"{cfg.task}_{model_spec}_{cfg.generation.n_instructions}_"
+                f"{sampling_token}"
+            ),
         )
         return _align_completion_series(generated)
 
-    completions_A = _load_or_generate_completions(cfg.model.name)
+    completions_A = _load_or_generate_completions(cfg.model.name, role="A")
 
     baseline_per_index = baseline_plan.aligned_to(instructions.index)
     if baseline_plan.is_flat:
-        completions_B = _load_or_generate_completions(baseline_plan.single_model)
+        completions_B = _load_or_generate_completions(
+            baseline_plan.single_model, role="B"
+        )
     else:
         per_baseline_completions = {
-            model: _load_or_generate_completions(model)
+            model: _load_or_generate_completions(model, role="B")
             for model in baseline_plan.unique_models
         }
         completions_B = pd.Series(
@@ -394,13 +410,12 @@ def main(cfg: "RunConfig"):
 
     judge_chat_model = make_model(
         model=cfg.judge.model,
-        max_tokens=cfg.judge.max_out_tokens,
-        max_model_len=cfg.judge.max_model_len,
-        chat_template=cfg.model.chat_template,
         **build_default_judge_model_kwargs(
             cfg.judge.model,
             cfg.model.engine_kwargs,
-            judge_engine_kwargs_override=cfg.judge.engine_kwargs,
+            judge_engine_kwargs_override=cfg.judge.model_kwargs(
+                fallback_chat_template=cfg.model.chat_template,
+            ),
         ),
     )
 

--- a/judgearena/mt_bench/mt_bench_utils.py
+++ b/judgearena/mt_bench/mt_bench_utils.py
@@ -36,6 +36,7 @@ from judgearena.repro import _to_jsonable, write_run_metadata
 from judgearena.utils import (
     cache_function_dataframe,
     compute_pref_summary,
+    generation_cache_token,
     is_thinking_model,
     make_model,
 )
@@ -62,21 +63,27 @@ def _align_mt_bench_completions(
 
 
 def _build_mt_bench_generation_kwargs(
-    *, cfg: RunConfig, model_spec: str
+    *, cfg: RunConfig, model_spec: str, role: str
 ) -> dict[str, object]:
-    """Battle-model engine kwargs, adding a thinking-token sub-budget when requested."""
-    generation_engine_kwargs = dict(cfg.model.engine_kwargs)
+    """Battle-model kwargs, adding a thinking-token sub-budget when requested."""
+    if role == "A":
+        generation_kwargs = cfg.model.evaluated_generation_kwargs()
+    elif role == "B":
+        generation_kwargs = cfg.model.baseline_generation_kwargs()
+    else:
+        raise ValueError(f"Unknown generation role: {role!r}")
     provider, _, model_name = model_spec.partition("/")
     if (
         cfg.judge.battle_thinking_token_budget is not None
         and provider == "VLLM"
         and is_thinking_model(model_name)
     ):
-        generation_engine_kwargs["thinking_token_budget"] = min(
+        max_tokens = int(generation_kwargs.get("max_tokens", cfg.model.max_out_tokens))
+        generation_kwargs["thinking_token_budget"] = min(
             int(cfg.judge.battle_thinking_token_budget),
-            int(cfg.model.max_out_tokens),
+            max_tokens,
         )
-    return generation_engine_kwargs
+    return generation_kwargs
 
 
 def _generate_mt_bench_completions(
@@ -86,21 +93,26 @@ def _generate_mt_bench_completions(
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     cache_prefix = "mt-bench"
 
-    def _run_generation(model_name: str) -> pd.DataFrame:
+    def _run_generation(
+        model_name: str, *, generation_kwargs: dict[str, object]
+    ) -> pd.DataFrame:
+        # MT-Bench's category-aware temperatures only kick in when the user has
+        # not explicitly pinned a per-role temperature; otherwise the config
+        # override should win for reproducibility.
+        temperature_config = (
+            None if "temperature" in generation_kwargs else FASTCHAT_TEMPERATURE_CONFIG
+        )
         return generate_multiturn(
             questions=questions_df,
             model=model_name,
             truncate_input_chars=cfg.generation.truncate_all_input_chars,
-            max_tokens=cfg.model.max_out_tokens,
             use_tqdm=cfg.run.use_tqdm,
-            max_model_len=cfg.model.max_model_len,
-            chat_template=cfg.model.chat_template,
-            temperature_config=FASTCHAT_TEMPERATURE_CONFIG,
+            temperature_config=temperature_config,
             strip_thinking_before_turn_2_prompt=cfg.judge.strip_thinking_before_judging,
-            **_build_mt_bench_generation_kwargs(cfg=cfg, model_spec=model_name),
+            **generation_kwargs,
         )
 
-    def _load_or_generate(model_name: str) -> pd.DataFrame:
+    def _load_or_generate(model_name: str, *, role: str) -> pd.DataFrame:
         loaded_answers = load_mt_bench_model_answers(
             model_name, n_instructions=cfg.generation.n_instructions
         )
@@ -110,10 +122,19 @@ def _generate_mt_bench_completions(
                 completions=loaded_answers,
                 model_name=model_name,
             )
+        # Fold the resolved generation kwargs into the cache key so changing any
+        # sampling param busts cached completions instead of reusing a stale run.
+        generation_kwargs = _build_mt_bench_generation_kwargs(
+            cfg=cfg, model_spec=model_name, role=role
+        )
+        sampling_token = generation_cache_token(generation_kwargs)
         generated_answers = cache_function_dataframe(
-            lambda: _run_generation(model_name),
+            lambda: _run_generation(model_name, generation_kwargs=generation_kwargs),
             ignore_cache=ignore_cache,
-            cache_name=f"{cache_prefix}_{model_name}_{cfg.generation.n_instructions}",
+            cache_name=(
+                f"{cache_prefix}_{model_name}_{cfg.generation.n_instructions}_"
+                f"{sampling_token}"
+            ),
         )
         return _align_mt_bench_completions(
             questions_df=questions_df,
@@ -121,7 +142,9 @@ def _generate_mt_bench_completions(
             model_name=model_name,
         )
 
-    return _load_or_generate(cfg.model.name), _load_or_generate(cfg.model.baseline)
+    return _load_or_generate(cfg.model.name, role="A"), _load_or_generate(
+        cfg.model.baseline, role="B"
+    )
 
 
 def _build_mt_bench_input_payloads(
@@ -354,16 +377,13 @@ def run_mt_bench(
             "MT-Bench keeps the original FastChat-style explanation-plus-verdict "
             "prompt when delegated to FastChat compatibility mode."
         )
-    judge_model_kwargs = {
-        "model": cfg.judge.model,
-        "max_tokens": cfg.judge.max_out_tokens,
-        "max_model_len": cfg.judge.max_model_len,
-        "chat_template": cfg.model.chat_template,
-        **{**cfg.model.engine_kwargs, **cfg.judge.engine_kwargs},
-    }
-    if resolved_prompt.delegated:
-        judge_model_kwargs["temperature"] = 0.0
-    judge_chat_model = make_model(**judge_model_kwargs)
+    judge_model_kwargs = cfg.judge.model_kwargs(
+        base_engine_kwargs=cfg.model.engine_kwargs,
+        fallback_chat_template=cfg.model.chat_template,
+    )
+    if resolved_prompt.delegated and cfg.judge.temperature is None:
+        judge_model_kwargs.setdefault("temperature", 0.0)
+    judge_chat_model = make_model(model=cfg.judge.model, **judge_model_kwargs)
     if resolved_prompt.delegated:
         return _run_mt_bench_fastchat(
             cfg=cfg,

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import os
 import re
 import time
@@ -330,8 +331,9 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
 
 
 class DummyModel:
-    def __init__(self, name: str):
+    def __init__(self, name: str, **init_kwargs):
         self.name = name
+        self.init_kwargs = dict(init_kwargs)
         self.message = "/".join(name.split("/")[1:])
 
     def batch(self, inputs, **invoke_kwargs) -> list[str]:
@@ -401,6 +403,10 @@ class ChatVLLM:
         model: str,
         max_tokens: int = 8192,
         chat_template: str | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        top_k: int | None = None,
+        seed: int | None = None,
         **vllm_kwargs,
     ):
         from vllm import LLM, SamplingParams
@@ -444,11 +450,18 @@ class ChatVLLM:
                     stacklevel=2,
                 )
 
+        if seed is not None:
+            vllm_kwargs.setdefault("seed", int(seed))
+
         self._sampling_params_kwargs = {
             "max_tokens": max_tokens,
-            "temperature": float(vllm_kwargs.pop("temperature", 0.6)),
-            "top_p": float(vllm_kwargs.pop("top_p", 0.95)),
+            "temperature": 0.6 if temperature is None else float(temperature),
+            "top_p": 0.95 if top_p is None else float(top_p),
         }
+        if top_k is not None:
+            self._sampling_params_kwargs["top_k"] = int(top_k)
+        if seed is not None:
+            self._sampling_params_kwargs["seed"] = int(seed)
         if thinking_token_budget is not None:
             if max_tokens is not None:
                 thinking_token_budget = min(int(thinking_token_budget), int(max_tokens))
@@ -615,6 +628,48 @@ class ChatVLLM:
         )
 
 
+def _route_sampling_params(
+    engine_kwargs: dict,
+    *,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    top_k: int | None = None,
+    seed: int | None = None,
+    supported_fields: set[str] | None = None,
+    top_k_via_model_kwargs: bool = False,
+    provider: str = "",
+) -> dict:
+    """Route the cross-backend sampling params onto a provider's constructor kwargs.
+
+    Only params that are explicitly set (not ``None``) are applied.
+    ``top_k_via_model_kwargs`` tunnels ``top_k`` through ``model_kwargs`` for
+    OpenAI-compatible backends that do not expose it directly. When
+    ``supported_fields`` is provided, a param the target class cannot accept
+    (and cannot be tunneled) is dropped with a warning rather than being passed
+    through and raising at construction time.
+    """
+    for key, value in (
+        ("temperature", temperature),
+        ("top_p", top_p),
+        ("seed", seed),
+        ("top_k", top_k),
+    ):
+        if value is None:
+            continue
+        if key == "top_k" and top_k_via_model_kwargs:
+            engine_kwargs.setdefault("model_kwargs", {})["top_k"] = value
+            continue
+        if supported_fields is not None and key not in supported_fields:
+            logger.warning(
+                "%s backend does not support sampling param %r; dropping it.",
+                provider or "This",
+                key,
+            )
+            continue
+        engine_kwargs[key] = value
+    return engine_kwargs
+
+
 def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
     """Instantiate a model wrapper from a provider/model-name string.
 
@@ -623,6 +678,9 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
             ``VLLM/meta-llama/Llama-3.3-70B-Instruct``.
         max_tokens: Maximum tokens the model may generate.
         **engine_kwargs: Engine-specific options forwarded to the model wrapper.
+            Common keys honoured across backends: ``temperature``, ``top_p``,
+            ``top_k``, ``seed``. vLLM-only keys (``max_model_len``,
+            ``chat_template``) are stripped before reaching hosted providers.
     """
     # Avoid mutating the original engine_kwargs dictionary
     # NOTE: this is a shallow copy since we are not modifying any
@@ -631,6 +689,11 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
 
     # Dedicated arguments like max_tokens always win over engine_kwargs.
     engine_kwargs["max_tokens"] = max_tokens or 8192
+
+    temperature = engine_kwargs.pop("temperature", None)
+    top_p = engine_kwargs.pop("top_p", None)
+    top_k = engine_kwargs.pop("top_k", None)
+    seed = engine_kwargs.pop("seed", None)
 
     model_provider, model_name = _split_model_spec(model)
 
@@ -654,7 +717,15 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
             engine_kwargs.pop(key, None)
 
     if model_provider == "Dummy":
-        return DummyModel(model)
+        dummy_kwargs = {k: v for k, v in engine_kwargs.items() if v is not None}
+        _route_sampling_params(
+            dummy_kwargs,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            seed=seed,
+        )
+        return DummyModel(model, **dummy_kwargs)
 
     logger.info("Loading %s(model=%s)", model_provider, model_name)
 
@@ -662,6 +733,13 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
     if model_provider == "VLLM":
         engine_kwargs = {k: v for k, v in engine_kwargs.items() if v is not None}
         engine_kwargs["chat_template"] = engine_kwargs.get("chat_template", None)
+        _route_sampling_params(
+            engine_kwargs,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            seed=seed,
+        )
 
         return ChatVLLM(
             model=model_name,
@@ -670,22 +748,28 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
 
     if model_provider == "OpenRouter":
         # Special case we need to override API url and key
+        openai_kwargs = dict(engine_kwargs)
+        # OpenAI-compatible chat backends expose temperature/top_p/seed directly
+        # but not top_k, which has to be tunneled through model_kwargs.
+        _route_sampling_params(
+            openai_kwargs,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            seed=seed,
+            top_k_via_model_kwargs=True,
+        )
         return ChatOpenAI(
             api_key=os.getenv("OPENROUTER_API_KEY"),
             base_url="https://openrouter.ai/api/v1",
             model=model_name,
-            **engine_kwargs,
+            **openai_kwargs,
         )
     else:
         model_classes = [
             LlamaCpp,
             ChatOpenAI,
         ]
-        if model_provider == "LlamaCpp":
-            engine_kwargs["model_path"] = model_name
-        else:
-            engine_kwargs["model"] = model_name
-
         try:
             from langchain_together.llms import Together
 
@@ -702,7 +786,30 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
         assert model_provider in model_cls_dict, (
             f"{model_provider} not available, choose among {list(model_cls_dict.keys())}"
         )
-        return model_cls_dict[model_provider](**engine_kwargs)
+        model_cls = model_cls_dict[model_provider]
+        if model_provider == "LlamaCpp":
+            engine_kwargs["model_path"] = model_name
+        else:
+            engine_kwargs["model"] = model_name
+
+        # Route sampling params against the target class's accepted fields:
+        # tunnel top_k via model_kwargs when the class lacks a top_k field,
+        # and drop any param the class cannot accept (e.g. Together has no
+        # ``seed``) instead of raising at construction time.
+        supported_fields = set(getattr(model_cls, "model_fields", {}))
+        _route_sampling_params(
+            engine_kwargs,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            seed=seed,
+            supported_fields=supported_fields,
+            top_k_via_model_kwargs=(
+                "top_k" not in supported_fields and "model_kwargs" in supported_fields
+            ),
+            provider=model_provider,
+        )
+        return model_cls(**engine_kwargs)
 
 
 def download_all():
@@ -759,6 +866,18 @@ class Timeblock:
         name = self.name if self.name else "block"
         msg = f"{name} took {self.duration} seconds"
         return msg
+
+
+def generation_cache_token(kwargs: dict[str, object]) -> str:
+    """Short, deterministic token of generation kwargs for cache-key busting.
+
+    Folds the resolved per-role generation kwargs (sampling params, max_tokens,
+    chat_template, ...) into a stable 16-char hash so that changing any of them
+    invalidates cached completions. Hashing keeps the cache name bounded even
+    when a long ``chat_template`` is present.
+    """
+    serialized = "_".join(f"{k}={kwargs[k]!r}" for k in sorted(kwargs))
+    return hashlib.sha256(serialized.encode()).hexdigest()[:16]
 
 
 def cache_function_dataframe(

--- a/tests/test_seed_plumbing.py
+++ b/tests/test_seed_plumbing.py
@@ -1,0 +1,163 @@
+"""Verify per-role sampling parameters reach the underlying backend."""
+
+from __future__ import annotations
+
+from judgearena.config import RunConfig, build_run_config
+from judgearena.utils import generation_cache_token, make_model
+
+
+def test_make_model_dummy_captures_temperature_and_seed():
+    """Dummy backend records the constructor kwargs so tests can verify them."""
+    model = make_model("Dummy/foo", max_tokens=64, temperature=0.3, seed=42)
+    assert model.init_kwargs.get("temperature") == 0.3
+    assert model.init_kwargs.get("seed") == 42
+
+
+def test_make_model_dummy_forwards_top_p_and_top_k():
+    model = make_model("Dummy/foo", max_tokens=64, top_p=0.95, top_k=50)
+    assert model.init_kwargs.get("top_p") == 0.95
+    assert model.init_kwargs.get("top_k") == 50
+
+
+def test_make_model_dummy_forwards_engine_kwargs():
+    """Arbitrary engine-specific kwargs flow through to DummyModel.init_kwargs."""
+    model = make_model("Dummy/foo", max_tokens=64, my_extra_flag="hello")
+    assert model.init_kwargs.get("my_extra_flag") == "hello"
+
+
+def test_model_args_evaluated_generation_kwargs_skip_unset_fields():
+    cfg = RunConfig(
+        task="alpaca-eval",
+        model={"name": "Dummy/a", "baseline": "Dummy/b"},
+        judge={"model": "Dummy/j"},
+    )
+    assert cfg.model.evaluated_generation_kwargs() == {"max_tokens": 32768}
+
+
+def test_dedicated_sampling_fields_only_override_when_set():
+    cfg = RunConfig(
+        task="alpaca-eval",
+        model={
+            "name": "Dummy/a",
+            "baseline": "Dummy/b",
+            "engine_kwargs": {
+                "temperature": 0.5,
+                "top_p": 0.8,
+                "chat_template": "<engine-template>",
+            },
+        },
+        judge={
+            "model": "Dummy/j",
+            "engine_kwargs": {"temperature": 0.2},
+        },
+    )
+    assert cfg.model.evaluated_generation_kwargs() == {
+        "temperature": 0.5,
+        "top_p": 0.8,
+        "chat_template": "<engine-template>",
+        "max_tokens": 32768,
+    }
+    assert cfg.model.baseline_generation_kwargs() == {
+        "temperature": 0.5,
+        "top_p": 0.8,
+        "chat_template": "<engine-template>",
+        "max_tokens": 32768,
+    }
+    assert cfg.judge.model_kwargs() == {
+        "temperature": 0.2,
+        "max_tokens": 32768,
+    }
+
+
+def test_baseline_sampling_params_inherit_from_model_when_unset():
+    cfg = RunConfig(
+        task="alpaca-eval",
+        model={
+            "name": "Dummy/a",
+            "baseline": "Dummy/b",
+            "temperature": 0.3,
+            "top_p": 0.9,
+            "top_k": 40,
+            "seed": 7,
+            "baseline_temperature": 0.95,  # explicit override wins
+        },
+        judge={"model": "Dummy/j"},
+    )
+    assert cfg.model.baseline_generation_kwargs() == {
+        "max_tokens": 32768,
+        "temperature": 0.95,  # explicit baseline value
+        "top_p": 0.9,  # inherited from model.top_p
+        "top_k": 40,  # inherited from model.top_k
+        "seed": 7,  # inherited from model.seed
+    }
+
+
+def test_generation_cache_token_is_sensitive_to_sampling_params():
+    base = {"max_tokens": 32768, "temperature": 0.0, "seed": 1}
+    same = {"seed": 1, "temperature": 0.0, "max_tokens": 32768}  # order independent
+    changed_seed = {**base, "seed": 2}
+    changed_temp = {**base, "temperature": 1.0}
+
+    assert generation_cache_token(base) == generation_cache_token(same)
+    assert generation_cache_token(base) != generation_cache_token(changed_seed)
+    assert generation_cache_token(base) != generation_cache_token(changed_temp)
+
+
+def test_model_args_per_role_kwargs_are_independent():
+    cfg = RunConfig(
+        task="alpaca-eval",
+        model={
+            "name": "Dummy/a",
+            "baseline": "Dummy/b",
+            "temperature": 0.1,
+            "seed": 11,
+            "baseline_temperature": 0.9,
+            "baseline_seed": 22,
+            "baseline_max_out_tokens": 128,
+            "engine_kwargs": {"shared": True},
+            "baseline_engine_kwargs": {"baseline_only": True},
+        },
+        judge={"model": "Dummy/j", "temperature": 0.0, "seed": 33},
+    )
+    assert cfg.model.evaluated_generation_kwargs() == {
+        "shared": True,
+        "max_tokens": 32768,
+        "temperature": 0.1,
+        "seed": 11,
+    }
+    assert cfg.model.baseline_generation_kwargs() == {
+        "baseline_only": True,
+        "max_tokens": 128,
+        "temperature": 0.9,
+        "seed": 22,
+    }
+    assert cfg.judge.model_kwargs() == {
+        "max_tokens": 32768,
+        "temperature": 0.0,
+        "seed": 33,
+    }
+
+
+def test_nested_cli_sampling_flags_land_on_correct_roles():
+    cfg = build_run_config(
+        [
+            "--task",
+            "alpaca-eval",
+            "--model.name",
+            "Dummy/A",
+            "--model.baseline",
+            "Dummy/B",
+            "--judge.model",
+            "Dummy/J",
+            "--model.seed",
+            "11",
+            "--model.baseline_seed",
+            "22",
+            "--judge.temperature",
+            "0.0",
+        ]
+    )
+    assert cfg.model.seed == 11
+    assert cfg.model.baseline_seed == 22
+    assert cfg.judge.temperature == 0.0
+    assert cfg.model.temperature is None


### PR DESCRIPTION
## Summary

Exposes every generation knob that can affect produced text **independently for the three runtime roles** (the evaluated model (A), the baseline/opponent model (B), and the LLM judge) within the hierarchical `RunConfig` (pydantic-settings) introduced in #64, and plumbs those knobs through to each backend.

### Caching

The generated-completion cache keys in the pairwise (`generate_and_evaluate`) and MT-Bench paths now incorporate a hash of the resolved per-role generation kwargs (via `generation_cache_token`), matching the ELO path. Changing any sampling parameter (temperature, seed, top_p/k, max_tokens, chat_template, ...) now busts the cache instead of silently reusing a stale run. (Existing on-disk caches for these paths are regenerated on the next run.)

## Why

vLLM's sampling parameters were hard-coded (`temperature=0.6`, `top_p=0.95`) at the wrapper layer, hosted providers ignored the seed, and a single `max_out_tokens` was forced on both battle models even when you'd want to ablate them independently. Describing each role's generation explicitly — and keying the completion cache on it — is the foundation for hashing and replaying a run deterministically.

## Test plan

- [x] `tests/test_seed_plumbing.py`:
  - `make_model` forwards `temperature` / `seed` / `top_p` / `top_k` / arbitrary `engine_kwargs` to the backend (asserted via `DummyModel.init_kwargs`).
  - the three resolver methods skip unset fields, only override `engine_kwargs` when a dedicated field is set, keep A/B/judge kwargs independent, and inherit baseline sampling from `model.*` when unset.
  - `generation_cache_token` is order-independent and changes when any sampling param changes.
  - nested CLI flags (`--model.seed`, `--model.baseline_seed`, `--judge.temperature`) land on the correct role.
- [x] `uv run pytest -q` — full suite green (205 passed locally).
- [x] `ruff check` — clean.
- [ ] CI runs the full suite.