### PR TITLE
1. Add native baselines and judge controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,20 +197,36 @@ Task names follow [LMHarness](https://github.com/EleutherAI/lm-evaluation-harnes
 
 ### Generate + judge (pairwise)
 
-| Task                  | Description                                                                                    |
-|-----------------------|------------------------------------------------------------------------------------------------|
-| `alpaca-eval`         | General instruction-following benchmark                                                        |
-| `arena-hard-v2.0`     | Arena-Hard v2.0 from official `lmarena-ai/arena-hard-auto` source                             |
-| `arena-hard-v0.1`     | Legacy Arena-Hard v0.1 from official `lmarena-ai/arena-hard-auto` source                      |
-| `m-arena-hard`        | Translated version of Arena-Hard in 23 languages                                               |
-| `m-arena-hard-{lang}` | Language-specific variants (e.g., `ar`, `cs`, `de`)                                            |
-| `m-arena-hard-EU`     | All EU languages combined                                                                      |
-| `mt-bench`            | Multi-turn benchmark with FastChat-compatible pairwise judging                                 |
-| `fluency-{lang}`      | Fluency evaluation for pretrained models (`finnish`, `french`, `german`, `spanish`, `swedish`) |
+| Task                         | Description                                                                                    |
+|------------------------------|------------------------------------------------------------------------------------------------|
+| `alpaca-eval`                | General instruction-following benchmark                                                        |
+| `arena-hard-v2.0`            | Arena-Hard v2.0 from official `lmarena-ai/arena-hard-auto` source                              |
+| `arena-hard-v0.1`            | Legacy Arena-Hard v0.1 from official `lmarena-ai/arena-hard-auto` source                       |
+| `m-arena-hard-v0.1`          | `CohereLabs/m-ArenaHard` (500 prompts, Google-Translate) across 23 languages                   |
+| `m-arena-hard-v0.1-{lang}`   | Language-specific v0.1 slice (e.g., `ar`, `cs`, `de`, `uk`, `zh`, `pl`)                        |
+| `m-arena-hard-v0.1-EU`       | All EU v0.1 languages combined                                                                 |
+| `m-arena-hard-v2.0`          | `CohereLabs/m-ArenaHard-v2.0` (498 prompts, in-house translation) across 23 languages          |
+| `m-arena-hard-v2.0-{lang}`   | Language-specific v2.0 slice                                                                   |
+| `m-arena-hard-v2.0-EU`       | All EU v2.0 languages combined                                                                 |
+| `mt-bench`                   | Multi-turn benchmark with FastChat-compatible pairwise judging                                 |
+| `fluency-{lang}`             | Fluency evaluation for pretrained models (`finnish`, `french`, `german`, `spanish`, `swedish`) |
+
+For MT-Bench, the default pairwise baseline is `gpt-4`.
+We diverge from FastChat's own `pairwise-baseline` default (`gpt-3.5-turbo`) to keep
+a stronger reference consistent with Arena-Hard v0.1; the `gpt-4.jsonl` completions
+ship in the `lmsys/mt-bench` HF Space. Override per run with `--model_B`.
 
 For Arena-Hard, JudgeArena resolves baseline metadata by task version:
 - `arena-hard-v0.1`: `gpt-4-0314`
-- `arena-hard-v2.0`: `o3-mini-2025-01-31` (standard prompts)
+- `arena-hard-v2.0`: per-question baseline routed by `category`:
+  - `o3-mini-2025-01-31` for `hard_prompt`, `coding`, and `math` (500 prompts).
+  - `gemini-2.0-flash-001` for `creative_writing` (250 prompts).
+
+For m-Arena-Hard, baseline completions are tied to the benchmark release:
+- `m-arena-hard-v0.1`: Aya Expanse 8B (`CohereLabs/aya-expanse-8b`), ingested
+  from `CohereLabs/deja-vu-pairwise-evals` (repeat 0) via
+  [`scripts/multilingual_arena_hard/ingest_deja_vu_aya_references.py`](scripts/multilingual_arena_hard/ingest_deja_vu_aya_references.py).
+- `m-arena-hard-v2.0`: Gemini 2.5 Flash (`google/gemini-2.5-flash`).
 
 ### ELO rating
 

--- a/judgearena/cli.py
+++ b/judgearena/cli.py
@@ -8,7 +8,6 @@ ELO rating flow; anything else runs the generate-and-judge flow.
 from __future__ import annotations
 
 import argparse
-import warnings
 
 from judgearena.cli_common import (
     add_common_arguments,
@@ -56,14 +55,6 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--dataset",
-        help="[DEPRECATED] Use `--task` instead.",
-    )
-    parser.add_argument(
-        "--arena",
-        help="[DEPRECATED] Use `--task elo-<arena>` instead.",
-    )
-    parser.add_argument(
         "--model_A",
         help=(
             "Model under evaluation. For pairwise tasks, this is Model A (paired with "
@@ -73,10 +64,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model_B",
         help="Model B for generate+judge tasks (not yet supported for elo tasks).",
-    )
-    parser.add_argument(
-        "--model",
-        help="[DEPRECATED] Use `--model_A` instead.",
     )
     parser.add_argument(
         "--use_tqdm",
@@ -118,58 +105,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _resolve_task(args: argparse.Namespace) -> str:
-    """Return the task value from --task, or a deprecated --dataset / --arena."""
-    set_flags = [
-        name
-        for name, value in (
-            ("--task", args.task),
-            ("--dataset", args.dataset),
-            ("--arena", args.arena),
-        )
-        if value is not None
-    ]
-    if len(set_flags) > 1:
-        raise SystemExit(
-            f"Specify exactly one of --task/--dataset/--arena, got {set_flags}."
-        )
-    if not set_flags:
-        raise SystemExit("One of --task/--dataset/--arena is required.")
-
-    if args.task is not None:
-        return args.task
-    if args.dataset is not None:
-        warnings.warn(
-            "--dataset is deprecated; use --task instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return args.dataset
-    # --arena was historically case-sensitive (e.g. "LMArena-140k").  Lowercase it
-    # here so the deprecated path lands on a valid ELO_TASK_TO_ARENA key without
-    # asking users to relearn the arena names.
-    lower_arena = args.arena.lower()
-    warnings.warn(
-        f"--arena is deprecated; use --task {ELO_TASK_PREFIX}{lower_arena} instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return f"{ELO_TASK_PREFIX}{lower_arena}"
-
-
-def _resolve_model_a(args: argparse.Namespace) -> str | None:
-    """Collapse the deprecated --model flag into --model_A."""
-    if args.model is not None and args.model_A is not None:
-        raise SystemExit(
-            "Specify exactly one of --model_A/--model; --model is a deprecated alias."
-        )
-    if args.model is not None:
-        warnings.warn(
-            "--model is deprecated; use --model_A instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return args.model
-    return args.model_A
+    if args.task is None:
+        raise SystemExit("--task is required.")
+    return args.task
 
 
 def _build_elo_args(
@@ -250,17 +188,20 @@ def cli(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     configure_logging(resolve_verbosity(args), log_file=args.log_file)
     task = _resolve_task(args)
-    model_a = _resolve_model_a(args)
     if task.startswith(ELO_TASK_PREFIX):
         if task not in ELO_TASK_TO_ARENA:
             raise SystemExit(
                 f"Unknown elo task {task!r}; expected one of {list(ELO_TASK_TO_ARENA)}."
             )
-        elo_args = _build_elo_args(args, arena=ELO_TASK_TO_ARENA[task], model_a=model_a)
+        elo_args = _build_elo_args(
+            args, arena=ELO_TASK_TO_ARENA[task], model_a=args.model_A
+        )
         logger.debug("Running with CLI args: %s", elo_args.__dict__)
         main_elo(elo_args)
     else:
-        ge_args = _build_generate_and_evaluate_args(args, task=task, model_a=model_a)
+        ge_args = _build_generate_and_evaluate_args(
+            args, task=task, model_a=args.model_A
+        )
         logger.debug("Running with CLI args: %s", ge_args.__dict__)
         main_generate_and_evaluate(ge_args)
 

--- a/judgearena/cli.py
+++ b/judgearena/cli.py
@@ -8,6 +8,7 @@ ELO rating flow; anything else runs the generate-and-judge flow.
 from __future__ import annotations
 
 import argparse
+import warnings
 
 from judgearena.cli_common import (
     add_common_arguments,
@@ -53,6 +54,14 @@ def _build_parser() -> argparse.ArgumentParser:
             "`mt-bench`, `fluency-{lang}`. ELO tasks: `elo-lmarena-100k`, `elo-lmarena-140k`, "
             "`elo-lmarena`, `elo-comparia`."
         ),
+    )
+    parser.add_argument(
+        "--dataset",
+        help="[DEPRECATED] Use `--task` instead.",
+    )
+    parser.add_argument(
+        "--arena",
+        help="[DEPRECATED] Use `--task elo-<arena>` instead.",
     )
     parser.add_argument(
         "--model_A",
@@ -105,9 +114,42 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _resolve_task(args: argparse.Namespace) -> str:
-    if args.task is None:
-        raise SystemExit("--task is required.")
-    return args.task
+    """Return the task value from --task, or a deprecated --dataset / --arena."""
+    set_flags = [
+        name
+        for name, value in (
+            ("--task", args.task),
+            ("--dataset", args.dataset),
+            ("--arena", args.arena),
+        )
+        if value is not None
+    ]
+    if len(set_flags) > 1:
+        raise SystemExit(
+            f"Specify exactly one of --task/--dataset/--arena, got {set_flags}."
+        )
+    if not set_flags:
+        raise SystemExit("One of --task/--dataset/--arena is required.")
+
+    if args.task is not None:
+        return args.task
+    if args.dataset is not None:
+        warnings.warn(
+            "--dataset is deprecated; use --task instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return args.dataset
+    # --arena was historically case-sensitive (e.g. "LMArena-140k").  Lowercase it
+    # here so the deprecated path lands on a valid ELO_TASK_TO_ARENA key without
+    # asking users to relearn the arena names.
+    lower_arena = args.arena.lower()
+    warnings.warn(
+        f"--arena is deprecated; use --task {ELO_TASK_PREFIX}{lower_arena} instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return f"{ELO_TASK_PREFIX}{lower_arena}"
 
 
 def _build_elo_args(

--- a/judgearena/cli.py
+++ b/judgearena/cli.py
@@ -17,7 +17,7 @@ from judgearena.cli_common import (
 )
 from judgearena.estimate_elo_ratings import CliEloArgs
 from judgearena.estimate_elo_ratings import main as main_elo
-from judgearena.generate_and_evaluate import CliArgs
+from judgearena.generate_and_evaluate import CliArgs, native_pairwise_baseline
 from judgearena.generate_and_evaluate import main as main_generate_and_evaluate
 from judgearena.log import configure_logging, get_logger
 
@@ -197,12 +197,15 @@ def _build_elo_args(
         swap_mode=args.swap_mode,
         ignore_cache=args.ignore_cache,
         truncate_all_input_chars=args.truncate_all_input_chars,
+        truncate_judge_input_chars=args.truncate_judge_input_chars,
         max_out_tokens_models=args.max_out_tokens_models,
         max_out_tokens_judge=args.max_out_tokens_judge,
         max_model_len=args.max_model_len,
+        max_judge_model_len=args.max_judge_model_len,
         chat_template=args.chat_template,
         result_folder=args.result_folder,
         engine_kwargs=parse_engine_kwargs(args.engine_kwargs),
+        judge_engine_kwargs=parse_engine_kwargs(args.judge_engine_kwargs),
         verbosity=resolve_verbosity(args),
         log_file=args.log_file,
         no_log_file=args.no_log_file,
@@ -212,7 +215,9 @@ def _build_elo_args(
 def _build_generate_and_evaluate_args(
     args: argparse.Namespace, task: str, model_a: str | None
 ) -> CliArgs:
-    if model_a is None or args.model_B is None:
+    if model_a is None or (
+        args.model_B is None and native_pairwise_baseline(task) is None
+    ):
         raise SystemExit(f"--model_A and --model_B are required for task {task!r}.")
     return CliArgs(
         task=task,
@@ -225,12 +230,15 @@ def _build_generate_and_evaluate_args(
         swap_mode=args.swap_mode,
         ignore_cache=args.ignore_cache,
         truncate_all_input_chars=args.truncate_all_input_chars,
+        truncate_judge_input_chars=args.truncate_judge_input_chars,
         max_out_tokens_models=args.max_out_tokens_models,
         max_out_tokens_judge=args.max_out_tokens_judge,
         max_model_len=args.max_model_len,
+        max_judge_model_len=args.max_judge_model_len,
         chat_template=args.chat_template,
         result_folder=args.result_folder,
         engine_kwargs=parse_engine_kwargs(args.engine_kwargs),
+        judge_engine_kwargs=parse_engine_kwargs(args.judge_engine_kwargs),
         verbosity=resolve_verbosity(args),
         log_file=args.log_file,
         no_log_file=args.no_log_file,

--- a/judgearena/cli_common.py
+++ b/judgearena/cli_common.py
@@ -23,12 +23,15 @@ class BaseCliArgs:
     swap_mode: str = "fixed"
     ignore_cache: bool = False
     truncate_all_input_chars: int = 8192
+    truncate_judge_input_chars: int | None = None
     max_out_tokens_models: int = 32768
     max_out_tokens_judge: int = 32768
     max_model_len: int | None = None
+    max_judge_model_len: int | None = None
     chat_template: str | None = None
     result_folder: str = "results"
     engine_kwargs: dict = field(default_factory=dict)
+    judge_engine_kwargs: dict = field(default_factory=dict)
     verbosity: int = 0
     log_file: str | None = None
     no_log_file: bool = False
@@ -101,9 +104,19 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         required=False,
         default=8192,
         help=(
-            "Character-level truncation applied before tokenization: truncates "
-            "each instruction before model A/B generation and truncates each "
-            "completion before judge evaluation."
+            "Character-level truncation applied to generation-side inputs: "
+            "truncates each instruction before model A/B generation."
+        ),
+    )
+    parser.add_argument(
+        "--truncate_judge_input_chars",
+        type=int,
+        required=False,
+        default=None,
+        help=(
+            "Character cap applied to judge-side inputs before evaluation. "
+            "When omitted, judge inputs are not character-truncated by this "
+            "CLI setting."
         ),
     )
     parser.add_argument(
@@ -132,10 +145,20 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         required=False,
         default=None,
         help=(
-            "Optional total context window for VLLM models (prompt + generation). "
-            "This is independent from --max_out_tokens_models/--max_out_tokens_judge, "
-            "which only cap generated tokens. This is useful on smaller GPUs to "
-            "avoid OOM."
+            "Optional total context window for the battle-generation VLLM "
+            "instances (prompt + generation). Independent from "
+            "--max_out_tokens_models/--max_out_tokens_judge, which only cap "
+            "generated tokens."
+        ),
+    )
+    parser.add_argument(
+        "--max_judge_model_len",
+        type=int,
+        required=False,
+        default=None,
+        help=(
+            "Optional total context window for the judge VLLM instance. When "
+            "omitted, no judge max_model_len override is passed."
         ),
     )
     parser.add_argument(
@@ -158,6 +181,16 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
             "JSON dict of engine-specific kwargs forwarded to the underlying "
             "engine. Example for vLLM: "
             '\'{"tensor_parallel_size": 2, "gpu_memory_utilization": 0.9}\'.'
+        ),
+    )
+    parser.add_argument(
+        "--judge_engine_kwargs",
+        type=str,
+        required=False,
+        default="{}",
+        help=(
+            "Optional JSON dict of engine-specific kwargs that override "
+            "--engine_kwargs only for the judge model."
         ),
     )
     parser.add_argument(

--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -269,10 +269,12 @@ def main(args: CliEloArgs) -> dict:
     ]
 
     judge_extra_kwargs = {}
-    if args.max_model_len is not None:
-        judge_extra_kwargs["max_model_len"] = args.max_model_len
+    if args.max_judge_model_len is not None:
+        judge_extra_kwargs["max_model_len"] = args.max_judge_model_len
     if args.chat_template is not None:
         judge_extra_kwargs["chat_template"] = args.chat_template
+    judge_extra_kwargs.update(args.engine_kwargs)
+    judge_extra_kwargs.update(args.judge_engine_kwargs)
 
     def run_judge() -> pd.DataFrame:
         judge_chat_model = make_model(
@@ -287,7 +289,7 @@ def main(args: CliEloArgs) -> dict:
             completions_B=completions_B,
             swap_mode=args.swap_mode,
             provide_explanation=args.provide_explanation,
-            truncate_input_chars=args.truncate_all_input_chars,
+            truncate_input_chars=args.truncate_judge_input_chars,
             use_tqdm=use_tqdm,
         )
         return pd.DataFrame(

--- a/judgearena/generate_and_evaluate.py
+++ b/judgearena/generate_and_evaluate.py
@@ -4,6 +4,7 @@ and then evaluates them using a judge model.
 """
 
 import json
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from functools import partial
@@ -16,9 +17,15 @@ from judgearena.evaluate import judge_and_parse_prefs, resolve_judge_prompts
 from judgearena.generate import generate_base, generate_instructions
 from judgearena.instruction_dataset import load_instructions
 from judgearena.instruction_dataset.arena_hard import (
+    ARENA_HARD_BASELINES,
     download_arena_hard,
     is_arena_hard_dataset,
 )
+from judgearena.instruction_dataset.m_arenahard import (
+    M_ARENA_HARD_BASELINES,
+    split_m_arena_hard_dataset,
+)
+from judgearena.instruction_dataset.mt_bench import MT_BENCH_BASELINES
 from judgearena.log import (
     attach_file_handler,
     get_logger,
@@ -36,6 +43,17 @@ from judgearena.utils import (
 )
 
 logger = get_logger(__name__)
+
+ALPACA_EVAL_BASELINES: dict[str, str] = {
+    "alpaca-eval": "gpt4_1106_preview",
+}
+
+PAIRWISE_BASELINES: dict[str, str | Mapping[str, str]] = {
+    **ALPACA_EVAL_BASELINES,
+    **ARENA_HARD_BASELINES,
+    **M_ARENA_HARD_BASELINES,
+    **MT_BENCH_BASELINES,
+}
 
 
 def try_load_dataset_completions(
@@ -90,6 +108,94 @@ class CliArgs(BaseCliArgs):
     use_tqdm: bool = False
 
 
+@dataclass(frozen=True)
+class BaselinePlan:
+    """Row-aligned baseline assignment for native pairwise baselines."""
+
+    baseline_by_index: pd.Series
+
+    @classmethod
+    def flat(cls, model: str, *, index: pd.Index) -> "BaselinePlan":
+        return cls(
+            baseline_by_index=pd.Series(model, index=index, name="model_B", dtype=str)
+        )
+
+    @classmethod
+    def per_row(cls, series: pd.Series) -> "BaselinePlan":
+        return cls(baseline_by_index=series.astype(str).rename("model_B"))
+
+    @property
+    def unique_models(self) -> list[str]:
+        return sorted(self.baseline_by_index.dropna().unique().tolist())
+
+    @property
+    def is_flat(self) -> bool:
+        return len(self.unique_models) == 1
+
+    @property
+    def single_model(self) -> str:
+        if not self.is_flat:
+            raise ValueError("BaselinePlan has more than one model.")
+        return self.unique_models[0]
+
+    @property
+    def display_name(self) -> str:
+        return self.single_model if self.is_flat else "+".join(self.unique_models)
+
+    def aligned_to(self, index: pd.Index) -> pd.Series:
+        return self.baseline_by_index.loc[index]
+
+
+def native_pairwise_baseline(task: str) -> str | Mapping[str, str] | None:
+    """Return the dataset-native pairwise baseline, if the task defines one."""
+    if task in PAIRWISE_BASELINES:
+        return PAIRWISE_BASELINES[task]
+    parsed_m_arena_hard = split_m_arena_hard_dataset(task)
+    if parsed_m_arena_hard is not None:
+        version_key, _lang_or_subset = parsed_m_arena_hard
+        return PAIRWISE_BASELINES[version_key]
+    return None
+
+
+def _resolve_baseline_plan(
+    args: CliArgs, instructions_df: pd.DataFrame
+) -> BaselinePlan:
+    if args.model_B is not None:
+        return BaselinePlan.flat(args.model_B, index=instructions_df.index)
+
+    native = native_pairwise_baseline(args.task)
+    if native is None:
+        raise ValueError(
+            f"--model_B is required for dataset '{args.task}'; no dataset-native "
+            "baseline is registered."
+        )
+    if isinstance(native, str):
+        return BaselinePlan.flat(native, index=instructions_df.index)
+    if isinstance(native, Mapping):
+        if "category" not in instructions_df.columns:
+            raise ValueError(
+                f"{args.task} requires a 'category' column for per-category "
+                "baseline routing."
+            )
+        per_row = instructions_df["category"].map(native)
+        if per_row.isna().any():
+            unknown = sorted(
+                instructions_df.loc[per_row.isna(), "category"].unique().tolist()
+            )
+            raise ValueError(
+                f"Unknown Arena-Hard categories for {args.task}: {unknown}. "
+                f"Known: {sorted(native.keys())}"
+            )
+        return BaselinePlan.per_row(per_row)
+    raise ValueError(f"Unsupported baseline shape for dataset '{args.task}'.")
+
+
+def _build_judge_engine_kwargs(args: CliArgs) -> dict[str, object]:
+    judge_kwargs = dict(args.engine_kwargs)
+    judge_kwargs.update(args.judge_engine_kwargs)
+    return judge_kwargs
+
+
 def load_contexts(dataset: str) -> pd.Series:
     path = data_root / "contexts" / dataset
     return pd.read_csv(path).loc[:, "instruction"]
@@ -128,30 +234,23 @@ def main(args: CliArgs):
 
     run_started_at = datetime.now(UTC)
 
-    # Build the result folder early so the file handler captures the entire run.
-    # Include a timestamp so each run gets its own unique directory.
-    name = f"{args.task}-{args.model_A}-{args.model_B}-{args.judge_model}"
-    name += f"-{args.swap_mode}"
-    name = name.replace("/", "_")
-    run_ts = run_started_at.strftime("%Y%m%d_%H%M%S")
-    res_folder = Path(args.result_folder) / f"{name}-{run_ts}"
-    res_folder.mkdir(parents=True, exist_ok=True)
-    if not args.no_log_file:
-        attach_file_handler(make_run_log_path(res_folder))
-
-    logger.info(
-        "Using task %s and evaluating models %s and %s.",
-        args.task,
-        args.model_A,
-        args.model_B,
-    )
-
     # Not working with vllm, not detecting model changes and serving the same cache for two different models...
     # if not args.ignore_cache:
     #     set_langchain_cache()
     ignore_cache = args.ignore_cache
 
     if args.task == "mt-bench":
+        model_b = args.model_B or native_pairwise_baseline(args.task)
+        if not isinstance(model_b, str):
+            raise ValueError("MT-Bench requires a flat native baseline.")
+        name = f"{args.task}-{args.model_A}-{model_b}-{args.judge_model}"
+        name += f"-{args.swap_mode}"
+        name = name.replace("/", "_")
+        run_ts = run_started_at.strftime("%Y%m%d_%H%M%S")
+        res_folder = Path(args.result_folder) / f"{name}-{run_ts}"
+        res_folder.mkdir(parents=True, exist_ok=True)
+        if not args.no_log_file:
+            attach_file_handler(make_run_log_path(res_folder))
         return run_mt_bench(
             args,
             ignore_cache,
@@ -166,21 +265,42 @@ def main(args: CliArgs):
         # to match files in https://huggingface.co/datasets/geoalgo/multilingual-contexts-to-be-completed
         lang = args.task.split("-")[-1]
         instructions = load_contexts(f"{lang}-contexts.csv")
+        instructions_df = pd.DataFrame({"instruction": instructions})
     else:
-        instructions = load_instructions(
+        instructions_df = load_instructions(
             dataset=args.task, n_instructions=args.n_instructions
-        ).loc[:, "instruction"]
+        )
+        instructions = instructions_df.loc[:, "instruction"]
 
     n_instructions = args.n_instructions if args.n_instructions else len(instructions)
     if args.n_instructions is not None:
-        instructions = instructions[:n_instructions]
+        instructions_df = instructions_df.head(n_instructions)
+        instructions = instructions.head(n_instructions)
+
+    baseline_plan = _resolve_baseline_plan(args=args, instructions_df=instructions_df)
+
+    name = f"{args.task}-{args.model_A}-{baseline_plan.display_name}-{args.judge_model}"
+    name += f"-{args.swap_mode}"
+    name = name.replace("/", "_")
+    run_ts = run_started_at.strftime("%Y%m%d_%H%M%S")
+    res_folder = Path(args.result_folder) / f"{name}-{run_ts}"
+    res_folder.mkdir(parents=True, exist_ok=True)
+    if not args.no_log_file:
+        attach_file_handler(make_run_log_path(res_folder))
 
     logger.info(
-        "Generating completions for task %s with model %s and %s "
+        "Using task %s and evaluating %s against baseline %s.",
+        args.task,
+        args.model_A,
+        baseline_plan.display_name,
+    )
+
+    logger.info(
+        "Generating completions for task %s with model %s and baseline %s "
         "(or loading them directly if present)",
         args.task,
         args.model_A,
-        args.model_B,
+        baseline_plan.display_name,
     )
 
     # TODO currently we just support base models for fluency, we could also support instruction-tuned models
@@ -205,54 +325,59 @@ def main(args: CliArgs):
             **args.engine_kwargs,
         )
     )
-    dataset_completions_A = try_load_dataset_completions(
-        args.task, args.model_A, n_instructions
-    )
-    if dataset_completions_A is not None:
-        completions_A = dataset_completions_A.set_index("instruction_index").loc[
-            :, "completion"
-        ]
-    else:
-        completions_A = cache_function_dataframe(
-            lambda: gen_fun(
-                instructions=instructions,
-                model=args.model_A,
-                use_tqdm=args.use_tqdm,
-            ),
-            ignore_cache=ignore_cache,
-            cache_name=f"{args.task}_{args.model_A}_{args.n_instructions}",
-        ).set_index("instruction_index")
-        completions_A = completions_A.loc[:, "completion"]
 
-    dataset_completions_B = try_load_dataset_completions(
-        args.task, args.model_B, n_instructions
-    )
-    if dataset_completions_B is not None:
-        completions_B = dataset_completions_B.set_index("instruction_index").loc[
-            :, "completion"
-        ]
-    else:
-        completions_B = cache_function_dataframe(
+    def _align_completion_series(df: pd.DataFrame) -> pd.Series:
+        return df.set_index("instruction_index").loc[instructions.index, "completion"]
+
+    def _load_or_generate_completions(model_spec: str) -> pd.Series:
+        preloaded = try_load_dataset_completions(args.task, model_spec, n_instructions)
+        if preloaded is not None:
+            return _align_completion_series(preloaded)
+        generated = cache_function_dataframe(
             lambda: gen_fun(
                 instructions=instructions,
-                model=args.model_B,
+                model=model_spec,
                 use_tqdm=args.use_tqdm,
             ),
             ignore_cache=ignore_cache,
-            cache_name=f"{args.task}_{args.model_B}_{args.n_instructions}",
-        ).set_index("instruction_index")
-        completions_B = completions_B.loc[:, "completion"]
+            cache_name=f"{args.task}_{model_spec}_{args.n_instructions}",
+        )
+        return _align_completion_series(generated)
+
+    completions_A = _load_or_generate_completions(args.model_A)
+
+    baseline_per_index = baseline_plan.aligned_to(instructions.index)
+    if baseline_plan.is_flat:
+        completions_B = _load_or_generate_completions(baseline_plan.single_model)
+    else:
+        per_baseline_completions = {
+            model: _load_or_generate_completions(model)
+            for model in baseline_plan.unique_models
+        }
+        completions_B = pd.Series(
+            [
+                per_baseline_completions[model].loc[instruction_index]
+                for instruction_index, model in baseline_per_index.items()
+            ],
+            index=instructions.index,
+            name="completion",
+        )
+
     logger.debug("First instruction/context: %s", instructions.values[0])
     logger.debug("First completion of %s:\n%s", args.model_A, completions_A.values[0])
-    logger.debug("First completion of %s:\n%s", args.model_B, completions_B.values[0])
+    logger.debug(
+        "First completion of %s:\n%s",
+        baseline_plan.display_name,
+        completions_B.values[0],
+    )
     logger.info("Evaluating completions with judge %s.", args.judge_model)
 
     judge_chat_model = make_model(
         model=args.judge_model,
         max_tokens=args.max_out_tokens_judge,
-        max_model_len=args.max_model_len,
+        max_model_len=args.max_judge_model_len,
         chat_template=args.chat_template,
-        **args.engine_kwargs,
+        **_build_judge_engine_kwargs(args),
     )
 
     # save argument for results analysis
@@ -286,22 +411,22 @@ def main(args: CliArgs):
         provide_explanation=args.provide_explanation,
         system_prompt=effective_judge_system_prompt,
         user_prompt_template=judge_user_prompt_template,
-        truncate_input_chars=args.truncate_all_input_chars,
+        truncate_input_chars=args.truncate_judge_input_chars,
         use_tqdm=args.use_tqdm,
     )
 
+    eval_instruction_index = instructions.head(n_instructions).index.tolist()
+    baseline_per_eval = baseline_per_index.loc[eval_instruction_index]
     df = pd.DataFrame(annotations)
-    df["instruction_index"] = instructions.head(n_instructions).index.tolist()
+    df["instruction_index"] = eval_instruction_index
     df["model_A"] = args.model_A
-    df["model_B"] = args.model_B
+    df["model_B"] = baseline_per_eval.tolist()
     df["judge"] = args.judge_model
 
     if args.swap_mode == "both":
         df_reversed = pd.DataFrame(annotations_reversed)
-        df_reversed["instruction_index"] = instructions.head(
-            n_instructions
-        ).index.tolist()
-        df_reversed["model_A"] = args.model_B
+        df_reversed["instruction_index"] = eval_instruction_index
+        df_reversed["model_A"] = baseline_per_eval.tolist()
         df_reversed["model_B"] = args.model_A
         df_reversed["judge"] = args.judge_model
         df = pd.concat([df, df_reversed])
@@ -314,18 +439,24 @@ def main(args: CliArgs):
     results = {
         "task": args.task,
         "model_A": args.model_A,
-        "model_B": args.model_B,
+        "model_B": baseline_plan.display_name,
+        "baseline_assignment": "per-row" if not baseline_plan.is_flat else "flat",
+        "baseline_models": baseline_plan.unique_models,
         "judge_model": args.judge_model,
         **summary,
         "preferences": prefs.tolist(),
     }
-    logger.info("%s vs %s judged by %s", args.model_A, args.model_B, args.judge_model)
+    logger.info(
+        "%s vs %s judged by %s",
+        args.model_A,
+        baseline_plan.display_name,
+        args.judge_model,
+    )
     print_results(results)
 
     with open(res_folder / f"results-{name}.json", "w") as f:
         json.dump(_to_jsonable(results), f, indent=2, allow_nan=False)
 
-    eval_instruction_index = instructions.head(n_instructions).index.tolist()
     eval_instructions = instructions.head(n_instructions).tolist()
     eval_completions_A = completions_A.head(n_instructions).tolist()
     eval_completions_B = completions_B.head(n_instructions).tolist()
@@ -341,6 +472,7 @@ def main(args: CliArgs):
                 "instructions": eval_instructions,
                 "completions_A": eval_completions_A,
                 "completions_B": eval_completions_B,
+                "baseline_model_B": baseline_per_eval.tolist(),
             },
             judge_system_prompt=effective_judge_system_prompt,
             judge_user_prompt_template=judge_user_prompt_template,

--- a/judgearena/instruction_dataset/__init__.py
+++ b/judgearena/instruction_dataset/__init__.py
@@ -4,9 +4,11 @@ from judgearena.instruction_dataset.arena_hard import (
     download_arena_hard,
     is_arena_hard_dataset,
 )
-from judgearena.instruction_dataset.m_arenahard import load_m_arenahard
+from judgearena.instruction_dataset.m_arenahard import (
+    load_m_arenahard,
+    split_m_arena_hard_dataset,
+)
 from judgearena.log import get_logger
-from judgearena.utils import data_root, download_hf, read_df
 
 logger = get_logger(__name__)
 
@@ -17,44 +19,18 @@ def load_instructions(dataset: str, n_instructions: int | None = None) -> pd.Dat
 
         df_instructions = load_mt_bench()
 
-    elif "m-arena-hard" in dataset:
-        if dataset == "m-arena-hard":
-            language = None
-        else:
-            # read the suffix part "m-arena-hard-EU" -> "EU"
-            language = dataset.split("-")[-1]
-            assert language in [
-                None,
-                "ar",
-                "cs",
-                "de",
-                "el",
-                "en",
-                "es",
-                "fa",
-                "fr",
-                "he",
-                "hi",
-                "id",
-                "it",
-                "ja",
-                "ko",
-                "nl",
-                "pl",
-                "pt",
-                "ro",
-                "ru",
-                "tr",
-                "uk",
-                "vi",
-                "zh",
-                "EU",
-            ]
-        logger.info(
-            "Loading m-arena-hard with language specification set to %s", language
-        )
-        df_instructions = load_m_arenahard(local_path=data_root, language=language)
+    elif (parsed := split_m_arena_hard_dataset(dataset)) is not None:
+        from judgearena.utils import data_root
 
+        version_key, lang_or_subset = parsed
+        logger.info(
+            "Loading %s with language specification set to %s",
+            version_key,
+            lang_or_subset,
+        )
+        df_instructions = load_m_arenahard(
+            local_path=data_root, version=version_key, language=lang_or_subset
+        )
         # sort by question_id, then language so that we get multiple languages if we truncate
         df_instructions.sort_values(["question_id", "lang"], inplace=True)
         df_instructions.rename(
@@ -72,6 +48,8 @@ def load_instructions(dataset: str, n_instructions: int | None = None) -> pd.Dat
             "arena-hard-v0.1",
             "arena-hard-v2.0",
         ]
+        from judgearena.utils import data_root, download_hf, read_df
+
         local_path_tables = data_root / "tables"
         if is_arena_hard_dataset(dataset):
             download_arena_hard(dataset=dataset, local_tables_path=local_path_tables)

--- a/judgearena/instruction_dataset/arena_hard.py
+++ b/judgearena/instruction_dataset/arena_hard.py
@@ -1,104 +1,103 @@
-from dataclasses import dataclass
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
-from datasets import Dataset, DatasetDict, IterableDataset, load_dataset
+from huggingface_hub import snapshot_download
 
 ARENA_HARD_HF_REPO_ID = "lmarena-ai/arena-hard-auto"
 
+# Mirrors upstream's `JUDGE_SETTINGS` baseline assignment in
+# `arena-hard-auto/utils/judge_utils.py` verbatim: v0.1 has a single flat
+# baseline, v2.0 routes per question category. `is_arena_hard_dataset` and
+# the dispatcher in `generate_and_evaluate.py` key off this map.
+#
+# Note: the released v2.0 `question.jsonl` only tags rows as `hard_prompt`
+# (500) or `creative_writing` (250); `coding` and `math` are inert keys
+# upstream ships for forward compatibility (no question carries those
+# labels, so the dispatcher never looks them up). We keep them so any
+# future re-tagging upstream lights up automatically without a code
+# change here.
+ARENA_HARD_BASELINES: dict[str, str | Mapping[str, str]] = {
+    "arena-hard-v0.1": "gpt-4-0314",
+    "arena-hard-v2.0": {
+        "hard_prompt": "o3-mini-2025-01-31",
+        "coding": "o3-mini-2025-01-31",
+        "math": "o3-mini-2025-01-31",
+        "creative_writing": "gemini-2.0-flash-001",
+    },
+}
 
-@dataclass(frozen=True)
-class ArenaHardSpec:
-    hf_variant: str
-    baseline_model: str
-
-
-ARENA_HARD_DATASETS: dict[str, ArenaHardSpec] = {
-    "arena-hard-v0.1": ArenaHardSpec(
-        hf_variant="arena-hard-v0.1",
-        baseline_model="gpt-4-0314",
-    ),
-    "arena-hard-v2.0": ArenaHardSpec(
-        hf_variant="arena-hard-v2.0",
-        baseline_model="o3-mini-2025-01-31",
-    ),
+# Dataset name -> upstream HF `data/<variant>/` directory. Kept private so the
+# public API of this module is just the baseline map and helpers below.
+_ARENA_HARD_HF_VARIANTS: dict[str, str] = {
+    "arena-hard-v0.1": "arena-hard-v0.1",
+    "arena-hard-v2.0": "arena-hard-v2.0",
 }
 
 
-def resolve_arena_hard_spec(dataset: str) -> ArenaHardSpec | None:
-    return ARENA_HARD_DATASETS.get(dataset)
-
-
 def is_arena_hard_dataset(dataset: str) -> bool:
-    return resolve_arena_hard_spec(dataset) is not None
+    return dataset in ARENA_HARD_BASELINES
 
 
-def arena_hard_baseline_model(dataset: str) -> str | None:
-    spec = resolve_arena_hard_spec(dataset)
-    if spec is None:
-        return None
-    return spec.baseline_model
+def arena_hard_native_baseline(
+    dataset: str,
+) -> str | Mapping[str, str] | None:
+    """Dataset-native baseline assignment.
 
-
-def _load_official_arena_hard_dataset(spec: ArenaHardSpec) -> pd.DataFrame:
-    data = load_dataset(
-        path=ARENA_HARD_HF_REPO_ID,
-        data_dir=f"data/{spec.hf_variant}",
-    )
-    return _dataset_like_to_dataframe(data)
-
-
-def _dataset_like_to_dataframe(
-    data: Dataset | DatasetDict | IterableDataset,
-) -> pd.DataFrame:
-    if isinstance(data, DatasetDict):
-        if "train" in data:
-            return data["train"].to_pandas()
-        first_split = next(iter(data.keys()))
-        return data[first_split].to_pandas()
-    if isinstance(data, Dataset):
-        return data.to_pandas()
-    if isinstance(data, IterableDataset):
-        return pd.DataFrame(list(data))
-    raise TypeError(f"Unsupported dataset object type: {type(data)}")
+    Returns a plain string for flat datasets (v0.1), a `{category: model}`
+    mapping for per-category datasets (v2.0), or `None` for datasets that
+    don't ship a native baseline.
+    """
+    return ARENA_HARD_BASELINES.get(dataset)
 
 
 def normalize_official_arena_hard(
     raw_df: pd.DataFrame, dataset: str
 ) -> tuple[pd.DataFrame, pd.DataFrame | None]:
-    spec = resolve_arena_hard_spec(dataset)
-    if spec is None:
+    if dataset not in _ARENA_HARD_HF_VARIANTS:
         raise ValueError(f"Unsupported Arena-Hard dataset: {dataset}")
-
-    instruction_index = _pick_instruction_index(raw_df)
-    instruction = _pick_instruction(raw_df)
-    df_instructions = pd.DataFrame(
-        {
-            "instruction_index": instruction_index,
-            "instruction": instruction,
-        }
-    )
-    df_instructions = df_instructions.dropna(
-        subset=["instruction_index", "instruction"]
-    )
-    df_instructions = df_instructions.drop_duplicates(subset=["instruction_index"])
-    df_instructions = df_instructions.sort_values("instruction_index")
-
+    df_instructions = _build_instructions(raw_df)
     df_model_outputs = _build_model_outputs(raw_df)
     return df_instructions, df_model_outputs
 
 
 def download_arena_hard(dataset: str, local_tables_path: Path) -> None:
-    """Load Arena-Hard from the Hub if instruction and model-output files are missing."""
-    spec = resolve_arena_hard_spec(dataset)
-    if spec is None:
+    """Populate `{dataset}.csv` and `{dataset}.csv.zip` on disk if missing.
+
+    Pulls the raw jsonl files directly via `snapshot_download` and reads them
+    with pandas: upstream's per-row `messages[].content` oscillates between
+    string and dict across answer files, so `datasets.load_dataset` can't
+    materialize them into a single Arrow schema.
+
+    Re-downloads when the instructions table is stale - currently only v2.0
+    detects this, because routing by category requires the `category` column
+    that older caches were written without.
+    """
+    if dataset not in _ARENA_HARD_HF_VARIANTS:
         return
     instructions_path = local_tables_path / "instructions" / f"{dataset}.csv"
     model_outputs_path = local_tables_path / "model_outputs" / f"{dataset}.csv.zip"
-    if instructions_path.exists() and model_outputs_path.exists():
+    if (
+        instructions_path.exists()
+        and model_outputs_path.exists()
+        and _instructions_cache_is_fresh(instructions_path, dataset)
+    ):
         return
 
-    raw_df = _load_official_arena_hard_dataset(spec)
+    variant = _ARENA_HARD_HF_VARIANTS[dataset]
+    snapshot_root = snapshot_download(
+        repo_id=ARENA_HARD_HF_REPO_ID,
+        repo_type="dataset",
+        allow_patterns=[
+            f"data/{variant}/question.jsonl",
+            f"data/{variant}/model_answer/*.jsonl",
+        ],
+        force_download=False,
+    )
+    raw_df = _read_arena_hard_jsonl_frames(
+        variant_dir=Path(snapshot_root) / "data" / variant
+    )
     df_instructions, df_model_outputs = normalize_official_arena_hard(
         raw_df=raw_df, dataset=dataset
     )
@@ -109,11 +108,100 @@ def download_arena_hard(dataset: str, local_tables_path: Path) -> None:
         df_model_outputs.to_csv(model_outputs_path, index=False)
 
 
+def _instructions_cache_is_fresh(instructions_path: Path, dataset: str) -> bool:
+    """Category-aware datasets need a `category` column; older caches lack it."""
+    native = arena_hard_native_baseline(dataset)
+    if not isinstance(native, Mapping):
+        return True
+    cached_columns = pd.read_csv(instructions_path, nrows=0).columns
+    return "category" in cached_columns
+
+
+def _read_arena_hard_jsonl_frames(variant_dir: Path) -> pd.DataFrame:
+    frames: list[pd.DataFrame] = []
+    question_path = variant_dir / "question.jsonl"
+    if question_path.exists():
+        frames.append(pd.read_json(question_path, lines=True))
+    answer_dir = variant_dir / "model_answer"
+    if answer_dir.exists():
+        for jsonl_path in sorted(answer_dir.glob("*.jsonl")):
+            frames.append(pd.read_json(jsonl_path, lines=True))
+    if not frames:
+        raise FileNotFoundError(f"No Arena-Hard jsonl files found under {variant_dir}")
+    return pd.concat(frames, ignore_index=True, sort=False)
+
+
+def _build_instructions(raw_df: pd.DataFrame) -> pd.DataFrame:
+    # Question rows are the ones with a prompt; model-answer rows don't have
+    # one and must not leak into the instructions table.
+    if "prompt" in raw_df.columns:
+        question_rows = raw_df[raw_df["prompt"].notna()].reset_index(drop=True)
+    else:
+        question_rows = raw_df.reset_index(drop=True)
+
+    if len(question_rows) == 0:
+        return pd.DataFrame(columns=["instruction_index", "instruction"])
+
+    columns: dict[str, pd.Series] = {
+        "instruction_index": _pick_instruction_index(question_rows),
+        "instruction": _pick_instruction(question_rows),
+    }
+    if "category" in question_rows.columns:
+        columns["category"] = question_rows["category"]
+    df = pd.DataFrame(columns)
+    df = df.dropna(subset=["instruction_index", "instruction"])
+    df["instruction"] = df["instruction"].astype(str)
+    df = df.drop_duplicates(subset=["instruction_index"])
+    df = df.sort_values("instruction_index").reset_index(drop=True)
+    return df
+
+
+def _build_model_outputs(raw_df: pd.DataFrame) -> pd.DataFrame | None:
+    if "model" not in raw_df.columns:
+        return None
+    extracted_output = raw_df.apply(_extract_assistant_output, axis=1)
+    instruction_index = _pick_instruction_index(raw_df)
+    df = pd.DataFrame(
+        {
+            "instruction_index": instruction_index,
+            "model": raw_df["model"],
+            "output": extracted_output,
+        }
+    )
+    df = df[df["model"].notna() & df["output"].notna()]
+    df = df.dropna(subset=["instruction_index"])
+    if df.empty:
+        return None
+    df["instruction_index"] = df["instruction_index"].astype(str)
+    df["model"] = df["model"].astype(str)
+    df["output"] = df["output"].astype(str)
+    return df.reset_index(drop=True)
+
+
+def _extract_assistant_output(row: pd.Series) -> str | None:
+    """Pull the assistant response out of either a flat `output` column or
+    upstream's nested `messages[-1].content.answer` shape.
+    """
+    output_value = row.get("output")
+    if isinstance(output_value, str) and output_value:
+        return output_value
+    messages = row.get("messages")
+    if isinstance(messages, list) and messages:
+        last = messages[-1]
+        content = last.get("content") if isinstance(last, dict) else None
+        if isinstance(content, dict):
+            answer = content.get("answer")
+            return answer if isinstance(answer, str) and answer else None
+        if isinstance(content, str) and content:
+            return content
+    return None
+
+
 def _pick_instruction_index(raw_df: pd.DataFrame) -> pd.Series:
-    for col in ["instruction_index", "question_id", "id"]:
+    for col in ["instruction_index", "uid", "question_id", "id"]:
         if col in raw_df.columns:
             return raw_df[col].astype(str)
-    return pd.Series(range(len(raw_df)), dtype=str)
+    return pd.Series(range(len(raw_df)), dtype=str, index=raw_df.index)
 
 
 def _pick_instruction(raw_df: pd.DataFrame) -> pd.Series:
@@ -121,13 +209,14 @@ def _pick_instruction(raw_df: pd.DataFrame) -> pd.Series:
         if col in raw_df.columns:
             if col == "turns":
                 return raw_df[col].apply(_turns_to_text)
-            return raw_df[col].astype(str)
+            return raw_df[col]
     raise ValueError(
-        f"Unable to infer instruction text column from Arena-Hard data. Available columns: {raw_df.columns.tolist()}"
+        "Unable to infer instruction text column from Arena-Hard data. "
+        f"Available columns: {raw_df.columns.tolist()}"
     )
 
 
-def _turns_to_text(turns_value) -> str:
+def _turns_to_text(turns_value: Any) -> str:
     if isinstance(turns_value, list):
         if not turns_value:
             return ""
@@ -142,17 +231,3 @@ def _turns_to_text(turns_value) -> str:
             if key in turns_value:
                 return str(turns_value[key])
     return str(turns_value)
-
-
-def _build_model_outputs(raw_df: pd.DataFrame) -> pd.DataFrame | None:
-    if not {"model", "output"}.issubset(raw_df.columns):
-        return None
-    instruction_index = _pick_instruction_index(raw_df)
-    df_outputs = pd.DataFrame(
-        {
-            "instruction_index": instruction_index,
-            "model": raw_df["model"].astype(str),
-            "output": raw_df["output"].fillna("").astype(str),
-        }
-    )
-    return df_outputs

--- a/judgearena/instruction_dataset/arena_hard.py
+++ b/judgearena/instruction_dataset/arena_hard.py
@@ -70,19 +70,12 @@ def download_arena_hard(dataset: str, local_tables_path: Path) -> None:
     string and dict across answer files, so `datasets.load_dataset` can't
     materialize them into a single Arrow schema.
 
-    Re-downloads when the instructions table is stale - currently only v2.0
-    detects this, because routing by category requires the `category` column
-    that older caches were written without.
     """
     if dataset not in _ARENA_HARD_HF_VARIANTS:
         return
     instructions_path = local_tables_path / "instructions" / f"{dataset}.csv"
     model_outputs_path = local_tables_path / "model_outputs" / f"{dataset}.csv.zip"
-    if (
-        instructions_path.exists()
-        and model_outputs_path.exists()
-        and _instructions_cache_is_fresh(instructions_path, dataset)
-    ):
+    if instructions_path.exists() and model_outputs_path.exists():
         return
 
     variant = _ARENA_HARD_HF_VARIANTS[dataset]
@@ -106,15 +99,6 @@ def download_arena_hard(dataset: str, local_tables_path: Path) -> None:
     df_instructions.to_csv(instructions_path, index=False)
     if df_model_outputs is not None:
         df_model_outputs.to_csv(model_outputs_path, index=False)
-
-
-def _instructions_cache_is_fresh(instructions_path: Path, dataset: str) -> bool:
-    """Category-aware datasets need a `category` column; older caches lack it."""
-    native = arena_hard_native_baseline(dataset)
-    if not isinstance(native, Mapping):
-        return True
-    cached_columns = pd.read_csv(instructions_path, nrows=0).columns
-    return "category" in cached_columns
 
 
 def _read_arena_hard_jsonl_frames(variant_dir: Path) -> pd.DataFrame:

--- a/judgearena/instruction_dataset/m_arenahard.py
+++ b/judgearena/instruction_dataset/m_arenahard.py
@@ -1,39 +1,132 @@
+"""Version-aware m-ArenaHard loader.
+
+Mirrors ``judgearena/instruction_dataset/arena_hard.py``: each supported
+``m-arena-hard-v{X.Y}`` maps to its dataset-native baseline, and a parallel
+private dict carries the upstream HF repo id. The dispatcher in
+``judgearena/instruction_dataset/__init__.py`` uses
+``split_m_arena_hard_dataset`` to parse ``m-arena-hard-v{X.Y}[-{lang}|-EU]``
+and then calls ``load_m_arenahard``.
+"""
+
 from pathlib import Path
 
 import pandas as pd
 from huggingface_hub import snapshot_download
 
-from judgearena.utils import data_root
+EU_LANGUAGES: tuple[str, ...] = (
+    "cs",
+    "de",
+    "el",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "nl",
+    "pl",
+    "pt",
+    "ro",
+    "uk",
+)
+
+NON_EU_LANGUAGES: tuple[str, ...] = (
+    "ar",
+    "fa",
+    "he",
+    "hi",
+    "id",
+    "ja",
+    "ko",
+    "ru",
+    "tr",
+    "vi",
+    "zh",
+)
+
+ALL_LANGUAGES: tuple[str, ...] = (*EU_LANGUAGES, *NON_EU_LANGUAGES)
+
+# Dataset name -> dataset-native baseline model. Shape mirrors
+# `ARENA_HARD_BASELINES` in `arena_hard.py`. v0.1 uses Aya Expanse 8B (free
+# completions from CohereLabs/deja-vu-pairwise-evals); v2.0 uses Gemini 2.5 Flash.
+M_ARENA_HARD_BASELINES: dict[str, str] = {
+    "m-arena-hard-v0.1": "CohereLabs/aya-expanse-8b",
+    "m-arena-hard-v2.0": "google/gemini-2.5-flash",
+}
+
+# Dataset name -> upstream HF repo id. Kept private; the on-disk cache subdir
+# is derived from the repo's short name.
+_M_ARENA_HARD_HF_REPOS: dict[str, str] = {
+    "m-arena-hard-v0.1": "CohereLabs/m-ArenaHard",
+    "m-arena-hard-v2.0": "CohereLabs/m-ArenaHard-v2.0",
+}
 
 
-def load_m_arenahard(local_path, language: str | None = None):
+def is_m_arena_hard_dataset(dataset: str) -> bool:
+    return split_m_arena_hard_dataset(dataset) is not None
+
+
+def split_m_arena_hard_dataset(dataset: str) -> tuple[str, str | None] | None:
+    """Parse ``m-arena-hard-v{X.Y}[-{lang}|-EU]`` into ``(version, suffix)``.
+
+    Returns ``None`` for any name that doesn't match a known version or that
+    carries an unknown suffix. ``suffix`` is ``None`` for the all-languages
+    variant, ``"EU"`` for the EU subset, or a 2-letter code in
+    :data:`ALL_LANGUAGES`. Versioned names only -- the unversioned
+    ``m-arena-hard`` alias is deliberately not accepted.
+    """
+    for version in M_ARENA_HARD_BASELINES:
+        if dataset == version:
+            return version, None
+        if dataset.startswith(f"{version}-"):
+            suffix = dataset[len(version) + 1 :]
+            if suffix == "EU" or suffix in ALL_LANGUAGES:
+                return version, suffix
+            return None
+    return None
+
+
+def m_arena_hard_native_baseline(dataset: str) -> str | None:
+    """Baseline for a dataset name, or ``None`` if it isn't m-arena-hard."""
+    parsed = split_m_arena_hard_dataset(dataset)
+    if parsed is None:
+        return None
+    return M_ARENA_HARD_BASELINES[parsed[0]]
+
+
+def load_m_arenahard(
+    local_path: Path,
+    version: str,
+    language: str | None = None,
+) -> pd.DataFrame:
+    """Load m-ArenaHard prompts for the requested version and language subset.
+
+    ``version`` must be a key in :data:`M_ARENA_HARD_BASELINES`. ``language``
+    is ``None`` for the full 23-language union, ``"EU"`` for the EU subset,
+    or a 2-letter language code for a single-language slice.
+
+    The returned DataFrame carries the upstream columns plus a ``lang``
+    column, with ``question_id`` rewritten to ``f"{question_id}-{lang}"`` so
+    multi-language slices have unique identifiers.
+    """
+    if version not in _M_ARENA_HARD_HF_REPOS:
+        raise ValueError(
+            f"Unsupported m-ArenaHard version: {version!r}. "
+            f"Known versions: {sorted(_M_ARENA_HARD_HF_REPOS)}."
+        )
+    repo_id = _M_ARENA_HARD_HF_REPOS[version]
+    local_subdir = repo_id.split("/", 1)[1]
     snapshot_download(
-        repo_id="CohereLabs/m-ArenaHard",
+        repo_id=repo_id,
         repo_type="dataset",
         allow_patterns="*",
-        local_dir=local_path / "m-ArenaHard",
+        local_dir=local_path / local_subdir,
         force_download=False,
     )
+    m_arena_root = local_path / local_subdir
 
-    df_union = []
-    m_arena_root = Path(local_path / "m-ArenaHard")
-    eu_languages = [
-        "cs",
-        "de",
-        "el",
-        "en",
-        "es",
-        "fr",
-        "it",
-        "nl",
-        "pl",
-        "pt",
-        "ro",
-        "uk",
-    ]
-    for path in sorted(Path(m_arena_root).rglob("*.parquet")):
+    df_union: list[pd.DataFrame] = []
+    for path in sorted(m_arena_root.rglob("*.parquet")):
         lg = path.parent.name
-        if language == "EU" and lg in eu_languages:
+        if language == "EU" and lg in EU_LANGUAGES:
             df = pd.read_parquet(path)
             df["lang"] = lg
             df_union.append(df)
@@ -42,16 +135,17 @@ def load_m_arenahard(local_path, language: str | None = None):
             df["lang"] = lg
             df_union.append(df)
 
-    assert len(df_union) > 0, f"Invalid language passed {language}"
+    assert len(df_union) > 0, (
+        f"No parquet matched under {m_arena_root} for language={language!r}."
+    )
     df_res = pd.concat(df_union, ignore_index=True)
-
-    # update index to still be unique by appendix language as a suffix
     df_res["question_id"] = df_res.apply(
         lambda row: f"{row['question_id']}-{row['lang']}", axis=1
     )
-
     return df_res
 
 
 if __name__ == "__main__":
-    load_m_arenahard(local_path=data_root, language="EU")
+    from judgearena.utils import data_root
+
+    load_m_arenahard(local_path=data_root, version="m-arena-hard-v0.1", language="EU")

--- a/judgearena/instruction_dataset/mt_bench.py
+++ b/judgearena/instruction_dataset/mt_bench.py
@@ -7,10 +7,66 @@ from huggingface_hub import snapshot_download
 
 from judgearena.utils import data_root
 
+MT_BENCH_SPACE_ID = "lmsys/mt-bench"
+MT_BENCH_QUESTION_PATTERN = "data/mt_bench/question.jsonl"
+MT_BENCH_MODEL_ANSWER_DIR = Path("data") / "mt_bench" / "model_answer"
 FASTCHAT_GPT4_REFERENCE_URL = (
     "https://raw.githubusercontent.com/lm-sys/FastChat/main/"
     "fastchat/llm_judge/data/mt_bench/reference_answer/gpt-4.jsonl"
 )
+
+# Mirrors ``ARENA_HARD_BASELINES`` / ``M_ARENA_HARD_BASELINES``: dataset name ->
+# dataset-native pairwise baseline. MT-Bench ships only one variant today, and
+# ``gpt-4`` is the stronger-reference choice (FastChat's own ``pairwise-baseline``
+# default is ``gpt-3.5-turbo``; we deliberately diverge here).
+MT_BENCH_BASELINES: dict[str, str] = {
+    "mt-bench": "gpt-4",
+}
+
+
+def is_mt_bench_dataset(dataset: str) -> bool:
+    return dataset in MT_BENCH_BASELINES
+
+
+def mt_bench_native_baseline(dataset: str) -> str | None:
+    """Baseline for a dataset name, or ``None`` if it isn't mt-bench."""
+    return MT_BENCH_BASELINES.get(dataset)
+
+
+def _normalize_question_id(question_id: object) -> object:
+    try:
+        return int(question_id)
+    except Exception:
+        return question_id
+
+
+def _snapshot_mt_bench_files(
+    *,
+    local_dir: Path,
+    allow_patterns: list[str],
+    expected_path: Path,
+    description: str,
+) -> None:
+    try:
+        snapshot_download(
+            repo_id=MT_BENCH_SPACE_ID,
+            repo_type="space",
+            allow_patterns=allow_patterns,
+            local_dir=local_dir,
+            force_download=False,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to download {description} from HuggingFace space "
+            f"'{MT_BENCH_SPACE_ID}'. If you're in an offline / restricted-network "
+            f"environment, pre-download the space snapshot and place the file at "
+            f"{expected_path}, or set OPENJURY_DATA to point to that directory."
+        ) from e
+    if not expected_path.exists():
+        raise FileNotFoundError(
+            f"Could not locate {description} after download. "
+            f"Expected file at {expected_path}."
+        )
 
 
 def _download_gpt4_references(local_dir: Path) -> Path | None:
@@ -46,32 +102,101 @@ def download_mt_bench(local_dir: Path | None = None) -> tuple[Path, Path | None]
 
     question_path = local_dir / "data" / "mt_bench" / "question.jsonl"
     if not question_path.exists():
-        try:
-            snapshot_download(
-                repo_id="lmsys/mt-bench",
-                repo_type="space",
-                allow_patterns=[
-                    "data/mt_bench/question.jsonl",
-                ],
-                local_dir=local_dir,
-                force_download=False,
-            )
-        except Exception as e:
-            raise RuntimeError(
-                "Failed to download MT-Bench questions from HuggingFace space "
-                "'lmsys/mt-bench'. If you're in an offline / restricted-network "
-                "environment, pre-download the space snapshot and place the "
-                f"questions file at {question_path}, or set OPENJURY_DATA to "
-                "point to that directory."
-            ) from e
-    if not question_path.exists():
-        raise FileNotFoundError(
-            "Could not locate MT-Bench questions after download. "
-            f"Expected file at {question_path}."
+        _snapshot_mt_bench_files(
+            local_dir=local_dir,
+            allow_patterns=[MT_BENCH_QUESTION_PATTERN],
+            expected_path=question_path,
+            description="MT-Bench questions",
         )
 
     gpt4_reference_path = _download_gpt4_references(local_dir)
     return question_path, gpt4_reference_path
+
+
+def download_mt_bench_model_answer(
+    model_id: str, local_dir: Path | None = None
+) -> Path:
+    """Download a cached MT-Bench baseline answer file if missing."""
+    if local_dir is None:
+        local_dir = data_root / "mt-bench"
+    answer_path = local_dir / MT_BENCH_MODEL_ANSWER_DIR / f"{model_id}.jsonl"
+    if answer_path.exists():
+        return answer_path
+    answer_path.parent.mkdir(parents=True, exist_ok=True)
+    allow_pattern = (MT_BENCH_MODEL_ANSWER_DIR / f"{model_id}.jsonl").as_posix()
+    _snapshot_mt_bench_files(
+        local_dir=local_dir,
+        allow_patterns=[allow_pattern],
+        expected_path=answer_path,
+        description=f"MT-Bench model answers for '{model_id}'",
+    )
+    return answer_path
+
+
+def _extract_answer_turns(record: dict, source_name: str) -> tuple[object, list[str]]:
+    question_id = record.get("question_id", record.get("id"))
+    if question_id is None:
+        raise ValueError(
+            f"MT-Bench answer record from {source_name} is missing question_id/id."
+        )
+    choices = record.get("choices")
+    if not (isinstance(choices, list) and choices):
+        raise ValueError(
+            f"MT-Bench answer record for question {question_id} in {source_name} is "
+            "missing a non-empty choices list."
+        )
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        raise ValueError(
+            f"MT-Bench answer record for question {question_id} in {source_name} has "
+            "a malformed first choice entry."
+        )
+    turns = first_choice.get("turns")
+    if not isinstance(turns, list):
+        raise ValueError(
+            f"MT-Bench answer record for question {question_id} in {source_name} is "
+            "missing a turns list."
+        )
+    return _normalize_question_id(question_id), turns
+
+
+def load_mt_bench_model_answers(
+    model: str,
+    n_instructions: int | None = None,
+    local_dir: Path | None = None,
+) -> pd.DataFrame | None:
+    """Load pre-generated MT-Bench answers from a local file or cached model id."""
+    local_path = Path(model)
+    if local_path.exists():
+        answer_path = local_path
+    elif "/" not in model:
+        answer_path = download_mt_bench_model_answer(
+            model_id=model, local_dir=local_dir
+        )
+    else:
+        return None
+
+    answer_records = pd.read_json(answer_path, lines=True).to_dict(orient="records")
+    rows = []
+    for rec in answer_records:
+        question_id, turns = _extract_answer_turns(rec, str(answer_path))
+        rows.append(
+            {
+                "instruction_index": question_id,
+                "completion_turn_1": turns[0] if len(turns) > 0 else "",
+                "completion_turn_2": turns[1] if len(turns) > 1 else "",
+            }
+        )
+
+    df_answers = pd.DataFrame(rows)
+    if df_answers.empty:
+        raise ValueError(
+            f"MT-Bench answer file {answer_path} did not contain any rows."
+        )
+    df_answers.sort_values("instruction_index", inplace=True)
+    if n_instructions is not None:
+        df_answers = df_answers.head(n_instructions)
+    return df_answers
 
 
 def load_mt_bench() -> pd.DataFrame:
@@ -126,10 +251,7 @@ def load_mt_bench() -> pd.DataFrame:
             raise ValueError(
                 f"MT-Bench question record missing question_id/id: keys={list(rec.keys())}"
             )
-        try:
-            qid = int(qid_raw)
-        except Exception:
-            qid = qid_raw
+        qid = _normalize_question_id(qid_raw)
 
         category = rec.get("category")
         turns = rec.get("turns")

--- a/judgearena/mt_bench/mt_bench_utils.py
+++ b/judgearena/mt_bench/mt_bench_utils.py
@@ -18,6 +18,10 @@ import pandas as pd
 from judgearena.eval_utils import _compute_grouped_stats, print_results
 from judgearena.generate import generate_multiturn
 from judgearena.instruction_dataset import load_instructions
+from judgearena.instruction_dataset.mt_bench import (
+    load_mt_bench_model_answers,
+    mt_bench_native_baseline,
+)
 from judgearena.log import get_logger
 from judgearena.mt_bench.fastchat_compat import (
     FASTCHAT_TEMPERATURE_CONFIG,
@@ -49,20 +53,26 @@ def _generate_mt_bench_completions(
             max_model_len=args.max_model_len,
             chat_template=args.chat_template,
             temperature_config=FASTCHAT_TEMPERATURE_CONFIG,
+            **args.engine_kwargs,
         )
 
-    completions_a = cache_function_dataframe(
-        lambda: _run_generation(args.model_A),
-        ignore_cache=ignore_cache,
-        cache_name=f"{cache_prefix}_{args.model_A}_{args.n_instructions}",
-    ).set_index("instruction_index")
+    def _load_or_generate(model_name: str) -> pd.DataFrame:
+        preloaded = load_mt_bench_model_answers(
+            model_name, n_instructions=args.n_instructions
+        )
+        if preloaded is not None:
+            return preloaded.set_index("instruction_index").loc[questions_df.index]
+        return (
+            cache_function_dataframe(
+                lambda: _run_generation(model_name),
+                ignore_cache=ignore_cache,
+                cache_name=f"{cache_prefix}_{model_name}_{args.n_instructions}",
+            )
+            .set_index("instruction_index")
+            .loc[questions_df.index]
+        )
 
-    completions_b = cache_function_dataframe(
-        lambda: _run_generation(args.model_B),
-        ignore_cache=ignore_cache,
-        cache_name=f"{cache_prefix}_{args.model_B}_{args.n_instructions}",
-    ).set_index("instruction_index")
-    return completions_a, completions_b
+    return _load_or_generate(args.model_A), _load_or_generate(args.model_B)
 
 
 def _build_mt_bench_result_name(args: CliArgs, suffix: str | None = None) -> str:
@@ -111,7 +121,7 @@ def _run_mt_bench_fastchat(
             model_b=args.model_B,
             turns_mode="both",
             swap_mode=args.swap_mode,
-            truncate_input_chars=args.truncate_all_input_chars,
+            truncate_input_chars=args.truncate_judge_input_chars,
             use_tqdm=args.use_tqdm,
         )
     )
@@ -149,6 +159,13 @@ def run_mt_bench(
     result_name: str,
 ):
     """MT-Bench pipeline with FastChat-compatible pairwise judging."""
+    if args.model_B is None:
+        args.model_B = mt_bench_native_baseline(args.task)
+    if args.model_B is None:
+        raise ValueError(
+            f"--model_B is required for dataset '{args.task}'; "
+            "no dataset-native baseline registered."
+        )
     questions_df = load_instructions("mt-bench", n_instructions=args.n_instructions)
     logger.info(
         "Generating multi-turn completions for MT-Bench with %s and %s.",
@@ -164,8 +181,9 @@ def run_mt_bench(
         model=args.judge_model,
         max_tokens=args.max_out_tokens_judge,
         temperature=0.0,
-        max_model_len=args.max_model_len,
+        max_model_len=args.max_judge_model_len,
         chat_template=args.chat_template,
+        **{**args.engine_kwargs, **args.judge_engine_kwargs},
     )
     return _run_mt_bench_fastchat(
         args=args,

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -475,7 +475,8 @@ def download_all():
         "alpaca-eval",
         "arena-hard-v0.1",
         "arena-hard-v2.0",
-        "m-arena-hard",
+        "m-arena-hard-v0.1",
+        "m-arena-hard-v2.0",
     ]:
         if is_arena_hard_dataset(dataset):
             download_arena_hard(dataset=dataset, local_tables_path=local_path_tables)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,10 +89,63 @@ def test_elo_task_dispatches_to_estimate_elo_ratings(
     assert elo_args.judge_model == "Dummy/J"
 
 
-def test_missing_task_raises(capture_mains):
-    with pytest.raises(SystemExit, match="--task is required"):
+def test_dataset_flag_is_deprecated_alias(capture_mains):
+    with pytest.warns(DeprecationWarning, match="--dataset is deprecated"):
         cli_module.cli(
             [
+                "--dataset",
+                "alpaca-eval",
+                "--model_A",
+                "Dummy/A",
+                "--model_B",
+                "Dummy/B",
+                "--judge",
+                "Dummy/J",
+            ]
+        )
+    assert capture_mains["module"] == "generate_and_evaluate"
+    assert capture_mains["args"].task == "alpaca-eval"
+
+
+def test_arena_flag_is_deprecated_alias_lowercases(capture_mains):
+    """`--arena ComparIA` must still route to the ComparIA ELO path."""
+    with pytest.warns(DeprecationWarning, match="--arena is deprecated"):
+        cli_module.cli(
+            [
+                "--arena",
+                "ComparIA",
+                "--model_A",
+                "Dummy/X",
+                "--judge",
+                "Dummy/J",
+            ]
+        )
+    assert capture_mains["module"] == "elo"
+    assert capture_mains["args"].arena == "ComparIA"
+
+
+def test_missing_task_raises(capture_mains):
+    with pytest.raises(SystemExit, match="One of --task"):
+        cli_module.cli(
+            [
+                "--model_A",
+                "Dummy/A",
+                "--model_B",
+                "Dummy/B",
+                "--judge",
+                "Dummy/J",
+            ]
+        )
+
+
+def test_multiple_task_flags_raise(capture_mains):
+    with pytest.raises(SystemExit, match="exactly one of"):
+        cli_module.cli(
+            [
+                "--task",
+                "alpaca-eval",
+                "--dataset",
+                "alpaca-eval",
                 "--model_A",
                 "Dummy/A",
                 "--model_B",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def capture_mains(monkeypatch):
     [
         "alpaca-eval",
         "arena-hard-v2.0",
-        "m-arena-hard-EU",
+        "m-arena-hard-v2.0-EU",
         "fluency-french",
         "mt-bench",
     ],
@@ -248,18 +248,47 @@ def test_unknown_elo_task_raises(capture_mains):
         )
 
 
-def test_generate_and_evaluate_requires_model_a_and_b(capture_mains):
+def test_pairwise_task_without_native_baseline_requires_model_a_and_b(capture_mains):
     with pytest.raises(SystemExit, match="--model_A and --model_B are required"):
         cli_module.cli(
             [
                 "--task",
-                "alpaca-eval",
+                "fluency-french",
                 "--model_A",
                 "Dummy/A",
                 "--judge",
                 "Dummy/J",
             ]
         )
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        "alpaca-eval",
+        "arena-hard-v0.1",
+        "m-arena-hard-v2.0-EU",
+        "mt-bench",
+    ],
+)
+def test_pairwise_task_allows_missing_model_b_when_native_baseline_exists(
+    capture_mains, task: str
+):
+    cli_module.cli(
+        [
+            "--task",
+            task,
+            "--model_A",
+            "Dummy/A",
+            "--judge",
+            "Dummy/J",
+        ]
+    )
+    assert capture_mains["module"] == "generate_and_evaluate"
+    ge_args: CliArgs = capture_mains["args"]
+    assert ge_args.task == task
+    assert ge_args.model_A == "Dummy/A"
+    assert ge_args.model_B is None
 
 
 def test_deprecated_model_flag_routes_into_pairwise_task(capture_mains):
@@ -329,3 +358,33 @@ def test_engine_kwargs_parsed_as_json(capture_mains):
     )
     ge_args: CliArgs = capture_mains["args"]
     assert ge_args.engine_kwargs == {"tensor_parallel_size": 4}
+
+
+def test_judge_side_kwargs_are_parsed_separately(capture_mains):
+    cli_module.cli(
+        [
+            "--task",
+            "arena-hard-v2.0",
+            "--model_A",
+            "Dummy/A",
+            "--judge",
+            "Dummy/J",
+            "--truncate_judge_input_chars",
+            "80000",
+            "--max_model_len",
+            "32768",
+            "--max_judge_model_len",
+            "65536",
+            "--engine_kwargs",
+            '{"tensor_parallel_size": 1}',
+            "--judge_engine_kwargs",
+            '{"tensor_parallel_size": 4}',
+        ]
+    )
+    ge_args: CliArgs = capture_mains["args"]
+    assert ge_args.model_B is None
+    assert ge_args.truncate_judge_input_chars == 80000
+    assert ge_args.max_model_len == 32768
+    assert ge_args.max_judge_model_len == 65536
+    assert ge_args.engine_kwargs == {"tensor_parallel_size": 1}
+    assert ge_args.judge_engine_kwargs == {"tensor_parallel_size": 4}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,99 +89,10 @@ def test_elo_task_dispatches_to_estimate_elo_ratings(
     assert elo_args.judge_model == "Dummy/J"
 
 
-def test_dataset_flag_is_deprecated_alias(capture_mains):
-    with pytest.warns(DeprecationWarning, match="--dataset is deprecated"):
-        cli_module.cli(
-            [
-                "--dataset",
-                "alpaca-eval",
-                "--model_A",
-                "Dummy/A",
-                "--model_B",
-                "Dummy/B",
-                "--judge",
-                "Dummy/J",
-            ]
-        )
-    assert capture_mains["module"] == "generate_and_evaluate"
-    assert capture_mains["args"].task == "alpaca-eval"
-
-
-def test_arena_flag_is_deprecated_alias_lowercases(capture_mains):
-    """`--arena ComparIA` must still route to the ComparIA ELO path.
-
-    The deprecated path is allowed to be case-insensitive because that was the
-    historical contract for ``judgearena-elo --arena LMArena-140k``.
-    """
-    with pytest.warns(DeprecationWarning, match="--arena is deprecated"):
-        cli_module.cli(
-            [
-                "--arena",
-                "ComparIA",
-                "--model_A",
-                "Dummy/X",
-                "--judge",
-                "Dummy/J",
-            ]
-        )
-    assert capture_mains["module"] == "elo"
-    assert capture_mains["args"].arena == "ComparIA"
-
-
-def test_model_flag_is_deprecated_alias(capture_mains):
-    with pytest.warns(DeprecationWarning, match="--model is deprecated"):
-        cli_module.cli(
-            [
-                "--task",
-                "elo-comparia",
-                "--model",
-                "Dummy/X",
-                "--judge",
-                "Dummy/J",
-            ]
-        )
-    assert capture_mains["module"] == "elo"
-    assert capture_mains["args"].model == "Dummy/X"
-
-
-def test_model_and_model_a_collide_raises(capture_mains):
-    with pytest.raises(SystemExit, match="exactly one of --model_A/--model"):
-        cli_module.cli(
-            [
-                "--task",
-                "elo-comparia",
-                "--model",
-                "Dummy/X",
-                "--model_A",
-                "Dummy/Y",
-                "--judge",
-                "Dummy/J",
-            ]
-        )
-
-
 def test_missing_task_raises(capture_mains):
-    with pytest.raises(SystemExit, match="One of --task"):
+    with pytest.raises(SystemExit, match="--task is required"):
         cli_module.cli(
             [
-                "--model_A",
-                "Dummy/A",
-                "--model_B",
-                "Dummy/B",
-                "--judge",
-                "Dummy/J",
-            ]
-        )
-
-
-def test_multiple_task_flags_raise(capture_mains):
-    with pytest.raises(SystemExit, match="exactly one of"):
-        cli_module.cli(
-            [
-                "--task",
-                "alpaca-eval",
-                "--dataset",
-                "alpaca-eval",
                 "--model_A",
                 "Dummy/A",
                 "--model_B",
@@ -289,26 +200,6 @@ def test_pairwise_task_allows_missing_model_b_when_native_baseline_exists(
     assert ge_args.task == task
     assert ge_args.model_A == "Dummy/A"
     assert ge_args.model_B is None
-
-
-def test_deprecated_model_flag_routes_into_pairwise_task(capture_mains):
-    """`--model` is a deprecated alias for `--model_A` even on pairwise tasks."""
-    with pytest.warns(DeprecationWarning, match="--model is deprecated"):
-        cli_module.cli(
-            [
-                "--task",
-                "alpaca-eval",
-                "--model",
-                "Dummy/A",
-                "--model_B",
-                "Dummy/B",
-                "--judge",
-                "Dummy/J",
-            ]
-        )
-    assert capture_mains["module"] == "generate_and_evaluate"
-    assert capture_mains["args"].model_A == "Dummy/A"
-    assert capture_mains["args"].model_B == "Dummy/B"
 
 
 def test_elo_forwards_optional_flags(capture_mains):

--- a/tests/test_generate_and_evaluate.py
+++ b/tests/test_generate_and_evaluate.py
@@ -3,7 +3,10 @@ import pytest
 
 import judgearena.generate_and_evaluate as generate_and_evaluate
 from judgearena.generate_and_evaluate import (
+    BaselinePlan,
     CliArgs,
+    _resolve_baseline_plan,
+    native_pairwise_baseline,
 )
 from judgearena.generate_and_evaluate import (
     main as main_generate_and_eval,
@@ -48,6 +51,92 @@ def mock_external_data_and_cache(monkeypatch):
     )
 
 
+def _make_args(task: str, model_b: str | None = None) -> CliArgs:
+    return CliArgs(
+        task=task,
+        model_A="A",
+        model_B=model_b,
+        judge_model="J",
+    )
+
+
+def _instructions(ids: list[str], categories: list[str] | None = None) -> pd.DataFrame:
+    data = {"instruction": list(ids)}
+    if categories is not None:
+        data["category"] = list(categories)
+    return pd.DataFrame(data, index=pd.Index(ids, name="instruction_index"))
+
+
+def test_resolve_plan_v01_flat_default():
+    plan = _resolve_baseline_plan(
+        args=_make_args("arena-hard-v0.1"),
+        instructions_df=_instructions(["q1", "q2"]),
+    )
+    assert plan.is_flat
+    assert plan.single_model == "gpt-4-0314"
+
+
+def test_resolve_plan_v20_routes_per_category():
+    plan = _resolve_baseline_plan(
+        args=_make_args("arena-hard-v2.0"),
+        instructions_df=_instructions(
+            ["qh", "qc"],
+            categories=["hard_prompt", "creative_writing"],
+        ),
+    )
+    assert not plan.is_flat
+    assert plan.baseline_by_index.loc["qh"] == "o3-mini-2025-01-31"
+    assert plan.baseline_by_index.loc["qc"] == "gemini-2.0-flash-001"
+
+
+def test_resolve_plan_explicit_model_b_overrides_native():
+    plan = _resolve_baseline_plan(
+        args=_make_args("arena-hard-v2.0", model_b="override"),
+        instructions_df=_instructions(
+            ["q1", "q2"],
+            categories=["hard_prompt", "creative_writing"],
+        ),
+    )
+    assert plan.is_flat
+    assert plan.single_model == "override"
+
+
+@pytest.mark.parametrize(
+    ("task", "expected"),
+    [
+        ("alpaca-eval", "gpt4_1106_preview"),
+        ("mt-bench", "gpt-4"),
+        ("m-arena-hard-v0.1-uk", "CohereLabs/aya-expanse-8b"),
+        ("m-arena-hard-v2.0-EU", "google/gemini-2.5-flash"),
+    ],
+)
+def test_native_pairwise_baseline_resolves_registered_tasks(task: str, expected: str):
+    assert native_pairwise_baseline(task) == expected
+
+
+def test_resolve_plan_task_without_native_baseline_requires_model_b():
+    with pytest.raises(ValueError, match="model_B"):
+        _resolve_baseline_plan(
+            args=_make_args("fluency-french"),
+            instructions_df=_instructions(["q1"]),
+        )
+
+
+def test_resolve_plan_v20_missing_category_raises():
+    with pytest.raises(ValueError, match="category"):
+        _resolve_baseline_plan(
+            args=_make_args("arena-hard-v2.0"),
+            instructions_df=_instructions(["q1"]),
+        )
+
+
+def test_baseline_plan_per_row_preserves_order():
+    series = pd.Series(["m1", "m2"], index=["a", "b"], name="model_B")
+    plan = BaselinePlan.per_row(series)
+    assert not plan.is_flat
+    assert plan.unique_models == ["m1", "m2"]
+
+
 @pytest.mark.parametrize(
     "task",
     [
@@ -55,7 +144,8 @@ def mock_external_data_and_cache(monkeypatch):
         "arena-hard-v2.0",
         "arena-hard-v0.1",
         "fluency-french",
-        "m-arena-hard-EU",
+        "m-arena-hard-v0.1-EU",
+        "m-arena-hard-v2.0-EU",
     ],
 )
 def test_generate_and_evaluate_context_completion(task: str, tmp_path):
@@ -96,3 +186,37 @@ def test_generate_and_evaluate_correct_order_bias(tmp_path):
 
     avg_pref = sum(prefs) / len(prefs)
     assert avg_pref == 0.5
+
+
+def test_generate_and_evaluate_passes_judge_side_controls(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_make_model(**kwargs):
+        captured["make_model"] = kwargs
+
+        class FakeJudge:
+            def batch(self, inputs, **_kwargs):
+                return ["score A: 0 score B: 10"] * len(inputs)
+
+        return FakeJudge()
+
+    monkeypatch.setattr(generate_and_evaluate, "make_model", fake_make_model)
+
+    prefs = main_generate_and_eval(
+        CliArgs(
+            task="alpaca-eval",
+            model_A="Dummy/no answer",
+            model_B="Dummy/open is better than close isnt'it",
+            judge_model="Dummy/score A: 0 score B: 10",
+            n_instructions=2,
+            truncate_judge_input_chars=12,
+            max_judge_model_len=65536,
+            engine_kwargs={"tensor_parallel_size": 1},
+            judge_engine_kwargs={"tensor_parallel_size": 4},
+            result_folder=str(tmp_path),
+        )
+    )
+
+    assert len(prefs) == 2
+    assert captured["make_model"]["max_model_len"] == 65536
+    assert captured["make_model"]["tensor_parallel_size"] == 4

--- a/tests/test_instruction_dataset.py
+++ b/tests/test_instruction_dataset.py
@@ -1,21 +1,65 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 import judgearena.generate_and_evaluate as generate_and_evaluate
 import judgearena.instruction_dataset as instruction_dataset
+import judgearena.utils as judgearena_utils
 from judgearena.instruction_dataset.arena_hard import (
-    arena_hard_baseline_model,
+    ARENA_HARD_BASELINES,
+    _build_instructions,
+    _build_model_outputs,
+    _extract_assistant_output,
+    arena_hard_native_baseline,
     normalize_official_arena_hard,
 )
 
 
-def test_arena_hard_baseline_resolution():
-    assert arena_hard_baseline_model("arena-hard-v0.1") == "gpt-4-0314"
-    assert arena_hard_baseline_model("arena-hard-v2.0") == "o3-mini-2025-01-31"
+def test_arena_hard_native_baseline_v01_is_flat_string():
+    assert arena_hard_native_baseline("arena-hard-v0.1") == "gpt-4-0314"
 
 
-def test_normalize_official_arena_hard_v01_shape():
+def test_arena_hard_native_baseline_v20_is_per_category_mapping():
+    native = arena_hard_native_baseline("arena-hard-v2.0")
+    assert isinstance(native, dict)
+    assert native["hard_prompt"] == "o3-mini-2025-01-31"
+    assert native["coding"] == "o3-mini-2025-01-31"
+    assert native["math"] == "o3-mini-2025-01-31"
+    assert native["creative_writing"] == "gemini-2.0-flash-001"
+
+
+def test_arena_hard_baselines_mapping_matches_upstream():
+    """Pin the exact baseline assignment so a silent edit to
+    ARENA_HARD_BASELINES can't drift away from upstream
+    (arena-hard-auto/utils/judge_utils.py::JUDGE_SETTINGS).
+    """
+    assert ARENA_HARD_BASELINES == {
+        "arena-hard-v0.1": "gpt-4-0314",
+        "arena-hard-v2.0": {
+            "hard_prompt": "o3-mini-2025-01-31",
+            "coding": "o3-mini-2025-01-31",
+            "math": "o3-mini-2025-01-31",
+            "creative_writing": "gemini-2.0-flash-001",
+        },
+    }
+
+
+def test_mt_bench_native_baseline_is_flat_string():
+    from judgearena.instruction_dataset.mt_bench import (
+        MT_BENCH_BASELINES,
+        is_mt_bench_dataset,
+        mt_bench_native_baseline,
+    )
+
+    assert is_mt_bench_dataset("mt-bench") is True
+    assert is_mt_bench_dataset("alpaca-eval") is False
+    assert mt_bench_native_baseline("mt-bench") == "gpt-4"
+    assert mt_bench_native_baseline("alpaca-eval") is None
+    assert MT_BENCH_BASELINES == {"mt-bench": "gpt-4"}
+
+
+def test_normalize_official_arena_hard_v01_drops_no_category():
     raw_df = pd.DataFrame(
         {
             "question_id": ["q1", "q2"],
@@ -35,6 +79,165 @@ def test_normalize_official_arena_hard_v01_shape():
     assert set(df_outputs.columns) == {"instruction_index", "model", "output"}
 
 
+def test_normalize_official_arena_hard_v20_preserves_category():
+    raw_df = pd.DataFrame(
+        {
+            "question_id": ["q1", "q2", "q1"],
+            "prompt": ["First prompt", "Second prompt", None],
+            "category": ["hard_prompt", "creative_writing", None],
+            "model": [None, None, "o3-mini-2025-01-31"],
+            "output": [None, None, "answer text"],
+        }
+    )
+    df_instructions, df_outputs = normalize_official_arena_hard(
+        raw_df=raw_df, dataset="arena-hard-v2.0"
+    )
+
+    assert "category" in df_instructions.columns
+    assert df_instructions.set_index("instruction_index")["category"].to_dict() == {
+        "q1": "hard_prompt",
+        "q2": "creative_writing",
+    }
+    assert df_outputs is not None
+    assert df_outputs["model"].tolist() == ["o3-mini-2025-01-31"]
+    assert df_outputs["output"].tolist() == ["answer text"]
+
+
+def test_build_model_outputs_extracts_upstream_messages_shape():
+    """Upstream's `model_answer/*.jsonl` rows keep the assistant response in
+    `messages[-1].content.answer` rather than a flat `output` column. Without
+    this extractor, a fresh `download_arena_hard` clone would silently drop
+    every baseline answer.
+    """
+    raw_df = pd.DataFrame(
+        [
+            {
+                "uid": "q1",
+                "model": "o3-mini-2025-01-31",
+                "messages": [
+                    {"role": "user", "content": "Prompt"},
+                    {
+                        "role": "assistant",
+                        "content": {"answer": "nested answer", "reasoning": "..."},
+                    },
+                ],
+            },
+            {
+                "uid": "q2",
+                "model": "gemini-2.0-flash-001",
+                "messages": [
+                    {"role": "user", "content": "Prompt"},
+                    {"role": "assistant", "content": "plain string answer"},
+                ],
+            },
+            {
+                "uid": "q3",
+                "model": "baseline",
+                "output": "flat output column",
+            },
+            {
+                "uid": "q4",
+                "model": "no-output-model",
+                "messages": [{"role": "assistant", "content": {"reasoning": "..."}}],
+            },
+        ]
+    )
+
+    df_outputs = _build_model_outputs(raw_df)
+
+    assert df_outputs is not None
+    outputs_by_model = dict(zip(df_outputs["model"], df_outputs["output"], strict=True))
+    assert outputs_by_model == {
+        "o3-mini-2025-01-31": "nested answer",
+        "gemini-2.0-flash-001": "plain string answer",
+        "baseline": "flat output column",
+    }
+    assert "no-output-model" not in outputs_by_model
+
+
+@pytest.mark.parametrize(
+    "row, expected",
+    [
+        ({"output": "flat"}, "flat"),
+        (
+            {
+                "messages": [
+                    {"role": "user", "content": "p"},
+                    {"role": "assistant", "content": {"answer": "nested"}},
+                ]
+            },
+            "nested",
+        ),
+        (
+            {
+                "messages": [
+                    {"role": "user", "content": "p"},
+                    {"role": "assistant", "content": "plain"},
+                ]
+            },
+            "plain",
+        ),
+        ({"output": None, "messages": None}, None),
+        (
+            {"messages": [{"role": "assistant", "content": {"reasoning": "only"}}]},
+            None,
+        ),
+    ],
+)
+def test_extract_assistant_output_covers_known_shapes(row, expected):
+    assert _extract_assistant_output(pd.Series(row)) == expected
+
+
+def test_build_model_outputs_returns_multi_model_rows_per_upstream_zip():
+    """The fresh-clone loader must produce one row per (model, uid) so the
+    flat zip consumed by `try_load_dataset_completions` pivots cleanly.
+    """
+    raw_df = pd.DataFrame(
+        [
+            {
+                "uid": "q1",
+                "model": "o3-mini-2025-01-31",
+                "messages": [{"role": "assistant", "content": {"answer": "o3 q1"}}],
+            },
+            {
+                "uid": "q2",
+                "model": "o3-mini-2025-01-31",
+                "messages": [{"role": "assistant", "content": {"answer": "o3 q2"}}],
+            },
+            {
+                "uid": "q1",
+                "model": "gemini-2.0-flash-001",
+                "messages": [{"role": "assistant", "content": {"answer": "gemini q1"}}],
+            },
+        ]
+    )
+
+    df_outputs = _build_model_outputs(raw_df)
+
+    assert df_outputs is not None
+    assert sorted(df_outputs["model"].unique().tolist()) == [
+        "gemini-2.0-flash-001",
+        "o3-mini-2025-01-31",
+    ]
+    assert df_outputs.shape[0] == 3
+
+
+def test_build_instructions_drops_model_answer_rows():
+    """Question rows and model-answer rows share a dataframe on fresh clone;
+    `_build_instructions` has to keep only the prompt rows so the instruction
+    table doesn't leak rows with no prompt text.
+    """
+    raw_df = pd.DataFrame(
+        [
+            {"uid": "q1", "prompt": "real prompt", "category": "hard_prompt"},
+            {"uid": "q1", "model": "baseline", "output": "answer"},
+        ]
+    )
+    df = _build_instructions(raw_df)
+    assert df["instruction_index"].tolist() == ["q1"]
+    assert df["instruction"].tolist() == ["real prompt"]
+
+
 def test_load_instructions_uses_explicit_version_filename(monkeypatch):
     captured = {}
 
@@ -52,12 +255,41 @@ def test_load_instructions_uses_explicit_version_filename(monkeypatch):
         )
 
     monkeypatch.setattr(instruction_dataset, "download_arena_hard", _fake_ensure)
-    monkeypatch.setattr(instruction_dataset, "read_df", _fake_read_df)
+    monkeypatch.setattr(judgearena_utils, "read_df", _fake_read_df)
     df = instruction_dataset.load_instructions(dataset="arena-hard-v2.0")
 
     assert captured["dataset"] == "arena-hard-v2.0"
     assert captured["path"].name == "arena-hard-v2.0.csv"
     assert df.index.tolist() == ["0", "1"]
+
+
+def test_load_instructions_surfaces_category_for_v20(monkeypatch):
+    """The per-category baseline plan in `generate_and_evaluate` keys off
+    the `category` column, so `load_instructions` must keep it round-tripping
+    from the cached CSV.
+    """
+    monkeypatch.setattr(
+        instruction_dataset,
+        "download_arena_hard",
+        lambda dataset, local_tables_path: None,
+    )
+    monkeypatch.setattr(
+        judgearena_utils,
+        "read_df",
+        lambda path: pd.DataFrame(
+            {
+                "instruction_index": ["q1", "q2"],
+                "instruction": ["a", "b"],
+                "category": ["hard_prompt", "creative_writing"],
+            }
+        ),
+    )
+
+    df = instruction_dataset.load_instructions(dataset="arena-hard-v2.0")
+
+    assert "category" in df.columns
+    assert df.loc["q1", "category"] == "hard_prompt"
+    assert df.loc["q2", "category"] == "creative_writing"
 
 
 def test_try_load_dataset_completions_uses_dataset_output_file(monkeypatch, tmp_path):

--- a/tests/test_mt_bench_downloads.py
+++ b/tests/test_mt_bench_downloads.py
@@ -1,5 +1,9 @@
+import pandas as pd
+
 import judgearena.instruction_dataset.mt_bench as mt_bench
+import judgearena.mt_bench.mt_bench_utils as mt_bench_utils
 import judgearena.utils as utils
+from judgearena.generate_and_evaluate import CliArgs
 
 
 def test_download_mt_bench_skips_question_download_if_cached(tmp_path, monkeypatch):
@@ -66,7 +70,8 @@ def test_download_all_includes_mt_bench(tmp_path, monkeypatch):
     tables_dir = tmp_path / "tables"
     assert [name for name, _ in hf_datasets] == [
         "alpaca-eval",
-        "m-arena-hard",
+        "m-arena-hard-v0.1",
+        "m-arena-hard-v2.0",
     ]
     assert arena_hard_datasets == [
         ("arena-hard-v0.1", tables_dir),
@@ -74,3 +79,157 @@ def test_download_all_includes_mt_bench(tmp_path, monkeypatch):
     ]
     assert calls["contexts"] == 1
     assert calls["mt_bench"] == 1
+
+
+def test_load_mt_bench_model_answers_reads_cached_baseline_file(tmp_path):
+    answer_path = tmp_path / "data" / "mt_bench" / "model_answer" / "gpt-4.jsonl"
+    answer_path.parent.mkdir(parents=True, exist_ok=True)
+    answer_path.write_text(
+        '{"question_id": 2, "choices": [{"turns": ["A2", "B2"]}]}\n'
+        '{"question_id": 1, "choices": [{"turns": ["A1"]}]}\n'
+    )
+
+    df_answers = mt_bench.load_mt_bench_model_answers("gpt-4", local_dir=tmp_path)
+
+    assert df_answers.to_dict(orient="records") == [
+        {
+            "instruction_index": 1,
+            "completion_turn_1": "A1",
+            "completion_turn_2": "",
+        },
+        {
+            "instruction_index": 2,
+            "completion_turn_1": "A2",
+            "completion_turn_2": "B2",
+        },
+    ]
+
+
+def test_generate_mt_bench_completions_uses_pregenerated_baseline(monkeypatch):
+    questions_df = pd.DataFrame(
+        {"turn_1": ["Q1", "Q2"], "turn_2": ["Q1b", "Q2b"]},
+        index=pd.Index([1, 2], name="instruction_index"),
+    )
+    generated_models = []
+
+    monkeypatch.setattr(
+        mt_bench_utils, "cache_function_dataframe", lambda fun, **_kwargs: fun()
+    )
+
+    def fake_generate_multiturn(**kwargs):
+        generated_models.append(kwargs["model"])
+        return pd.DataFrame(
+            {
+                "instruction_index": [1, 2],
+                "completion_turn_1": ["Gen A1", "Gen A2"],
+                "completion_turn_2": ["Gen B1", "Gen B2"],
+            }
+        )
+
+    monkeypatch.setattr(mt_bench_utils, "generate_multiturn", fake_generate_multiturn)
+    monkeypatch.setattr(
+        mt_bench_utils,
+        "load_mt_bench_model_answers",
+        lambda model, n_instructions=None: (
+            pd.DataFrame(
+                {
+                    "instruction_index": [2, 1],
+                    "completion_turn_1": ["Base A2", "Base A1"],
+                    "completion_turn_2": ["Base B2", "Base B1"],
+                }
+            )
+            if model == "gpt-4"
+            else None
+        ),
+    )
+
+    args = CliArgs(
+        task="mt-bench",
+        model_A="VLLM/example/model-a",
+        model_B="gpt-4",
+        judge_model="Dummy/J",
+        n_instructions=2,
+        engine_kwargs={"gpu_memory_utilization": 0.7},
+    )
+
+    completions_a, completions_b = mt_bench_utils._generate_mt_bench_completions(
+        args=args,
+        questions_df=questions_df,
+        ignore_cache=False,
+    )
+
+    assert generated_models == ["VLLM/example/model-a"]
+    assert completions_a.loc[1, "completion_turn_1"] == "Gen A1"
+    assert completions_b.loc[1, "completion_turn_1"] == "Base A1"
+    assert completions_b.loc[2, "completion_turn_2"] == "Base B2"
+
+
+def test_run_mt_bench_resolves_native_baseline_and_judge_controls(
+    monkeypatch, tmp_path
+):
+    questions_df = pd.DataFrame(
+        {"turn_1": ["Q1"], "turn_2": ["Q1b"]},
+        index=pd.Index([1], name="instruction_index"),
+    )
+    captured = {}
+
+    monkeypatch.setattr(
+        mt_bench_utils,
+        "load_instructions",
+        lambda dataset, n_instructions=None: questions_df,
+    )
+    monkeypatch.setattr(
+        mt_bench_utils,
+        "_generate_mt_bench_completions",
+        lambda args, questions_df, ignore_cache: (
+            pd.DataFrame(
+                {"completion_turn_1": ["A1"], "completion_turn_2": ["A2"]},
+                index=questions_df.index,
+            ),
+            pd.DataFrame(
+                {"completion_turn_1": ["B1"], "completion_turn_2": ["B2"]},
+                index=questions_df.index,
+            ),
+        ),
+    )
+
+    def fake_make_model(**kwargs):
+        captured["make_model"] = kwargs
+        return object()
+
+    monkeypatch.setattr(mt_bench_utils, "make_model", fake_make_model)
+
+    def fake_run_mt_bench_fastchat(**kwargs):
+        captured["fastchat"] = kwargs
+        return pd.Series([0.0], dtype=float)
+
+    monkeypatch.setattr(
+        mt_bench_utils,
+        "_run_mt_bench_fastchat",
+        fake_run_mt_bench_fastchat,
+    )
+
+    args = CliArgs(
+        task="mt-bench",
+        model_A="VLLM/example/model-a",
+        model_B=None,
+        judge_model="VLLM/Judge",
+        n_instructions=1,
+        truncate_judge_input_chars=80000,
+        max_judge_model_len=65536,
+        engine_kwargs={"tensor_parallel_size": 1},
+        judge_engine_kwargs={"tensor_parallel_size": 4},
+        result_folder=str(tmp_path),
+    )
+
+    mt_bench_utils.run_mt_bench(
+        args,
+        ignore_cache=False,
+        res_folder=tmp_path,
+        result_name="mt-bench-test",
+    )
+
+    assert args.model_B == "gpt-4"
+    assert captured["make_model"]["max_model_len"] == 65536
+    assert captured["make_model"]["tensor_parallel_size"] == 4
+    assert captured["fastchat"]["args"].truncate_judge_input_chars == 80000

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,13 +29,14 @@ def test_download_all_dispatches_arena_hard_versions(monkeypatch, tmp_path):
     utils.download_all()
 
     tables_dir = tmp_path / "tables"
-    assert calls[:4] == [
+    assert calls[:5] == [
         ("hf", "alpaca-eval", tables_dir),
         ("arena", "arena-hard-v0.1", tables_dir),
         ("arena", "arena-hard-v2.0", tables_dir),
-        ("hf", "m-arena-hard", tables_dir),
+        ("hf", "m-arena-hard-v0.1", tables_dir),
+        ("hf", "m-arena-hard-v2.0", tables_dir),
     ]
-    assert calls[4] == (
+    assert calls[5] == (
         "snapshot",
         "geoalgo/multilingual-contexts-to-be-completed",
         tmp_path / "contexts",


### PR DESCRIPTION
## Summary
- Add dataset-native baseline resolution for AlpacaEval, Arena-Hard, m-Arena-Hard, and MT-Bench.
- Add judge-side limit controls and split judge/battle engine kwargs needed by benchmark runs.
- Update benchmark docs and focused baseline/limit tests.

## Stack
1. This PR targets `main`.
2. Next: `pr32-split/02-inference-metadata-thinking`.

## Test plan
- `uv run pytest tests/test_cli.py tests/test_generate_and_evaluate.py tests/test_instruction_dataset.py tests/test_mt_bench_downloads.py`
- `uv run ruff check ...` on touched files