### PR TITLE
Add paper experiment scripts

### DIFF
--- a/scripts/analyze_lmarena_elo.py
+++ b/scripts/analyze_lmarena_elo.py
@@ -1,0 +1,334 @@
+"""Build random1k LMArena Elo tables and plots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.colors import to_hex
+
+RESULTS_ROOT = Path("/home/lushtake/slurmpilot/jobs")
+OUTPUT_DIR = Path("docs/generated/lmarena_elo")
+RESULTS_GLOB = "elo-gemma4-random1k-seed*/results/elo-*/results-*.json"
+
+QWEN_MODELS = [
+    "VLLM/Qwen/Qwen3.5-0.8B",
+    "VLLM/Qwen/Qwen3.5-2B",
+    "VLLM/Qwen/Qwen3.5-4B",
+    "VLLM/Qwen/Qwen3.5-9B",
+    "VLLM/Qwen/Qwen3.5-27B-FP8",
+    "VLLM/Qwen/Qwen3.5-35B-A3B-FP8",
+]
+
+CASE_STUDY_MODELS = [
+    "VLLM/Qwen/Qwen3.5-9B",
+    "VLLM/HuggingFaceTB/SmolLM3-3B",
+    "VLLM/allenai/Olmo-3-7B-Instruct",
+    "VLLM/allenai/Olmo-3-7B-Think",
+    "VLLM/CohereLabs/tiny-aya-global",
+    "VLLM/swiss-ai/Apertus-8B-Instruct-2509",
+    "VLLM/utter-project/EuroLLM-1.7B-Instruct",
+    "VLLM/utter-project/EuroLLM-9B-Instruct",
+]
+
+RANDOM1K_ELO_MODELS = list(dict.fromkeys(QWEN_MODELS + CASE_STUDY_MODELS))
+
+MODEL_LABELS = {
+    "VLLM/Qwen/Qwen3.5-0.8B": "Qwen3.5-0.8B",
+    "VLLM/Qwen/Qwen3.5-2B": "Qwen3.5-2B",
+    "VLLM/Qwen/Qwen3.5-4B": "Qwen3.5-4B",
+    "VLLM/Qwen/Qwen3.5-9B": "Qwen3.5-9B",
+    "VLLM/Qwen/Qwen3.5-27B-FP8": "Qwen3.5-27B-FP8",
+    "VLLM/Qwen/Qwen3.5-35B-A3B-FP8": "Qwen3.5-35B-A3B-FP8",
+    "VLLM/HuggingFaceTB/SmolLM3-3B": "SmolLM3-3B",
+    "VLLM/allenai/Olmo-3-7B-Instruct": "Olmo-3-7B",
+    "VLLM/allenai/Olmo-3-7B-Think": "Olmo-3-7B-Think",
+    "VLLM/CohereLabs/tiny-aya-global": "Tiny Aya",
+    "VLLM/swiss-ai/Apertus-8B-Instruct-2509": "Apertus-8B",
+    "VLLM/utter-project/EuroLLM-1.7B-Instruct": "EuroLLM-1.7B",
+    "VLLM/utter-project/EuroLLM-9B-Instruct": "EuroLLM-9B",
+}
+
+TABLE_COLUMNS = [
+    "model_A",
+    "model_label",
+    "arena",
+    "elo_mean",
+    "elo_std",
+    "elo_ci_low",
+    "elo_ci_high",
+    "elo_num_bootstraps",
+    "num_battles",
+    "llm_judged_battles",
+    "human_anchor_battles",
+    "sampling_mode",
+    "random_seed",
+    "requested_rows",
+    "sampled_rows",
+    "sample_fingerprint",
+    "source_job",
+    "source_path",
+]
+
+_VIRIDIS = plt.get_cmap("viridis")
+
+
+def _parse_results(path: Path) -> dict:
+    with path.open() as fh:
+        return json.load(fh)
+
+
+def _summary(payload: dict) -> dict:
+    return payload.get("summary", payload)
+
+
+def _elo_bootstrap_values(payload: dict, model: str) -> np.ndarray:
+    values = [
+        float(rating[model])
+        for rating in payload.get("bootstrap_ratings", [])
+        if model in rating
+    ]
+    return np.asarray(values, dtype=float)
+
+
+def _elo_bootstrap_ci(payload: dict, model: str) -> tuple[float, float]:
+    values = _elo_bootstrap_values(payload, model)
+    if values.size == 0:
+        return float("nan"), float("nan")
+    low, high = np.percentile(values, [2.5, 97.5])
+    return float(low), float(high)
+
+
+def _candidate_row(path: Path) -> dict[str, object] | None:
+    payload = _parse_results(path)
+    summary = _summary(payload)
+    metadata = summary.get("sampling_metadata", {}) or {}
+    if metadata.get("sampling_mode") != "seeded_random":
+        return None
+    if int(metadata.get("requested_rows", -1)) != 1000:
+        return None
+    if int(metadata.get("random_seed", -1)) != 0:
+        return None
+    model = str(summary["model_A"])
+    if model not in RANDOM1K_ELO_MODELS:
+        return None
+    elo_ci_low, elo_ci_high = _elo_bootstrap_ci(payload, model)
+    return {
+        "model_A": model,
+        "model_label": MODEL_LABELS[model],
+        "arena": summary.get("arena"),
+        "elo_mean": summary.get("elo_mean"),
+        "elo_std": summary.get("elo_std"),
+        "elo_ci_low": elo_ci_low,
+        "elo_ci_high": elo_ci_high,
+        "elo_num_bootstraps": summary.get("elo_num_bootstraps"),
+        "num_battles": summary.get("num_battles"),
+        "llm_judged_battles": summary.get("llm_judged_battles"),
+        "human_anchor_battles": summary.get("human_anchor_battles"),
+        "sampling_mode": metadata.get("sampling_mode"),
+        "random_seed": metadata.get("random_seed"),
+        "requested_rows": metadata.get("requested_rows"),
+        "sampled_rows": metadata.get("sampled_rows"),
+        "sample_fingerprint": metadata.get("sample_fingerprint"),
+        "source_job": path.parents[2].name,
+        "source_path": str(path),
+    }
+
+
+def build_elo_dataframe(
+    results_root: Path = RESULTS_ROOT,
+    *,
+    results_glob: str = RESULTS_GLOB,
+    require_models: Iterable[str] | None = None,
+) -> pd.DataFrame:
+    latest_by_model: dict[str, dict[str, object]] = {}
+    for path in sorted(results_root.glob(results_glob)):
+        row = _candidate_row(path)
+        if row is None:
+            continue
+        existing = latest_by_model.get(str(row["model_A"]))
+        if existing is None or str(row["source_path"]) > str(existing["source_path"]):
+            latest_by_model[str(row["model_A"])] = row
+
+    required = list(require_models or [])
+    if required:
+        missing = sorted(set(required) - set(latest_by_model))
+        if missing:
+            raise FileNotFoundError(
+                "Missing random1k Elo results for: " + ", ".join(missing)
+            )
+
+    rows = list(latest_by_model.values())
+    if not rows:
+        return pd.DataFrame(columns=TABLE_COLUMNS)
+
+    fingerprints = {row.get("sample_fingerprint") for row in rows}
+    if len(fingerprints) != 1:
+        raise ValueError(f"Expected one sample_fingerprint, got {sorted(fingerprints)}")
+
+    df = pd.DataFrame(rows)
+    df["model_A"] = pd.Categorical(
+        df["model_A"], categories=RANDOM1K_ELO_MODELS, ordered=True
+    )
+    df = df.sort_values("model_A").reset_index(drop=True)
+    df["model_A"] = df["model_A"].astype(str)
+    return df.loc[:, TABLE_COLUMNS]
+
+
+def _save_figure(fig: plt.Figure, pdf_path: Path, png_path: Path) -> None:
+    fig.tight_layout()
+    fig.savefig(pdf_path, bbox_inches="tight")
+    fig.savefig(png_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _colors(models: Sequence[str]) -> list[str]:
+    values = np.linspace(0.08, 0.92, len(models))
+    return [to_hex(_VIRIDIS(value)) for value in values]
+
+
+def _write_barplot(
+    df: pd.DataFrame,
+    *,
+    models: Sequence[str],
+    title: str,
+    pdf_path: Path,
+    png_path: Path,
+) -> None:
+    ordered = df.set_index("model_A").reindex(models)
+    values = ordered["elo_mean"].to_numpy(dtype=float)
+    ci_low = ordered["elo_ci_low"].to_numpy(dtype=float)
+    ci_high = ordered["elo_ci_high"].to_numpy(dtype=float)
+    errors = np.vstack(
+        [
+            np.maximum(values - ci_low, 0.0),
+            np.maximum(ci_high - values, 0.0),
+        ]
+    )
+    x = np.arange(len(models))
+
+    fig, ax = plt.subplots(figsize=(13.5, 5.8))
+    ax.bar(
+        x,
+        values,
+        width=0.55,
+        color=_colors(models),
+        yerr=errors,
+        capsize=2,
+        error_kw={"linewidth": 0.8},
+    )
+    ax.set_xticks(x)
+    ax.set_xticklabels(
+        [MODEL_LABELS[model] for model in models], rotation=25, ha="right"
+    )
+    ax.set_ylabel("Estimated Elo")
+    ax.set_xlabel("")
+    ax.set_ylim(0, float(np.nanmax(values + errors) * 1.08))
+    ax.set_title(title)
+    ax.grid(axis="y", alpha=0.3)
+
+    _save_figure(fig, pdf_path, png_path)
+
+
+def _write_case_study_table(df: pd.DataFrame, path: Path) -> None:
+    ordered = df.set_index("model_A").reindex(CASE_STUDY_MODELS)
+    ordered = ordered.sort_values("elo_mean", ascending=False)
+    lines = [
+        r"\begin{tabular}{lrr}",
+        r"\toprule",
+        r"\textbf{Model} & \textbf{LMArena Elo} & \textbf{95\% CI} \\",
+        r"\midrule",
+    ]
+    for model, row in ordered.iterrows():
+        lines.append(
+            f"{MODEL_LABELS[str(model)]} & {float(row['elo_mean']):.1f} & "
+            f"[{float(row['elo_ci_low']):.1f}, {float(row['elo_ci_high']):.1f}] \\\\"
+        )
+    lines.extend([r"\bottomrule", r"\end{tabular}", ""])
+    path.write_text("\n".join(lines))
+
+
+def _subset(df: pd.DataFrame, models: Sequence[str]) -> pd.DataFrame:
+    return df[df["model_A"].isin(models)].copy()
+
+
+def write_outputs(df: pd.DataFrame, output_dir: Path = OUTPUT_DIR) -> dict[str, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    qwen = _subset(df, QWEN_MODELS)
+    case_study = _subset(df, CASE_STUDY_MODELS)
+
+    qwen_csv = output_dir / "qwen_lmarena_elo_random1k_seed0_results.csv"
+    qwen_json = output_dir / "qwen_lmarena_elo_random1k_seed0_results.json"
+    qwen_pdf = output_dir / "qwen_lmarena_elo_random1k_seed0.pdf"
+    qwen_png = output_dir / "qwen_lmarena_elo_random1k_seed0.png"
+    case_csv = output_dir / "case_study_lmarena_elo_random1k_seed0_results.csv"
+    case_json = output_dir / "case_study_lmarena_elo_random1k_seed0_results.json"
+    case_pdf = output_dir / "case_study_lmarena_elo_random1k_seed0.pdf"
+    case_png = output_dir / "case_study_lmarena_elo_random1k_seed0.png"
+    case_tex = output_dir / "case_study_lmarena_elo_random1k_seed0_table.tex"
+
+    qwen.to_csv(qwen_csv, index=False)
+    qwen_json.write_text(qwen.to_json(orient="records", indent=2) + "\n")
+    case_study.to_csv(case_csv, index=False)
+    case_json.write_text(case_study.to_json(orient="records", indent=2) + "\n")
+
+    _write_barplot(
+        qwen,
+        models=QWEN_MODELS,
+        title="Qwen Estimated LMArena-140K Elo (Random 1K, Seed 0)",
+        pdf_path=qwen_pdf,
+        png_path=qwen_png,
+    )
+    _write_barplot(
+        case_study,
+        models=CASE_STUDY_MODELS,
+        title="Case Study Estimated LMArena-140K Elo (Random 1K, Seed 0)",
+        pdf_path=case_pdf,
+        png_path=case_png,
+    )
+    _write_case_study_table(case_study, case_tex)
+
+    return {
+        "qwen_csv": qwen_csv,
+        "qwen_json": qwen_json,
+        "qwen_plot_pdf": qwen_pdf,
+        "qwen_plot_png": qwen_png,
+        "case_study_csv": case_csv,
+        "case_study_json": case_json,
+        "case_study_plot_pdf": case_pdf,
+        "case_study_plot_png": case_png,
+        "case_study_table_tex": case_tex,
+    }
+
+
+def run_analysis(
+    results_root: Path = RESULTS_ROOT,
+    output_dir: Path = OUTPUT_DIR,
+) -> tuple[pd.DataFrame, dict[str, Path]]:
+    df = build_elo_dataframe(results_root, require_models=RANDOM1K_ELO_MODELS)
+    written = write_outputs(df, output_dir)
+    return df, written
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results-root", type=Path, default=RESULTS_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=OUTPUT_DIR)
+    args = parser.parse_args(argv)
+
+    df, written = run_analysis(args.results_root, args.output_dir)
+    print(f"Rows: {len(df)}")
+    print(f"Sample fingerprint: {df['sample_fingerprint'].iloc[0]}")
+    print("Wrote artifacts:")
+    for key, path in written.items():
+        print(f"  {key}: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase_b_marena_localized_prompt_table.py
+++ b/scripts/phase_b_marena_localized_prompt_table.py
@@ -1,0 +1,317 @@
+"""Build the localized m-Arena-Hard judge-prompt ablation table.
+
+The table uses only the Phase B runs with m-Arena-Hard v2.0 language-localized
+judge prompts. It mirrors the case-study leaderboard style, but restricts the
+columns to AR/PL/UK/ZH and reports the average rank across those localized
+benchmark cells.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+DEFAULT_RESULTS_ROOT = Path("/home/lushtake/slurmpilot/jobs")
+DEFAULT_RESULTS_GLOB = (
+    "phase-b-serial-marena-localized-prompts-*/results/*/results-*.json"
+)
+
+DATASET_ORDER: list[str] = [
+    "m-arena-hard-v2.0-ar",
+    "m-arena-hard-v2.0-pl",
+    "m-arena-hard-v2.0-uk",
+    "m-arena-hard-v2.0-zh",
+]
+
+DATASET_HEADER: dict[str, str] = {
+    "m-arena-hard-v2.0-ar": "AR",
+    "m-arena-hard-v2.0-pl": "PL",
+    "m-arena-hard-v2.0-uk": "UK",
+    "m-arena-hard-v2.0-zh": "ZH",
+}
+
+DATASET_PROMPT_PRESET: dict[str, str] = {
+    "m-arena-hard-v2.0-ar": "m-arena-hard-v2-localized-ar",
+    "m-arena-hard-v2.0-pl": "m-arena-hard-v2-localized-pl",
+    "m-arena-hard-v2.0-uk": "m-arena-hard-v2-localized-uk",
+    "m-arena-hard-v2.0-zh": "m-arena-hard-v2-localized-zh",
+}
+
+MODEL_HEADER: dict[str, str] = {
+    "Qwen/Qwen3.5-9B": "Qwen3.5-9B",
+    "allenai/Olmo-3-7B-Think": "Olmo-3-7B-Think",
+    "allenai/Olmo-3-7B-Instruct": "Olmo-3-7B",
+    "HuggingFaceTB/SmolLM3-3B": "SmolLM3-3B",
+    "CohereLabs/tiny-aya-global": "Tiny Aya",
+    "swiss-ai/Apertus-8B-Instruct-2509": "Apertus-8B",
+    "utter-project/EuroLLM-9B-Instruct": "EuroLLM-9B",
+    "utter-project/EuroLLM-1.7B-Instruct": "EuroLLM-1.7B",
+}
+
+EXPECTED_CELL_COUNT = len(DATASET_ORDER) * len(MODEL_HEADER)
+
+ARCH_CONSTRAINED_MODELS: set[str] = {
+    "utter-project/EuroLLM-1.7B-Instruct",
+    "utter-project/EuroLLM-9B-Instruct",
+}
+
+
+def discrete_winrate(prefs: np.ndarray) -> float:
+    valid = prefs[~np.isnan(prefs)]
+    if valid.size == 0:
+        return float("nan")
+    wins = int((valid < 0.5).sum())
+    ties = int((valid == 0.5).sum())
+    return (wins + 0.5 * ties) / float(valid.size)
+
+
+def bootstrap_winrate_ci(
+    prefs: np.ndarray,
+    n_bootstrap: int = 1000,
+    seed: int = 0,
+) -> tuple[float, float]:
+    valid = prefs[~np.isnan(prefs)]
+    if valid.size == 0:
+        return float("nan"), float("nan")
+    rng = np.random.default_rng(seed)
+    n = valid.size
+    boot = np.empty(n_bootstrap, dtype=float)
+    for i in range(n_bootstrap):
+        sample = valid[rng.integers(0, n, size=n)]
+        wins = (sample < 0.5).sum()
+        ties = (sample == 0.5).sum()
+        boot[i] = (wins + 0.5 * ties) / float(n)
+    low, high = np.percentile(boot, [2.5, 97.5])
+    return float(low), float(high)
+
+
+def _strip_vllm_prefix(model: str) -> str:
+    return model[len("VLLM/") :] if model.startswith("VLLM/") else model
+
+
+def load_cell(path: Path) -> tuple[str, str, str, np.ndarray, dict]:
+    with path.open() as fh:
+        data = json.load(fh)
+
+    summary = data.get("summary") or data
+    dataset = summary.get("dataset") or summary.get("task")
+    if dataset is None:
+        raise KeyError("dataset")
+    model_a = _strip_vllm_prefix(summary["model_A"])
+    prompt_preset = summary.get("judge_prompt_preset")
+    prefs = np.asarray(data.get("preferences") or summary.get("preferences") or [])
+    return dataset, model_a, prompt_preset, prefs.astype(float), data
+
+
+def _is_expected_localized_cell(dataset: str, model: str, prompt_preset: str) -> bool:
+    return (
+        dataset in DATASET_ORDER
+        and model in MODEL_HEADER
+        and prompt_preset == DATASET_PROMPT_PRESET[dataset]
+    )
+
+
+def find_cells(
+    root: Path,
+    results_glob: str = DEFAULT_RESULTS_GLOB,
+) -> list[Path]:
+    if root.name == "results":
+        candidates = sorted(root.glob("*/results-*.json"))
+    else:
+        candidates = sorted(root.glob(results_glob))
+
+    latest: dict[tuple[str, str], Path] = {}
+    for path in candidates:
+        dataset, model, prompt_preset, _prefs, _raw = load_cell(path)
+        if not _is_expected_localized_cell(dataset, model, prompt_preset):
+            continue
+        key = (dataset, model)
+        if key not in latest or path.stat().st_mtime > latest[key].stat().st_mtime:
+            latest[key] = path
+    return [latest[key] for key in sorted(latest)]
+
+
+def fmt_winrate(wr: float, low: float, high: float, arch: bool) -> str:
+    dagger = r"{}^{\dagger}" if arch else ""
+    return f"${wr:.2f}_{{{low:.2f}}}^{{{high:.2f}}}{dagger}$"
+
+
+def fmt_avg_rank(rank: float) -> str:
+    return f"\\textbf{{{rank:.3f}}}"
+
+
+def localized_average_rank(
+    table: dict[tuple[str, str], dict],
+    model: str,
+    datasets: list[str] = DATASET_ORDER,
+    models: list[str] | None = None,
+) -> float:
+    ranks = _localized_rank_table(table, datasets=datasets, models=models)
+    return float(ranks[model])
+
+
+def _localized_rank_table(
+    table: dict[tuple[str, str], dict],
+    datasets: list[str] = DATASET_ORDER,
+    models: list[str] | None = None,
+) -> dict[str, float]:
+    models = models or list(MODEL_HEADER)
+    rank_sums = {model: 0.0 for model in models}
+    for dataset in datasets:
+        scores = {model: float(table[(dataset, model)]["winrate"]) for model in models}
+        for model, rank in _average_descending_ranks(scores).items():
+            rank_sums[model] += rank
+    return {model: rank_sums[model] / len(datasets) for model in models}
+
+
+def _average_descending_ranks(scores: dict[str, float]) -> dict[str, float]:
+    ordered = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+    ranks: dict[str, float] = {}
+    i = 0
+    while i < len(ordered):
+        j = i + 1
+        while j < len(ordered) and abs(ordered[j][1] - ordered[i][1]) < 1e-12:
+            j += 1
+        avg_rank = (i + 1 + j) / 2
+        for index in range(i, j):
+            ranks[ordered[index][0]] = avg_rank
+        i = j
+    return ranks
+
+
+def render_table(
+    table: dict[tuple[str, str], dict],
+    model_order: list[str] | None = None,
+) -> str:
+    candidate_order = model_order or list(MODEL_HEADER)
+    avg_ranks = _localized_rank_table(table, models=candidate_order)
+    sorted_models = sorted(candidate_order, key=lambda model: avg_ranks[model])
+
+    lines: list[str] = []
+    lines.append(r"\begin{table}[t]")
+    lines.append(r"\centering")
+    lines.append(r"\footnotesize")
+    lines.append(
+        r"\caption{Localized judge-prompt ablation on m-Arena-Hard~v2.0. "
+        r"The evaluated model completions and Gemma-4-31B-IT judge route match "
+        r"\cref{tab:benchmark_results}, but each language uses a translated "
+        r"score-style judge prompt instead of the English \texttt{default} "
+        r"prompt. Each cell reports the evaluated model's win-rate against "
+        r"Gemini 2.5 Flash with empirical 95\% confidence intervals from "
+        r"1\,000 bootstrap resamples; \textit{Avg Rank} reports the mean rank "
+        r"over AR/PL/UK/ZH, with lower being better.}"
+    )
+    lines.append(r"\label{tab:marena_hard_localized_prompt_results}")
+    lines.append(r"\setlength{\tabcolsep}{4pt}")
+    lines.append(r"\renewcommand{\arraystretch}{1.15}")
+    lines.append(r"\resizebox{0.82\textwidth}{!}{%")
+    lines.append(r"\begin{tabular}{l rrrr r}")
+    lines.append(r"\toprule")
+    lines.append(
+        r" & \multicolumn{4}{c}{\textbf{Localized m-Arena-Hard v2.0 prompts}} & \\"
+    )
+    lines.append(r"\cmidrule(lr){2-5}")
+    header_cells = [r"\textbf{Model}"]
+    header_cells.extend(DATASET_HEADER[dataset] for dataset in DATASET_ORDER)
+    header_cells.append(r"\textbf{Avg Rank}")
+    lines.append(" & ".join(header_cells) + r" \\")
+    lines.append(r"\midrule")
+
+    for model in sorted_models:
+        row = [MODEL_HEADER[model]]
+        for dataset in DATASET_ORDER:
+            cell = table[(dataset, model)]
+            row.append(
+                fmt_winrate(
+                    cell["winrate"],
+                    cell["ci_low"],
+                    cell["ci_high"],
+                    cell["arch"],
+                )
+            )
+        row.append(fmt_avg_rank(avg_ranks[model]))
+        lines.append(" & ".join(row) + r" \\")
+
+    lines.append(r"\bottomrule")
+    lines.append(r"\end{tabular}")
+    lines.append(r"}")
+    lines.append(r"\end{table}")
+    return "\n".join(lines) + "\n"
+
+
+def build_table(
+    cells: list[Path],
+    *,
+    n_bootstrap: int = 1000,
+    seed: int = 0,
+) -> dict[tuple[str, str], dict]:
+    table: dict[tuple[str, str], dict] = {}
+    for path in cells:
+        dataset, model, _prompt_preset, prefs, _raw = load_cell(path)
+        wr = discrete_winrate(prefs)
+        ci_low, ci_high = bootstrap_winrate_ci(
+            prefs,
+            n_bootstrap=n_bootstrap,
+            seed=seed,
+        )
+        table[(dataset, model)] = {
+            "winrate": wr,
+            "ci_low": ci_low,
+            "ci_high": ci_high,
+            "n": int(prefs.size),
+            "arch": model in ARCH_CONSTRAINED_MODELS,
+        }
+    return table
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=DEFAULT_RESULTS_ROOT,
+        help="Slurmpilot jobs root or one job's results directory.",
+    )
+    parser.add_argument(
+        "--results-glob",
+        default=DEFAULT_RESULTS_GLOB,
+        help="Glob used when --root points at the Slurmpilot jobs root.",
+    )
+    parser.add_argument(
+        "--n-bootstrap",
+        type=int,
+        default=1000,
+        help="Number of bootstrap resamples per cell.",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Optional path to write the LaTeX table. Always also prints to stdout.",
+    )
+    args = parser.parse_args()
+
+    cells = find_cells(args.root, args.results_glob)
+    if len(cells) != EXPECTED_CELL_COUNT:
+        raise SystemExit(
+            f"expected {EXPECTED_CELL_COUNT} localized cells, found {len(cells)} "
+            f"under {args.root}"
+        )
+
+    table = build_table(cells, n_bootstrap=args.n_bootstrap, seed=args.seed)
+    rendered = render_table(table)
+    print(rendered)
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered)
+        print(f"\nwrote LaTeX table to {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/phase_b_paper_table.py
+++ b/scripts/phase_b_paper_table.py
@@ -1,0 +1,346 @@
+"""Build the Phase B leaderboard LaTeX table for the paper.
+
+Reads all 64 Phase B `results-*.json` files, computes per-cell winrates with
+95 % percentile bootstrap CIs on `preferences`, and emits a LaTeX `tabular`
+fragment ready to drop into `judge_arena_neurips2026.tex` as
+`tab:benchmark_results`.
+
+The discrete winrate convention matches `judgearena.utils.compute_pref_summary`:
+`prefs < 0.5` is a win for model_A, `prefs > 0.5` a loss, `prefs == 0.5` a
+tie, and `winrate = (num_wins + 0.5 * num_ties) / num_battles`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+
+DEFAULT_RESULTS_ROOT = Path("/home/lushtake/slurmpilot/jobs")
+DEFAULT_RESULTS_GLOB = "phase-b-serial-*/results/*/results-*.json"
+DEFAULT_ELO_CSV = Path(
+    "docs/generated/lmarena_elo/case_study_lmarena_elo_random1k_seed0_results.csv"
+)
+
+DATASET_ORDER: list[str] = [
+    "alpaca-eval",
+    "arena-hard-v0.1",
+    "arena-hard-v2.0",
+    "mt-bench",
+    "m-arena-hard-v2.0-ar",
+    "m-arena-hard-v2.0-pl",
+    "m-arena-hard-v2.0-uk",
+    "m-arena-hard-v2.0-zh",
+]
+
+DATASET_HEADER: dict[str, str] = {
+    "alpaca-eval": "AlpacaEval",
+    "arena-hard-v0.1": "AH v0.1",
+    "arena-hard-v2.0": "AH v2.0",
+    "mt-bench": "MT-Bench",
+    "m-arena-hard-v2.0-ar": "AR",
+    "m-arena-hard-v2.0-pl": "PL",
+    "m-arena-hard-v2.0-uk": "UK",
+    "m-arena-hard-v2.0-zh": "ZH",
+}
+
+MODEL_HEADER: dict[str, str] = {
+    "Qwen/Qwen3.5-9B": "Qwen3.5-9B",
+    "allenai/Olmo-3-7B-Instruct": "Olmo-3-7B",
+    "allenai/Olmo-3-7B-Think": "Olmo-3-7B-Think",
+    "CohereLabs/tiny-aya-global": "Tiny Aya",
+    "HuggingFaceTB/SmolLM3-3B": "SmolLM3-3B",
+    "swiss-ai/Apertus-8B-Instruct-2509": "Apertus-8B",
+    "utter-project/EuroLLM-9B-Instruct": "EuroLLM-9B",
+    "utter-project/EuroLLM-1.7B-Instruct": "EuroLLM-1.7B",
+}
+
+EXPECTED_CELL_COUNT = len(DATASET_ORDER) * len(MODEL_HEADER)
+TABLE_TRAILING_HEADERS = [r"\textbf{Overall}", r"\textbf{LMArena Elo}"]
+
+ARCH_CONSTRAINED_LONG_PROMPT_DATASETS: set[str] = {
+    "arena-hard-v2.0",
+    "m-arena-hard-v2.0-ar",
+    "m-arena-hard-v2.0-pl",
+    "m-arena-hard-v2.0-uk",
+    "m-arena-hard-v2.0-zh",
+    "mt-bench",
+}
+ARCH_CONSTRAINED_MODELS: set[str] = {
+    "utter-project/EuroLLM-1.7B-Instruct",
+    "utter-project/EuroLLM-9B-Instruct",
+}
+
+
+def discrete_winrate(prefs: np.ndarray) -> float:
+    valid = prefs[~np.isnan(prefs)]
+    if valid.size == 0:
+        return float("nan")
+    wins = int((valid < 0.5).sum())
+    ties = int((valid == 0.5).sum())
+    return (wins + 0.5 * ties) / float(valid.size)
+
+
+def bootstrap_winrate_ci(
+    prefs: np.ndarray,
+    n_bootstrap: int = 1000,
+    seed: int = 0,
+) -> tuple[float, float]:
+    valid = prefs[~np.isnan(prefs)]
+    if valid.size == 0:
+        return float("nan"), float("nan")
+    rng = np.random.default_rng(seed)
+    n = valid.size
+    boot = np.empty(n_bootstrap, dtype=float)
+    for i in range(n_bootstrap):
+        sample = valid[rng.integers(0, n, size=n)]
+        wins = (sample < 0.5).sum()
+        ties = (sample == 0.5).sum()
+        boot[i] = (wins + 0.5 * ties) / float(n)
+    low, high = np.percentile(boot, [2.5, 97.5])
+    return float(low), float(high)
+
+
+def load_cell(path: Path) -> tuple[str, str, np.ndarray, dict]:
+    with open(path) as f:
+        d = json.load(f)
+    summary = d.get("summary") or d
+    dataset = summary.get("dataset") or summary.get("task")
+    if dataset is None:
+        raise KeyError("dataset")
+    model_a = summary["model_A"]
+    if model_a.startswith("VLLM/"):
+        model_a = model_a[len("VLLM/") :]
+    prefs = np.asarray(
+        d.get("preferences") or summary.get("preferences") or [], dtype=float
+    )
+    return dataset, model_a, prefs, d
+
+
+def find_cells(root: Path, results_glob: str = DEFAULT_RESULTS_GLOB) -> list[Path]:
+    if root.name == "results":
+        candidates = sorted(root.glob("*/results-*.json"))
+    else:
+        candidates = sorted(root.glob(results_glob))
+
+    latest: dict[tuple[str, str], Path] = {}
+    for path in candidates:
+        dataset, model, _prefs, _raw = load_cell(path)
+        if dataset not in DATASET_ORDER or model not in MODEL_HEADER:
+            continue
+        key = (dataset, model)
+        if key not in latest or path.stat().st_mtime > latest[key].stat().st_mtime:
+            latest[key] = path
+    return [latest[key] for key in sorted(latest)]
+
+
+def fmt_winrate(wr: float, low: float, high: float, arch: bool) -> str:
+    dagger = r"{}^{\dagger}" if arch else ""
+    return f"${wr:.2f}_{{{low:.2f}}}^{{{high:.2f}}}{dagger}$"
+
+
+def fmt_overall(wr: float) -> str:
+    return f"\\textbf{{{wr:.3f}}}"
+
+
+def fmt_elo(mean: float, low: float, high: float) -> str:
+    return f"${mean:.0f}_{{{low:.0f}}}^{{{high:.0f}}}$"
+
+
+def overall_benchmark_average(
+    table: dict[tuple[str, str], dict],
+    model: str,
+    datasets: list[str],
+) -> float:
+    values = [float(table[(dataset, model)]["winrate"]) for dataset in datasets]
+    return float(np.mean(values))
+
+
+def table_preamble_lines() -> list[str]:
+    return [
+        r"\setlength{\tabcolsep}{4pt}",
+        r"\renewcommand{\arraystretch}{1.15}",
+        r"\resizebox{\textwidth}{!}{%",
+        r"\begin{tabular}{l rrrr rrrr r r}",
+    ]
+
+
+def table_header_line(benchmark_headers: list[str], trailing_headers: list[str]) -> str:
+    header_cells = [r"\textbf{Model}"] + benchmark_headers + trailing_headers
+    return " & ".join(header_cells) + r" \\"
+
+
+def _strip_vllm_prefix(model: str) -> str:
+    return model[len("VLLM/") :] if model.startswith("VLLM/") else model
+
+
+def load_lmarena_elo(path: Path) -> dict[str, dict[str, float]]:
+    if not path.exists():
+        raise FileNotFoundError(f"missing LMArena Elo CSV: {path}")
+
+    with path.open(newline="") as fh:
+        rows = list(csv.DictReader(fh))
+
+    elo: dict[str, dict[str, float]] = {}
+    for row in rows:
+        model = _strip_vllm_prefix(row["model_A"])
+        if model not in MODEL_HEADER:
+            continue
+        elo[model] = {
+            "mean": float(row["elo_mean"]),
+            "low": float(row["elo_ci_low"]),
+            "high": float(row["elo_ci_high"]),
+        }
+
+    missing = sorted(set(MODEL_HEADER) - set(elo))
+    if missing:
+        raise FileNotFoundError("missing LMArena Elo rows for: " + ", ".join(missing))
+    return elo
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=DEFAULT_RESULTS_ROOT,
+        help="Phase B Slurmpilot jobs root or one job's results directory.",
+    )
+    parser.add_argument(
+        "--results-glob",
+        default=DEFAULT_RESULTS_GLOB,
+        help="Glob used when --root points at the Slurmpilot jobs root.",
+    )
+    parser.add_argument(
+        "--elo-csv",
+        type=Path,
+        default=DEFAULT_ELO_CSV,
+        help="Random1k LMArena Elo CSV with quantile CI columns.",
+    )
+    parser.add_argument(
+        "--n-bootstrap",
+        type=int,
+        default=1000,
+        help="Number of bootstrap resamples per cell.",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Optional path to write the LaTeX fragment to. Always also prints to stdout.",
+    )
+    args = parser.parse_args()
+
+    cells = find_cells(args.root, args.results_glob)
+    if len(cells) != EXPECTED_CELL_COUNT:
+        raise SystemExit(
+            f"expected {EXPECTED_CELL_COUNT} cells, found {len(cells)} under {args.root}"
+        )
+    lmarena_elo = load_lmarena_elo(args.elo_csv)
+
+    table: dict[tuple[str, str], dict] = {}
+    for path in cells:
+        dataset, model, prefs, _raw = load_cell(path)
+        wr = discrete_winrate(prefs)
+        arch = (
+            model in ARCH_CONSTRAINED_MODELS
+            and dataset in ARCH_CONSTRAINED_LONG_PROMPT_DATASETS
+        )
+        ci_low, ci_high = bootstrap_winrate_ci(
+            prefs,
+            n_bootstrap=args.n_bootstrap,
+            seed=args.seed,
+        )
+        table[(dataset, model)] = {
+            "winrate": wr,
+            "ci_low": ci_low,
+            "ci_high": ci_high,
+            "n": int(prefs.size),
+            "arch": arch,
+        }
+
+    overall: dict[str, dict] = {}
+    for model in MODEL_HEADER:
+        wr = overall_benchmark_average(table, model, DATASET_ORDER)
+        overall[model] = {
+            "winrate": wr,
+        }
+
+    model_order = sorted(MODEL_HEADER.keys(), key=lambda m: -overall[m]["winrate"])
+
+    lines: list[str] = []
+    lines.append(r"\begin{table}[t]")
+    lines.append(r"\centering")
+    lines.append(r"\footnotesize")
+    lines.append(
+        r"\caption{Win-rate of eight open models against each benchmark's "
+        r"default reference baseline, judged by Gemma-4-31B-IT (OpenRouter) under "
+        r"the tuned \texttt{default} preset (one judge call per battle, "
+        r"\texttt{swap\_mode=fixed}). Each cell averages "
+        r"$\mathbf{1}[\sigma(\Delta\text{score}) < 0.5] + 0.5 \cdot \mathbf{1}[\cdot = 0.5]$ "
+        r"over the benchmark's prompts (per-cell $n$ matches its native size: "
+        r"AlpacaEval 805, AH v0.1 500, AH v2.0 750, MT-Bench 160, m-AH v2.0 "
+        r"498). Benchmark cells report empirical 95\% CIs from 1\,000 "
+        r"bootstrap resamples as subscripts/superscripts. The \textit{Overall} "
+        r"column averages the eight benchmark-level win-rate point estimates "
+        r"and reports that point estimate only. The LMArena Elo column uses the seeded random 1K "
+        r"English battle setup with the same CI convention. "
+        r"Cells marked with $^{\dagger}$ are subject "
+        r"to EuroLLM's 4096-token positional cap on long-prompt benchmarks "
+        r"(\cref{sec:exp_cross_benchmark}); the underlying input is truncated for "
+        r"$\sim$2--9\,\% of rows.}"
+    )
+    lines.append(r"\label{tab:benchmark_results}")
+    lines.extend(table_preamble_lines())
+    lines.append(r"\toprule")
+    lines.append(
+        r" & \multicolumn{4}{c}{\textbf{English / single-language}} & "
+        r"\multicolumn{4}{c}{\textbf{m-Arena-Hard v2.0}} & & \\"
+    )
+    lines.append(r"\cmidrule(lr){2-5} \cmidrule(lr){6-9}")
+    lines.append(
+        table_header_line(
+            [DATASET_HEADER[d] for d in DATASET_ORDER],
+            TABLE_TRAILING_HEADERS,
+        )
+    )
+    lines.append(r"\midrule")
+
+    for model in model_order:
+        row = [MODEL_HEADER[model]]
+        for dataset in DATASET_ORDER:
+            cell = table[(dataset, model)]
+            row.append(
+                fmt_winrate(
+                    cell["winrate"],
+                    cell["ci_low"],
+                    cell["ci_high"],
+                    cell["arch"],
+                )
+            )
+        ov = overall[model]
+        row.append(fmt_overall(ov["winrate"]))
+        elo = lmarena_elo[model]
+        row.append(fmt_elo(elo["mean"], elo["low"], elo["high"]))
+        lines.append(" & ".join(row) + r" \\")
+
+    lines.append(r"\bottomrule")
+    lines.append(r"\end{tabular}")
+    lines.append(r"}")
+    lines.append(r"\end{table}")
+
+    out = "\n".join(lines) + "\n"
+    print(out)
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(out)
+        print(f"\nwrote LaTeX fragment to {args.out}", file=__import__("sys").stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/phase_b_serial_runner.py
+++ b/scripts/phase_b_serial_runner.py
@@ -1,0 +1,379 @@
+"""Phase B serial runner: judge a frozen (dataset x model) cell matrix.
+
+Submitted as a single Slurm job by ``slurmpilot_scripts/launch_phase_b_serial.py``.
+For each cell:
+
+    1. Read pre-frozen CLI args from ``phase_b_cells.json`` (or the override
+       named by ``JUDGEARENA_PHASE_B_CELLS_FILENAME``) written by the launcher
+       at submit time on the login node, where the launcher module is
+       importable. Freezing args at submit time makes the run reproducible: a
+       launcher edit landed mid-run does not change what the in-flight job
+       executes.
+    2. Skip if a JSON-valid ``results-*.json`` for that cell already exists
+       in ``$CWD/results/<name>/`` (mirrors ``arena.py``'s skip semantics
+       plus a JSON-validity check so a half-written file doesn't masquerade
+       as done).
+    3. Otherwise spawn ``python -m judgearena.cli`` as a
+       subprocess. Subprocess isolation matters because (a) vLLM's CUDA
+       context lives in the subprocess so a CUDA fault doesn't poison the
+       next cell, (b) one cell's transient OpenRouter outage doesn't lose
+       the other 47 cells' work.
+
+Continues across failures and prints a per-cell FAIL/SKIP/OK summary at the
+end. Exits non-zero if any cell errored, so Slurm marks the job FAILED.
+
+Re-running is idempotent: cells with a valid results-*.json are skipped, so
+a partial run can resume cleanly from where it left off.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from judgearena.generate_and_evaluate import CliArgs
+
+DEFAULT_CELLS_FILENAME = "phase_b_cells.json"
+SUPPORTED_CLI_KEYS = frozenset(
+    (set(CliArgs.__dataclass_fields__.keys()) - {"task"}) | {"dataset"}
+)
+
+
+def _slugify(value: str) -> str:
+    """Mirror the ``"/" -> "_"`` substitution in ``generate_and_evaluate``'s
+    output-folder naming."""
+    return value.replace("/", "_")
+
+
+def _validate_results_file(path: Path) -> tuple[bool, str]:
+    """Two-part check that ``path`` represents a usable Phase B cell.
+
+    1. JSON parses (catches truncated writes, IO errors).
+    2. ``num_missing < num_battles`` (catches all-missing runs where every
+       judge call returned a non-parseable verdict — the subprocess exits
+       0 in this case but the file is operationally useless).
+
+    The schema is the flat dict written by ``generate_and_evaluate`` at
+    ``[generate_and_evaluate.py:556-569]``; we still defensively unwrap a
+    nested ``summary`` shape because previous runs / future refactors may
+    differ.
+    """
+    try:
+        with path.open() as fh:
+            payload = json.load(fh)
+    except (json.JSONDecodeError, OSError) as exc:
+        return False, f"json_invalid:{exc.__class__.__name__}"
+
+    summary = payload.get("summary") or payload
+    num_missing = summary.get("num_missing")
+    num_battles = summary.get("num_battles")
+    if num_battles is None:
+        num_battles = summary.get("n")
+    if num_missing is None or num_battles is None:
+        return False, "missing_num_missing_or_num_battles"
+    if int(num_battles) <= 0:
+        return False, "num_battles_zero"
+    if int(num_missing) >= int(num_battles):
+        return (
+            False,
+            f"all_missing:num_missing={num_missing}/{num_battles}",
+        )
+    return True, ""
+
+
+def _find_valid_results_path(
+    *,
+    result_folder: Path,
+    dataset: str,
+    model_a: str,
+    judge_model: str,
+    swap_mode: str,
+) -> Path | None:
+    """Return the most recent valid ``results-*.json`` for this cell if any.
+
+    The folder name embeds ``baseline_plan.display_name`` which is resolved at
+    runtime (and varies for arena-hard's per-row baseline plans). We therefore
+    glob over the baseline slot rather than recomputing the resolution here.
+    The trailing ``*`` after ``swap_mode`` covers MT-Bench's ``-mtbench`` suffix
+    appended by ``_build_mt_bench_result_name`` ([mt_bench_utils.py:176-182]);
+    without it MT-Bench cells were misclassified as FAIL even when results were
+    written correctly.
+    Picks the newest mtime when multiple folders match (e.g. baseline string
+    changed between runs) so re-validation after a re-judge sees the fresh
+    output, not a stale one.
+    """
+    pattern = f"{dataset}-{_slugify(model_a)}-*-{_slugify(judge_model)}-{swap_mode}*"
+    candidates: list[Path] = []
+    for cell_folder in result_folder.glob(pattern):
+        candidates.extend(cell_folder.glob("results-*.json"))
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    for results_path in candidates:
+        is_valid, reason = _validate_results_file(results_path)
+        if is_valid:
+            return results_path
+        print(
+            f"  [warn] {results_path} exists but failed validity check "
+            f"({reason}); ignoring for skip-detection.",
+            flush=True,
+        )
+    return None
+
+
+def _args_to_argv(args: dict[str, object]) -> list[str]:
+    """Convert ``build_eval_args`` output to argv flags accepted by
+    ``judgearena.cli``.
+
+    Most booleans use the ``--flag=true/false`` form so they go through
+    ``parse_optional_bool`` inside the shared CLI argument helpers. The top-level
+    ``judgearena.cli`` parser handles ``--use_tqdm`` specially as a plain
+    ``store_true`` flag, so emit it only when truthy.
+
+    Frozen cells can include metadata used only for reporting. Drop anything
+    that is not a real CLI flag so the subprocess argv stays parseable.
+    """
+    argv: list[str] = []
+    for key, value in args.items():
+        if key not in SUPPORTED_CLI_KEYS:
+            continue
+        if value is None:
+            continue
+        if key == "dataset":
+            argv.append(f"--task={value}")
+            continue
+        if key == "use_tqdm":
+            if value:
+                argv.append("--use_tqdm")
+            continue
+        if isinstance(value, bool):
+            argv.append(f"--{key}={'true' if value else 'false'}")
+        else:
+            argv.append(f"--{key}={value}")
+    return argv
+
+
+@dataclass
+class CellOutcome:
+    dataset: str
+    model_a: str
+    status: str
+    elapsed_seconds: float
+    note: str = ""
+
+
+def _run_cell(
+    *,
+    dataset: str,
+    model_a: str,
+    judge_model: str,
+    swap_mode: str,
+    args: dict[str, object],
+    result_folder: Path,
+) -> CellOutcome:
+    started_at = time.time()
+    existing = _find_valid_results_path(
+        result_folder=result_folder,
+        dataset=dataset,
+        model_a=model_a,
+        judge_model=judge_model,
+        swap_mode=swap_mode,
+    )
+    if existing is not None:
+        return CellOutcome(
+            dataset=dataset,
+            model_a=model_a,
+            status="SKIP",
+            elapsed_seconds=time.time() - started_at,
+            note=f"reusing {existing.relative_to(result_folder)}",
+        )
+
+    cell_args = dict(args)
+    cell_args["result_folder"] = str(result_folder)
+    cmd = [
+        sys.executable,
+        "-u",
+        "-m",
+        "judgearena.cli",
+        *_args_to_argv(cell_args),
+    ]
+    print(f"  $ {' '.join(cmd)}", flush=True)
+    proc = subprocess.run(cmd, check=False)
+    elapsed = time.time() - started_at
+    if proc.returncode != 0:
+        return CellOutcome(
+            dataset=dataset,
+            model_a=model_a,
+            status="FAIL",
+            elapsed_seconds=elapsed,
+            note=f"exit_code={proc.returncode}",
+        )
+
+    # Subprocess isolation means we can't observe ``num_missing`` inside the
+    # child; re-validate the on-disk artefact here so a child that exits 0
+    # while writing an all-missing file (e.g. every OpenRouter call returned
+    # a non-parseable verdict) is surfaced as FAIL rather than silently OK.
+    written = _find_valid_results_path(
+        result_folder=result_folder,
+        dataset=dataset,
+        model_a=model_a,
+        judge_model=judge_model,
+        swap_mode=swap_mode,
+    )
+    if written is None:
+        pattern = (
+            f"{dataset}-{_slugify(model_a)}-*-{_slugify(judge_model)}-{swap_mode}*"
+        )
+        any_file = next(
+            (p for d in result_folder.glob(pattern) for p in d.glob("results-*.json")),
+            None,
+        )
+        if any_file is None:
+            note = "exit_code=0 but no results-*.json was written"
+        else:
+            _, reason = _validate_results_file(any_file)
+            note = f"exit_code=0 but {any_file.name} failed validity ({reason})"
+        return CellOutcome(
+            dataset=dataset,
+            model_a=model_a,
+            status="FAIL",
+            elapsed_seconds=elapsed,
+            note=note,
+        )
+
+    return CellOutcome(
+        dataset=dataset,
+        model_a=model_a,
+        status="OK",
+        elapsed_seconds=elapsed,
+        note=f"wrote {written.relative_to(result_folder)}",
+    )
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds < 90:
+        return f"{seconds:.1f}s"
+    minutes, sec = divmod(int(seconds), 60)
+    if minutes < 90:
+        return f"{minutes}m{sec:02d}s"
+    hours, mins = divmod(minutes, 60)
+    return f"{hours}h{mins:02d}m"
+
+
+def _cells_path(script_dir: Path) -> Path:
+    filename = os.getenv(
+        "JUDGEARENA_PHASE_B_CELLS_FILENAME",
+        DEFAULT_CELLS_FILENAME,
+    )
+    path = Path(filename)
+    if not path.is_absolute():
+        path = script_dir / path
+    return path
+
+
+def _print_summary(outcomes: list[CellOutcome]) -> None:
+    print()
+    print("=" * 100)
+    print("PHASE B SERIAL RUNNER SUMMARY")
+    print("=" * 100)
+    by_status: dict[str, int] = {"OK": 0, "SKIP": 0, "FAIL": 0}
+    total_runtime = 0.0
+    for outcome in outcomes:
+        by_status[outcome.status] = by_status.get(outcome.status, 0) + 1
+        total_runtime += outcome.elapsed_seconds
+        print(
+            f"  [{outcome.status:4}] {outcome.dataset:24} "
+            f"{outcome.model_a.replace('VLLM/', ''):45} "
+            f"{_format_duration(outcome.elapsed_seconds):>7}  {outcome.note}"
+        )
+    print("-" * 100)
+    print(
+        f"  total cells={len(outcomes)}  OK={by_status.get('OK', 0)}  "
+        f"SKIP={by_status.get('SKIP', 0)}  FAIL={by_status.get('FAIL', 0)}  "
+        f"wallclock={_format_duration(total_runtime)}"
+    )
+
+
+def _load_cells(script_dir: Path) -> list[dict[str, object]]:
+    cells_path = _cells_path(script_dir)
+    if not cells_path.exists():
+        raise SystemExit(
+            f"{cells_path.name} not found at {cells_path}; the launcher "
+            "should have written it next to this runner before submitting."
+        )
+    with cells_path.open() as fh:
+        cells = json.load(fh)
+    if not isinstance(cells, list) or not cells:
+        raise SystemExit(f"{cells_path.name} at {cells_path} is empty or malformed.")
+    return cells
+
+
+def main() -> int:
+    script_dir = Path(__file__).resolve().parent
+    cells = _load_cells(script_dir)
+    cells_path = _cells_path(script_dir)
+    cwd = Path.cwd()
+    result_folder = cwd / "results"
+    result_folder.mkdir(parents=True, exist_ok=True)
+
+    print("PHASE B SERIAL RUNNER (Gemma-4-31B-IT judge)", flush=True)
+    print(f"  cwd={cwd}", flush=True)
+    print(f"  cells_path={cells_path}", flush=True)
+    print(f"  result_folder={result_folder}", flush=True)
+    print(f"  total cells: {len(cells)}", flush=True)
+
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        print(
+            "[fail] OPENROUTER_API_KEY missing from environment; aborting "
+            "before any cell runs.",
+            flush=True,
+        )
+        return 2
+    if os.environ.get("JUDGEARENA_IGNORE_CACHE", "1") == "1":
+        print(
+            "[fail] JUDGEARENA_IGNORE_CACHE=1; Phase B requires cache reuse.",
+            flush=True,
+        )
+        return 2
+    if os.environ.get("JUDGEARENA_SKIP_JUDGING", "0") == "1":
+        print(
+            "[fail] JUDGEARENA_SKIP_JUDGING=1; Phase B must run the judge.", flush=True
+        )
+        return 2
+
+    outcomes: list[CellOutcome] = []
+    for idx, cell in enumerate(cells, start=1):
+        dataset = str(cell["dataset"])
+        model_a = str(cell["model_A"])
+        judge_model = str(cell["judge_model"])
+        swap_mode = str(cell["swap_mode"])
+        args = cell  # build_eval_args output, already includes everything needed
+        print()
+        print(
+            f"[cell {idx}/{len(cells)}] dataset={dataset} model={model_a}",
+            flush=True,
+        )
+        outcome = _run_cell(
+            dataset=dataset,
+            model_a=model_a,
+            judge_model=judge_model,
+            swap_mode=swap_mode,
+            args=args,
+            result_folder=result_folder,
+        )
+        print(
+            f"  -> {outcome.status} ({_format_duration(outcome.elapsed_seconds)})"
+            f"{' ' + outcome.note if outcome.note else ''}",
+            flush=True,
+        )
+        outcomes.append(outcome)
+
+    _print_summary(outcomes)
+    return 1 if any(o.status == "FAIL" for o in outcomes) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/slurmpilot_scripts/launch_generation_and_evaluation.py
+++ b/slurmpilot_scripts/launch_generation_and_evaluation.py
@@ -73,7 +73,7 @@ for language in [
                 "dataset": f"{language}-contexts",
                 "model_A": baseline,
                 "model_B": model,
-                "judge_model": "VLLM/Qwen/Qwen2.5-32B-Instruct-GPTQ-Int8",
+                "judge_model": "VLLM/Qwen/Qwen3.5-27B-FP8",
                 "n_instructions": 100,
                 # "ignore_cache": None,
             }


### PR DESCRIPTION
## Summary
- Add scripts for LMArena Elo analysis, Phase B serial execution, and paper table generation.
- Update the experiment launcher default judge model for the paper benchmark setup.
- Keep paper artifact generation as the final consumer of the stacked runtime changes.

## Stack
- Base: `pr32-split/04-elo-sampling-gemini`.
- This is the final PR in the stack.

## Test plan
- `uv run ruff check scripts/analyze_lmarena_elo.py scripts/phase_b_marena_localized_prompt_table.py scripts/phase_b_paper_table.py scripts/phase_b_serial_runner.py slurmpilot_scripts/launch_generation_and_evaluation.py`
- `uv run python -m py_compile scripts/analyze_lmarena_elo.py scripts/phase_b_marena_localized_prompt_table.py scripts/phase_b_paper_table.py scripts/phase_b_serial_runner.py slurmpilot_scripts/launch_generation_and_evaluation.py`