### PR TITLE
Add inference metadata and thinking support

### DIFF
--- a/judgearena/cli.py
+++ b/judgearena/cli.py
@@ -75,6 +75,10 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Model B for generate+judge tasks (not yet supported for elo tasks).",
     )
     parser.add_argument(
+        "--model",
+        help="[DEPRECATED] Use `--model_A` instead.",
+    )
+    parser.add_argument(
         "--use_tqdm",
         action="store_true",
         help="[generate+judge] Use tqdm (not compatible with vLLM).",
@@ -152,6 +156,22 @@ def _resolve_task(args: argparse.Namespace) -> str:
     return f"{ELO_TASK_PREFIX}{lower_arena}"
 
 
+def _resolve_model_a(args: argparse.Namespace) -> str | None:
+    """Collapse the deprecated --model flag into --model_A."""
+    if args.model is not None and args.model_A is not None:
+        raise SystemExit(
+            "Specify exactly one of --model_A/--model; --model is a deprecated alias."
+        )
+    if args.model is not None:
+        warnings.warn(
+            "--model is deprecated; use --model_A instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return args.model
+    return args.model_A
+
+
 def _build_elo_args(
     args: argparse.Namespace, arena: str, model_a: str | None
 ) -> CliEloArgs:
@@ -178,6 +198,9 @@ def _build_elo_args(
         ignore_cache=args.ignore_cache,
         judge_prompt_preset=args.judge_prompt_preset,
         mt_bench_judge_mode=args.mt_bench_judge_mode,
+        battle_thinking_token_budget=args.battle_thinking_token_budget,
+        strip_thinking_before_judging=args.strip_thinking_before_judging,
+        skip_judging=args.skip_judging,
         truncate_all_input_chars=args.truncate_all_input_chars,
         truncate_judge_input_chars=args.truncate_judge_input_chars,
         max_out_tokens_models=args.max_out_tokens_models,
@@ -213,6 +236,9 @@ def _build_generate_and_evaluate_args(
         ignore_cache=args.ignore_cache,
         judge_prompt_preset=args.judge_prompt_preset,
         mt_bench_judge_mode=args.mt_bench_judge_mode,
+        battle_thinking_token_budget=args.battle_thinking_token_budget,
+        strip_thinking_before_judging=args.strip_thinking_before_judging,
+        skip_judging=args.skip_judging,
         truncate_all_input_chars=args.truncate_all_input_chars,
         truncate_judge_input_chars=args.truncate_judge_input_chars,
         max_out_tokens_models=args.max_out_tokens_models,
@@ -234,20 +260,17 @@ def cli(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     configure_logging(resolve_verbosity(args), log_file=args.log_file)
     task = _resolve_task(args)
+    model_a = _resolve_model_a(args)
     if task.startswith(ELO_TASK_PREFIX):
         if task not in ELO_TASK_TO_ARENA:
             raise SystemExit(
                 f"Unknown elo task {task!r}; expected one of {list(ELO_TASK_TO_ARENA)}."
             )
-        elo_args = _build_elo_args(
-            args, arena=ELO_TASK_TO_ARENA[task], model_a=args.model_A
-        )
+        elo_args = _build_elo_args(args, arena=ELO_TASK_TO_ARENA[task], model_a=model_a)
         logger.debug("Running with CLI args: %s", elo_args.__dict__)
         main_elo(elo_args)
     else:
-        ge_args = _build_generate_and_evaluate_args(
-            args, task=task, model_a=args.model_A
-        )
+        ge_args = _build_generate_and_evaluate_args(args, task=task, model_a=model_a)
         logger.debug("Running with CLI args: %s", ge_args.__dict__)
         main_generate_and_evaluate(ge_args)
 

--- a/judgearena/cli_common.py
+++ b/judgearena/cli_common.py
@@ -28,6 +28,9 @@ class BaseCliArgs:
     ignore_cache: bool = False
     judge_prompt_preset: str = "default"
     mt_bench_judge_mode: str = "default"
+    battle_thinking_token_budget: int | None = None
+    strip_thinking_before_judging: bool = False
+    skip_judging: bool = False
     truncate_all_input_chars: int = 8192
     truncate_judge_input_chars: int | None = None
     max_out_tokens_models: int = 32768
@@ -54,6 +57,17 @@ class BaseCliArgs:
         )
 
 
+def parse_optional_bool(raw: str | None) -> bool:
+    if raw is None:
+        return True
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise argparse.ArgumentTypeError(f"Expected a boolean value, got '{raw}'.")
+
+
 def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     """Register the CLI flags shared by all judgearena entrypoints."""
     parser.add_argument(
@@ -75,7 +89,10 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--provide_explanation",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        type=parse_optional_bool,
         help=(
             "If specified, judge will provide explanation before making a "
             "judgement. Does not necessarily improve the accuracy of the judge "
@@ -96,7 +113,10 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--ignore_cache",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        type=parse_optional_bool,
         help="If specified, ignore cache of previous completions.",
     )
     parser.add_argument(
@@ -106,7 +126,8 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         default="default",
         help=(
             "Judge prompt preset to use. 'default' preserves the existing score-first "
-            "JudgeArena prompts, while 'skywork' enables a verdict-first preset."
+            "JudgeArena prompts, while 'skywork' enables an optional Skywork-style "
+            "verdict-first preset."
         ),
     )
     parser.add_argument(
@@ -119,6 +140,43 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
             "--judge_prompt_preset like the other benchmarks, while "
             "'fastchat_original' preserves the original FastChat-style "
             "prompting and [[A]]/[[B]]/[[C]] verdict parsing."
+        ),
+    )
+    parser.add_argument(
+        "--battle_thinking_token_budget",
+        type=int,
+        required=False,
+        default=None,
+        help=(
+            "Optional reasoning-token sub-budget for battle-model generation. "
+            "This stays inside --max_out_tokens_models."
+        ),
+    )
+    parser.add_argument(
+        "--strip_thinking_before_judging",
+        nargs="?",
+        const=True,
+        default=False,
+        type=parse_optional_bool,
+        help=(
+            "If specified, strip visible reasoning traces from model completions "
+            "before sending them to the judge."
+        ),
+    )
+    parser.add_argument(
+        "--skip_judging",
+        nargs="?",
+        const=True,
+        default=False,
+        type=parse_optional_bool,
+        help=(
+            "If specified, generate battle-model completions and write a "
+            "generation-only summary (gen-results-<name>.json with limit_events) "
+            "but skip judge-model construction and the judging loop entirely. "
+            "Useful for decoupling expensive paid-judge calls from the cheap "
+            "local generation phase: run once with --skip_judging=True to "
+            "materialize the completion cache, inspect cap rates, then rerun "
+            "with --skip_judging=False to judge from cache."
         ),
     )
     parser.add_argument(
@@ -147,9 +205,9 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         required=False,
         default=None,
         help=(
-            "Character cap applied to judge-side inputs before evaluation. "
-            "When omitted, judge inputs are not character-truncated by this "
-            "CLI setting."
+            "Character cap applied to judge-side inputs (completions, "
+            "reference, instruction) before judge evaluation. When omitted, "
+            "judge inputs are not character-truncated by this CLI setting."
         ),
     )
     parser.add_argument(
@@ -191,7 +249,10 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         help=(
             "Optional total context window for the judge VLLM instance. When "
-            "omitted, no judge max_model_len override is passed."
+            "omitted, no judge max_model_len override is passed. Set higher "
+            "than the battle model_len when the judge needs to see longer "
+            "prompts (e.g. long completions from both A and B) than the "
+            "battle generator can fit."
         ),
     )
     parser.add_argument(
@@ -223,7 +284,10 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         default="{}",
         help=(
             "Optional JSON dict of engine-specific kwargs that override "
-            "--engine_kwargs only for the judge model."
+            "``--engine_kwargs`` only for the judge model. Useful when the "
+            "judge needs a different tensor-parallel or quantization config "
+            "than the battle models, e.g. a 70B judge on TP=2 while the "
+            "battle models run on TP=1 to dodge compile-time deadlocks."
         ),
     )
     parser.add_argument(

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -3,6 +3,7 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -22,13 +23,23 @@ from judgearena.judge_prompt_presets import (
 from judgearena.log import get_logger
 from judgearena.repro import _to_jsonable, write_run_metadata
 from judgearena.utils import (
+    LimitEventTracker,
     compute_pref_summary,
     data_root,
     do_inference,
     download_hf,
     read_df,
-    truncate,
+    strip_thinking_tags,
+    strip_thinking_tags_with_metadata,
+    truncate_with_metadata,
 )
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
+
+_PREFLIGHT_MAX_ITERATIONS = 3
+_PREFLIGHT_RESERVED_TOKENS = 256
+_PREFLIGHT_MIN_COMPLETION_CHARS = 512
 
 logger = get_logger(__name__)
 
@@ -45,6 +56,7 @@ class PairScore:
         )
 
     def parse_model_raw(self, judge_completion: str) -> float | None:
+        judge_completion = strip_thinking_tags(judge_completion)
         if self.parser_mode == "verdict":
             return self._parse_bracketed_verdict(judge_completion)
         if self.parser_mode == "score":
@@ -117,6 +129,7 @@ def evaluate_completions(
     truncate_input_chars: int | None = 8192,
     provide_explanation: bool = False,
     prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
+    strip_thinking_before_judging: bool = False,
 ):
     """
     :param dataset:
@@ -142,8 +155,9 @@ def evaluate_completions(
         dataset=dataset,
     ).loc[:, "instruction"]
 
-    # A bit ugly, only loads if local path exist as we do not have a local path of completion for cases such as
-    # m-arena-hard.
+    # Only loads if the per-dataset local path exists; some datasets (e.g.
+    # language slices of m-arena-hard for which no baseline has been written
+    # yet) may not ship a local completions file.
     dataset_output_path = local_path_tables / "model_outputs" / f"{dataset}.csv.zip"
     if dataset_output_path.exists():
         df_outputs = read_df(dataset_output_path)
@@ -184,6 +198,7 @@ def evaluate_completions(
         from langchain_together.llms import Together
 
         judge_chat_model = Together(model="meta-llama/Llama-3.3-70B-Instruct-Turbo")
+    limit_event_tracker = LimitEventTracker()
 
     unique_string = dataset + "-" + datetime.now().strftime("%Y%m%d_%H%M%S")
     output_folder = data_root / "judge-evals" / unique_string
@@ -199,12 +214,15 @@ def evaluate_completions(
         instructions=instructions.tolist(),
         completions_A=completions_A.loc[instructions.index].tolist(),
         completions_B=completions_B.loc[instructions.index].tolist(),
+        case_ids=instructions.index.tolist(),
         system_prompt=resolved_prompt.system_prompt,
         user_prompt_template=resolved_prompt.user_prompt_template,
         prompt_preset=resolved_prompt.preset_name,
         use_tqdm=use_tqdm,
         truncate_input_chars=truncate_input_chars,
         provide_explanation=provide_explanation,
+        strip_thinking_before_judging=strip_thinking_before_judging,
+        limit_event_tracker=limit_event_tracker,
     )
 
     # Pairwise judge results
@@ -218,6 +236,7 @@ def evaluate_completions(
     results = {
         **compute_pref_summary(prefs),
         "judge_prompt_preset": resolved_prompt.preset_name,
+        "limit_events": limit_event_tracker.build_summary(),
     }
     pd.DataFrame(annotations).to_csv(output_folder / "annotations.csv", index=False)
 
@@ -235,6 +254,7 @@ def evaluate_completions(
         "truncate_input_chars": truncate_input_chars,
         "provide_explanation": provide_explanation,
         "judge_prompt_preset": resolved_prompt.preset_name,
+        "strip_thinking_before_judging": strip_thinking_before_judging,
     }
 
     try:
@@ -264,7 +284,12 @@ class JudgeAnnotation:
     completion_B: str  # completion of the second model
     judge_completion: str  # output of the judge
     judge_input: str | None = None  # input that was passed to the judge
-    prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET
+    completion_A_for_judge: str | None = None
+    completion_B_for_judge: str | None = None
+    completion_A_reasoning_stripped: bool = False
+    completion_B_reasoning_stripped: bool = False
+    completion_A_truncated_for_judge: bool = False
+    completion_B_truncated_for_judge: bool = False
 
 
 def annotate_battles(
@@ -272,12 +297,18 @@ def annotate_battles(
     instructions: list[str],
     completions_A: list[str],
     completions_B: list[str],
+    case_ids: list[object] | None = None,
     system_prompt: str | None = None,
     user_prompt_template: str = None,
     truncate_input_chars: int | None = 8192,
     use_tqdm: bool = False,
     provide_explanation: bool = False,
     prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
+    strip_thinking_before_judging: bool = False,
+    limit_event_tracker: LimitEventTracker | None = None,
+    judge_tokenizer: "PreTrainedTokenizerBase | None" = None,
+    max_judge_model_len: int | None = None,
+    max_out_tokens_judge: int | None = None,
 ) -> list[JudgeAnnotation]:
     """
     Directly evaluate from list of instructions and completions
@@ -305,10 +336,23 @@ def annotate_battles(
     :param user_prompt_template:
     :param truncate_input_chars: Max characters to truncate completions before sending to judge.
     :param use_tqdm:
+    :param judge_tokenizer: Optional HF tokenizer matching the judge model; when
+        supplied together with ``max_judge_model_len`` triggers a preflight
+        tokenize-and-retry pass that shrinks per-completion character caps until
+        the rendered prompt fits the judge context window. Converts the hard
+        ``VLLMValidationError`` class into a soft ``judge_input_token_truncation``
+        limit event.
+    :param max_judge_model_len: Judge-side ``max_model_len``; required for the
+        preflight pass to be active.
+    :param max_out_tokens_judge: Judge-side output budget subtracted from
+        ``max_judge_model_len`` to derive the per-request prompt budget.
     :return:
     """
     # alternatively pass list of tuples
     assert len(instructions) == len(completions_A) == len(completions_B)
+    if case_ids is None:
+        case_ids = [None] * len(instructions)
+    assert len(case_ids) == len(instructions)
 
     resolved_prompt = resolve_judge_prompts(
         provide_explanation=provide_explanation,
@@ -316,25 +360,107 @@ def annotate_battles(
         system_prompt=system_prompt,
         user_prompt_template=user_prompt_template,
     )
-
     message_templates: list[tuple[str, str]] = []
     if resolved_prompt.system_prompt is not None:
         message_templates.append(("system", resolved_prompt.system_prompt))
     message_templates.append(("user", resolved_prompt.user_prompt_template))
-    prompt_template = ChatPromptTemplate.from_messages(message_templates)
 
-    inputs = prompt_template.batch(
-        [
+    prompt_template = ChatPromptTemplate.from_messages(message_templates)
+    truncated_completion_count = 0
+    input_payloads = []
+    annotation_input_metadata: list[dict[str, object]] = []
+    for case_id, user_prompt, completion_A, completion_B in zip(
+        case_ids, instructions, completions_A, completions_B, strict=True
+    ):
+        raw_completion_A = completion_A if isinstance(completion_A, str) else ""
+        raw_completion_B = completion_B if isinstance(completion_B, str) else ""
+        completion_A_for_judge = raw_completion_A
+        completion_B_for_judge = raw_completion_B
+        stripped_A = False
+        stripped_B = False
+        if strip_thinking_before_judging:
+            completion_A_for_judge, stripped_A = strip_thinking_tags_with_metadata(
+                completion_A_for_judge
+            )
+            completion_B_for_judge, stripped_B = strip_thinking_tags_with_metadata(
+                completion_B_for_judge
+            )
+            if stripped_A and limit_event_tracker is not None:
+                limit_event_tracker.record(
+                    "thinking_trace_stripped_before_judging",
+                    stage="judge_input",
+                    field="completion_A",
+                    case_id=case_id,
+                    original_length=len(raw_completion_A),
+                    final_length=len(completion_A_for_judge),
+                )
+            if stripped_B and limit_event_tracker is not None:
+                limit_event_tracker.record(
+                    "thinking_trace_stripped_before_judging",
+                    stage="judge_input",
+                    field="completion_B",
+                    case_id=case_id,
+                    original_length=len(raw_completion_B),
+                    final_length=len(completion_B_for_judge),
+                )
+        truncated_completion_A, truncated_A = truncate_with_metadata(
+            completion_A_for_judge,
+            max_len=truncate_input_chars,
+            tracker=limit_event_tracker,
+            kind="judge_input_char_truncation",
+            stage="judge_input",
+            field="completion_A",
+            case_id=case_id,
+        )
+        truncated_completion_B, truncated_B = truncate_with_metadata(
+            completion_B_for_judge,
+            max_len=truncate_input_chars,
+            tracker=limit_event_tracker,
+            kind="judge_input_char_truncation",
+            stage="judge_input",
+            field="completion_B",
+            case_id=case_id,
+        )
+        truncated_completion_count += int(truncated_A)
+        truncated_completion_count += int(truncated_B)
+        input_payloads.append(
             {
                 "user_prompt": user_prompt,
-                "completion_A": truncate(completion_A, max_len=truncate_input_chars),
-                "completion_B": truncate(completion_B, max_len=truncate_input_chars),
+                "completion_A": truncated_completion_A,
+                "completion_B": truncated_completion_B,
             }
-            for user_prompt, completion_A, completion_B in zip(
-                instructions, completions_A, completions_B, strict=True
-            )
-        ]
-    )
+        )
+        annotation_input_metadata.append(
+            {
+                "completion_A_for_judge": truncated_completion_A,
+                "completion_B_for_judge": truncated_completion_B,
+                "completion_A_reasoning_stripped": stripped_A,
+                "completion_B_reasoning_stripped": stripped_B,
+                "completion_A_truncated_for_judge": truncated_A,
+                "completion_B_truncated_for_judge": truncated_B,
+            }
+        )
+    if truncated_completion_count:
+        logger.warning(
+            "Warning: truncated "
+            f"{truncated_completion_count} judge inputs to "
+            f"{truncate_input_chars} characters before evaluation."
+        )
+    inputs = prompt_template.batch(input_payloads)
+
+    if judge_tokenizer is not None and max_judge_model_len:
+        inputs = _preflight_shrink_to_judge_budget(
+            prompt_template=prompt_template,
+            inputs=inputs,
+            input_payloads=input_payloads,
+            annotation_input_metadata=annotation_input_metadata,
+            case_ids=case_ids,
+            judge_tokenizer=judge_tokenizer,
+            max_judge_model_len=max_judge_model_len,
+            max_out_tokens_judge=max_out_tokens_judge,
+            limit_event_tracker=limit_event_tracker,
+        )
+
     logger.info("Start LLM judge annotation (%d annotations).", len(inputs))
     judge_completions = do_inference(
         chat_model=judge_chat_model,
@@ -343,12 +469,20 @@ def annotate_battles(
     )
 
     annotations = []
-    for judge_input, judge_completion, instruction, completion_A, completion_B in zip(
+    for (
+        judge_input,
+        judge_completion,
+        instruction,
+        completion_A,
+        completion_B,
+        annotation_input_metadata_row,
+    ) in zip(
         inputs,
         judge_completions,
         instructions,
         completions_A,
         completions_B,
+        annotation_input_metadata,
         strict=True,
     ):
         annotations.append(
@@ -358,7 +492,7 @@ def annotate_battles(
                 instruction=instruction,
                 completion_A=completion_A,
                 completion_B=completion_B,
-                prompt_preset=resolved_prompt.preset_name,
+                **annotation_input_metadata_row,
             )
         )
     return annotations
@@ -369,13 +503,20 @@ def judge_and_parse_prefs(
     instructions: list[str],
     completions_A: list[str],
     completions_B: list[str],
+    case_ids: list[object] | None = None,
     swap_mode: str = "fixed",
     provide_explanation: bool = False,
+    prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
+    parser_mode: str = "score",
+    strip_thinking_before_judging: bool = False,
     system_prompt: str | None = None,
     user_prompt_template: str | None = None,
-    prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
     truncate_input_chars: int = 8192,
     use_tqdm: bool = False,
+    limit_event_tracker: LimitEventTracker | None = None,
+    judge_tokenizer: "PreTrainedTokenizerBase | None" = None,
+    max_judge_model_len: int | None = None,
+    max_out_tokens_judge: int | None = None,
 ) -> tuple[list[JudgeAnnotation], list[JudgeAnnotation] | None, pd.Series]:
     """Run judge annotation and parse preferences, handling swap_mode='both'.
 
@@ -394,24 +535,23 @@ def judge_and_parse_prefs(
             judge_chat_model,
         )
 
-    resolved_prompt = resolve_judge_prompts(
-        provide_explanation=provide_explanation,
-        prompt_preset=prompt_preset,
-        system_prompt=system_prompt,
-        user_prompt_template=user_prompt_template,
-    )
-
     annotations = annotate_battles(
         judge_chat_model=judge_chat_model,
         instructions=instructions,
         completions_A=completions_A,
         completions_B=completions_B,
+        case_ids=case_ids,
         provide_explanation=provide_explanation,
-        system_prompt=resolved_prompt.system_prompt,
-        user_prompt_template=resolved_prompt.user_prompt_template,
-        prompt_preset=resolved_prompt.preset_name,
+        prompt_preset=prompt_preset,
+        strip_thinking_before_judging=strip_thinking_before_judging,
+        system_prompt=system_prompt,
+        user_prompt_template=user_prompt_template,
         truncate_input_chars=truncate_input_chars,
         use_tqdm=use_tqdm,
+        limit_event_tracker=limit_event_tracker,
+        judge_tokenizer=judge_tokenizer,
+        max_judge_model_len=max_judge_model_len,
+        max_out_tokens_judge=max_out_tokens_judge,
     )
 
     annotations_reversed = None
@@ -421,18 +561,24 @@ def judge_and_parse_prefs(
             instructions=instructions,
             completions_A=completions_B,
             completions_B=completions_A,
+            case_ids=case_ids,
             provide_explanation=provide_explanation,
-            system_prompt=resolved_prompt.system_prompt,
-            user_prompt_template=resolved_prompt.user_prompt_template,
-            prompt_preset=resolved_prompt.preset_name,
+            prompt_preset=prompt_preset,
+            strip_thinking_before_judging=strip_thinking_before_judging,
+            system_prompt=system_prompt,
+            user_prompt_template=user_prompt_template,
             truncate_input_chars=truncate_input_chars,
             use_tqdm=use_tqdm,
+            limit_event_tracker=limit_event_tracker,
+            judge_tokenizer=judge_tokenizer,
+            max_judge_model_len=max_judge_model_len,
+            max_out_tokens_judge=max_out_tokens_judge,
         )
 
     def _none_to_nan(x):
         return float("nan") if x is None else x
 
-    score_parser = PairScore(parser_mode=resolved_prompt.parser_mode)
+    score_parser = PairScore(parser_mode=parser_mode)
     prefs = pd.Series(
         [score_parser.parse_model_raw(a.judge_completion) for a in annotations]
     )
@@ -448,3 +594,161 @@ def judge_and_parse_prefs(
         prefs = pd.concat([prefs, (1 - prefs_reversed)]).reset_index(drop=True)
 
     return annotations, annotations_reversed, prefs
+
+
+_LC_ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
+
+
+def _count_chat_tokens(prompt_value: Any, tokenizer: Any) -> int:
+    """Count tokens the way vLLM's ``llm.chat()`` tokenizes after applying the
+    tokenizer's chat template. Falls back to raw-string encoding for tokenizers
+    without a chat template or if template application raises."""
+    if hasattr(prompt_value, "to_messages"):
+        messages = [
+            {
+                "role": _LC_ROLE_MAP.get(msg.type, msg.type),
+                "content": msg.content,
+            }
+            for msg in prompt_value.to_messages()
+        ]
+        try:
+            return len(tokenizer.apply_chat_template(messages, tokenize=True))
+        except Exception:
+            pass
+    if hasattr(prompt_value, "to_string"):
+        text = prompt_value.to_string()
+    else:
+        text = str(prompt_value)
+    return len(tokenizer.encode(text))
+
+
+def _find_token_overflows(
+    inputs: list[Any], tokenizer: Any, safe_budget: int
+) -> list[tuple[int, int]]:
+    """Return ``(index, token_count)`` for inputs whose tokenized length exceeds
+    ``safe_budget``."""
+    overflows: list[tuple[int, int]] = []
+    for idx, item in enumerate(inputs):
+        token_count = _count_chat_tokens(item, tokenizer)
+        if token_count > safe_budget:
+            overflows.append((idx, token_count))
+    return overflows
+
+
+def _chars_per_token(text: str, tokenizer: Any) -> float:
+    """Return a conservative char-to-token ratio for ``text``, floored at 1.0.
+
+    Short/empty inputs yield a low ratio, which under-truncates rather than
+    overflowing - the safe direction for the preflight shrink loop.
+    """
+    text = text if isinstance(text, str) else ""
+    if not text:
+        return 1.0
+    token_count = max(1, len(tokenizer.encode(text)))
+    return max(1.0, len(text) / token_count)
+
+
+def _render_with_empty_completions(
+    prompt_template: ChatPromptTemplate, user_prompt: str
+) -> Any:
+    """Render the prompt template with empty completions so the fixed template
+    + user-prompt overhead can be measured per case. ``ChatPromptTemplate``
+    uses ``str.format()`` on each message, so empty strings substitute cleanly
+    for both completion slots."""
+    return prompt_template.invoke(
+        {
+            "user_prompt": user_prompt,
+            "completion_A": "",
+            "completion_B": "",
+        }
+    )
+
+
+def _preflight_shrink_to_judge_budget(
+    *,
+    prompt_template: ChatPromptTemplate,
+    inputs: list[Any],
+    input_payloads: list[dict[str, str]],
+    annotation_input_metadata: list[dict[str, object]],
+    case_ids: list[object],
+    judge_tokenizer: Any,
+    max_judge_model_len: int,
+    max_out_tokens_judge: int | None,
+    limit_event_tracker: LimitEventTracker | None,
+) -> list[Any]:
+    """Bounded shrink-and-re-render loop that converts judge-context overflows
+    into soft ``judge_input_token_truncation`` limit events instead of a hard
+    ``VLLMValidationError`` at request time.
+
+    The per-completion budget subtracts the case-specific template + user-prompt
+    overhead so that one iteration typically suffices; the 3-iteration bound is
+    a genuine safety net for the rare pathological case where the char-to-token
+    ratio shifts after truncation (e.g. dropping multi-byte glyphs).
+    """
+    safe_budget = (
+        max_judge_model_len - (max_out_tokens_judge or 0) - _PREFLIGHT_RESERVED_TOKENS
+    )
+    for _ in range(_PREFLIGHT_MAX_ITERATIONS):
+        overflows = _find_token_overflows(inputs, judge_tokenizer, safe_budget)
+        if not overflows:
+            return inputs
+        for idx, _token_count in overflows:
+            payload = input_payloads[idx]
+            fixed_tokens = _count_chat_tokens(
+                _render_with_empty_completions(prompt_template, payload["user_prompt"]),
+                judge_tokenizer,
+            )
+            per_completion_budget = max(256, (safe_budget - fixed_tokens) // 2)
+            ratio_A = _chars_per_token(payload["completion_A"], judge_tokenizer)
+            ratio_B = _chars_per_token(payload["completion_B"], judge_tokenizer)
+            new_cap_A = max(
+                _PREFLIGHT_MIN_COMPLETION_CHARS,
+                int(per_completion_budget * ratio_A * 0.9),
+            )
+            new_cap_B = max(
+                _PREFLIGHT_MIN_COMPLETION_CHARS,
+                int(per_completion_budget * ratio_B * 0.9),
+            )
+            payload["completion_A"], shrunk_A = truncate_with_metadata(
+                payload["completion_A"],
+                max_len=new_cap_A,
+                tracker=limit_event_tracker,
+                kind="judge_input_token_truncation",
+                stage="judge_input",
+                field="completion_A",
+                case_id=case_ids[idx],
+            )
+            payload["completion_B"], shrunk_B = truncate_with_metadata(
+                payload["completion_B"],
+                max_len=new_cap_B,
+                tracker=limit_event_tracker,
+                kind="judge_input_token_truncation",
+                stage="judge_input",
+                field="completion_B",
+                case_id=case_ids[idx],
+            )
+            metadata_row = annotation_input_metadata[idx]
+            metadata_row["completion_A_for_judge"] = payload["completion_A"]
+            metadata_row["completion_B_for_judge"] = payload["completion_B"]
+            if shrunk_A:
+                metadata_row["completion_A_truncated_for_judge"] = True
+            if shrunk_B:
+                metadata_row["completion_B_truncated_for_judge"] = True
+        inputs = prompt_template.batch(input_payloads)
+
+    final_overflows = _find_token_overflows(inputs, judge_tokenizer, safe_budget)
+    for idx, token_count in final_overflows:
+        if limit_event_tracker is not None:
+            limit_event_tracker.record(
+                "judge_input_token_truncation_failed",
+                stage="judge_input",
+                case_id=case_ids[idx],
+                original_length=token_count,
+                final_length=safe_budget,
+                note=(
+                    f"{_PREFLIGHT_MAX_ITERATIONS} shrink iterations did not "
+                    f"bring tokens under {safe_budget}; falling through to "
+                    "vLLM validation."
+                ),
+            )
+    return inputs

--- a/judgearena/generate.py
+++ b/judgearena/generate.py
@@ -1,11 +1,52 @@
+from typing import Any
+
 import pandas as pd
 from langchain_core.prompts import ChatPromptTemplate
 
 from judgearena.utils import (
+    LimitEventTracker,
     do_inference,
     make_model,
-    truncate,
+    strip_thinking_tags_with_metadata,
+    truncate_with_metadata,
 )
+
+
+def _record_generation_output_limit_events(
+    *,
+    metadata: list[dict[str, Any]],
+    case_ids: list[object],
+    field: str,
+    model_spec: str,
+    limit_event_tracker: LimitEventTracker | None,
+) -> list[bool]:
+    hit_token_limit: list[bool] = []
+    for case_id, metadata_row in zip(case_ids, metadata, strict=True):
+        row = metadata_row or {}
+        finish_reason = str(row.get("finish_reason") or "").lower()
+        reached_limit = finish_reason == "length"
+        hit_token_limit.append(reached_limit)
+        if limit_event_tracker is None:
+            continue
+        if reached_limit:
+            limit_event_tracker.record(
+                "generation_output_token_limit",
+                stage="generation_output",
+                field=field,
+                case_id=case_id,
+                model_spec=model_spec,
+                note=finish_reason,
+            )
+        if row.get("thinking_budget_exhausted"):
+            limit_event_tracker.record(
+                "generation_thinking_token_budget",
+                stage="generation_output",
+                field=field,
+                case_id=case_id,
+                model_spec=model_spec,
+                note=str(row.get("thinking_token_budget")),
+            )
+    return hit_token_limit
 
 
 def generate_instructions(
@@ -15,9 +56,17 @@ def generate_instructions(
     max_tokens: int | None = 32768,
     use_tqdm: bool = True,
     system_prompt: str | None = None,
+    limit_event_tracker: LimitEventTracker | None = None,
     **engine_kwargs,
 ) -> pd.DataFrame:
-    chat_model = make_model(model, max_tokens=max_tokens, **engine_kwargs)
+    chat_model = make_model(
+        model,
+        max_tokens=max_tokens,
+        limit_event_tracker=limit_event_tracker,
+        limit_event_stage="generation_model_init",
+        limit_event_model_spec=model,
+        **engine_kwargs,
+    )
 
     # TODO improve prompt to generate instructions
     if system_prompt is None:
@@ -28,24 +77,47 @@ def generate_instructions(
         [("system", system_prompt), ("user", "{user_prompt}")]
     )
 
-    inputs = prompt_template.batch(
-        [
-            {
-                "user_prompt": truncate(user_prompt, max_len=truncate_input_chars),
-            }
-            for user_prompt in instructions
-        ]
-    )
+    prompt_truncated: list[bool] = []
+    input_payloads = []
+    case_ids = instructions.index.tolist()
+    for case_id, user_prompt in zip(case_ids, instructions, strict=True):
+        truncated_user_prompt, was_truncated = truncate_with_metadata(
+            user_prompt,
+            max_len=truncate_input_chars,
+            tracker=limit_event_tracker,
+            kind="generation_input_char_truncation",
+            stage="generation_input",
+            field="user_prompt",
+            case_id=case_id,
+            model_spec=model,
+        )
+        prompt_truncated.append(was_truncated)
+        input_payloads.append({"user_prompt": truncated_user_prompt})
+    inputs = prompt_template.batch(input_payloads)
 
-    completions = do_inference(
+    completions, completion_metadata = do_inference(
         chat_model=chat_model,
         inputs=inputs,
         use_tqdm=use_tqdm,
+        return_metadata=True,
+    )
+    hit_token_limit = _record_generation_output_limit_events(
+        metadata=completion_metadata,
+        case_ids=case_ids,
+        field="completion",
+        model_spec=model,
+        limit_event_tracker=limit_event_tracker,
     )
     df_outputs = pd.DataFrame(
         data={
             "completion": completions,
-            "instruction_index": instructions.index.tolist(),
+            "instruction_index": case_ids,
+            "generation_prompt_truncated": prompt_truncated,
+            "generation_output_finish_reason": [
+                metadata_row.get("finish_reason")
+                for metadata_row in completion_metadata
+            ],
+            "generation_output_hit_token_limit": hit_token_limit,
         },
     )
     return df_outputs
@@ -69,8 +141,9 @@ def _infer_grouped_by_temperature(
     inputs: list,
     temperatures: list[float],
     use_tqdm: bool,
-) -> list[str]:
+) -> tuple[list[str], list[dict[str, Any]]]:
     outputs: list[str] = [""] * len(inputs)
+    outputs_metadata: list[dict[str, Any]] = [{} for _ in inputs]
     groups: dict[float, list[int]] = {}
     for idx, temp in enumerate(temperatures):
         groups.setdefault(float(temp), []).append(idx)
@@ -87,15 +160,17 @@ def _infer_grouped_by_temperature(
                 model_spec, max_tokens=max_tokens, temperature=temp, **model_kwargs
             )
 
-        group_outs = do_inference(
+        group_outs, group_metadata = do_inference(
             chat_model=group_model,
             inputs=group_inputs,
             use_tqdm=use_tqdm,
+            return_metadata=True,
         )
-        for i, out in zip(idxs, group_outs, strict=True):
+        for i, out, metadata_row in zip(idxs, group_outs, group_metadata, strict=True):
             outputs[i] = out
+            outputs_metadata[i] = metadata_row
 
-    return outputs
+    return outputs, outputs_metadata
 
 
 def generate_multiturn(
@@ -105,6 +180,8 @@ def generate_multiturn(
     max_tokens: int | None = 8192,
     use_tqdm: bool = True,
     temperature_config: dict[str, float] | None = None,
+    limit_event_tracker: LimitEventTracker | None = None,
+    strip_thinking_before_turn_2_prompt: bool = False,
     **model_kwargs,
 ) -> pd.DataFrame:
     """Generate two-turn completions for MT-Bench style questions."""
@@ -114,10 +191,23 @@ def generate_multiturn(
 
     if use_category_temperatures and local_provider:
         chat_model = make_model(
-            model, max_tokens=max_tokens, temperature=0.0, **model_kwargs
+            model,
+            max_tokens=max_tokens,
+            temperature=0.0,
+            limit_event_tracker=limit_event_tracker,
+            limit_event_stage="generation_model_init",
+            limit_event_model_spec=model,
+            **model_kwargs,
         )
     else:
-        chat_model = make_model(model, max_tokens=max_tokens, **model_kwargs)
+        chat_model = make_model(
+            model,
+            max_tokens=max_tokens,
+            limit_event_tracker=limit_event_tracker,
+            limit_event_stage="generation_model_init",
+            limit_event_model_spec=model,
+            **model_kwargs,
+        )
 
     system_prompt = "You are a helpful assistant."
     idxs = questions.index.tolist()
@@ -131,15 +221,25 @@ def generate_multiturn(
     turn1_template = ChatPromptTemplate.from_messages(
         [("system", system_prompt), ("user", "{user_prompt}")]
     )
-    turn1_inputs = turn1_template.batch(
-        [
-            {"user_prompt": truncate(row["turn_1"], max_len=truncate_input_chars)}
-            for _, row in questions.iterrows()
-        ]
-    )
+    turn1_prompt_truncated: list[bool] = []
+    turn1_payloads = []
+    for question_id, row in questions.iterrows():
+        truncated_turn_1, was_truncated = truncate_with_metadata(
+            row["turn_1"],
+            max_len=truncate_input_chars,
+            tracker=limit_event_tracker,
+            kind="generation_input_char_truncation",
+            stage="generation_input",
+            field="turn_1",
+            case_id=question_id,
+            model_spec=model,
+        )
+        turn1_prompt_truncated.append(was_truncated)
+        turn1_payloads.append({"user_prompt": truncated_turn_1})
+    turn1_inputs = turn1_template.batch(turn1_payloads)
 
     if use_category_temperatures:
-        completions_turn_1 = _infer_grouped_by_temperature(
+        completions_turn_1, turn1_metadata = _infer_grouped_by_temperature(
             model_spec=model,
             provider=provider,
             max_tokens=max_tokens,
@@ -150,17 +250,33 @@ def generate_multiturn(
             use_tqdm=use_tqdm,
         )
     else:
-        completions_turn_1 = do_inference(
+        completions_turn_1, turn1_metadata = do_inference(
             chat_model=chat_model,
             inputs=turn1_inputs,
             use_tqdm=use_tqdm,
+            return_metadata=True,
         )
+    turn1_hit_token_limit = _record_generation_output_limit_events(
+        metadata=turn1_metadata,
+        case_ids=idxs,
+        field="completion_turn_1",
+        model_spec=model,
+        limit_event_tracker=limit_event_tracker,
+    )
 
     turn2_inputs = []
-    for (_, row), t1_answer in zip(
+    turn2_turn1_truncated: list[bool] = []
+    turn2_answer_truncated: list[bool] = []
+    turn2_prompt_truncated: list[bool] = []
+    turn2_turn1_answer_thinking_stripped: list[bool] = []
+    for (question_id, row), t1_answer in zip(
         questions.iterrows(), completions_turn_1, strict=True
     ):
         if row["turn_2"] is None:
+            turn2_turn1_truncated.append(False)
+            turn2_answer_truncated.append(False)
+            turn2_prompt_truncated.append(False)
+            turn2_turn1_answer_thinking_stripped.append(False)
             turn2_inputs.append(
                 turn1_template.invoke({"user_prompt": "No follow-up question."})
             )
@@ -173,20 +289,66 @@ def generate_multiturn(
                     ("user", "{turn_2}"),
                 ]
             )
+            truncated_turn_1, turn1_was_truncated = truncate_with_metadata(
+                row["turn_1"],
+                max_len=truncate_input_chars,
+                tracker=limit_event_tracker,
+                kind="generation_input_char_truncation",
+                stage="generation_input",
+                field="turn_1_for_turn_2",
+                case_id=question_id,
+                model_spec=model,
+            )
+            # Strip <think>...</think> from the turn-1 answer before the
+            # character cap fires. Mirrors what the Qwen3 chat template does
+            # natively for historical assistant turns; applying it here
+            # ensures a 30K-char cap lands on the visible answer rather than
+            # deep inside a runaway reasoning block, which would silently
+            # destroy the </think> closer and force the whole thinking
+            # fragment into the turn-2 prompt.
+            t1_answer_str = str(t1_answer)
+            if strip_thinking_before_turn_2_prompt:
+                t1_answer_str, thinking_stripped = strip_thinking_tags_with_metadata(
+                    t1_answer_str
+                )
+            else:
+                thinking_stripped = False
+            turn2_turn1_answer_thinking_stripped.append(thinking_stripped)
+            truncated_turn_1_answer, answer_was_truncated = truncate_with_metadata(
+                t1_answer_str,
+                max_len=truncate_input_chars,
+                tracker=limit_event_tracker,
+                kind="generation_input_char_truncation",
+                stage="generation_input",
+                field="turn_1_answer",
+                case_id=question_id,
+                model_spec=model,
+            )
+            truncated_turn_2, turn2_was_truncated = truncate_with_metadata(
+                row["turn_2"],
+                max_len=truncate_input_chars,
+                tracker=limit_event_tracker,
+                kind="generation_input_char_truncation",
+                stage="generation_input",
+                field="turn_2",
+                case_id=question_id,
+                model_spec=model,
+            )
+            turn2_turn1_truncated.append(turn1_was_truncated)
+            turn2_answer_truncated.append(answer_was_truncated)
+            turn2_prompt_truncated.append(turn2_was_truncated)
             turn2_inputs.append(
                 multi_turn_template.invoke(
                     {
-                        "turn_1": truncate(row["turn_1"], max_len=truncate_input_chars),
-                        "turn_1_answer": truncate(
-                            str(t1_answer), max_len=truncate_input_chars
-                        ),
-                        "turn_2": truncate(row["turn_2"], max_len=truncate_input_chars),
+                        "turn_1": truncated_turn_1,
+                        "turn_1_answer": truncated_turn_1_answer,
+                        "turn_2": truncated_turn_2,
                     }
                 )
             )
 
     if use_category_temperatures:
-        completions_turn_2 = _infer_grouped_by_temperature(
+        completions_turn_2, turn2_metadata = _infer_grouped_by_temperature(
             model_spec=model,
             provider=provider,
             max_tokens=max_tokens,
@@ -197,17 +359,40 @@ def generate_multiturn(
             use_tqdm=use_tqdm,
         )
     else:
-        completions_turn_2 = do_inference(
+        completions_turn_2, turn2_metadata = do_inference(
             chat_model=chat_model,
             inputs=turn2_inputs,
             use_tqdm=use_tqdm,
+            return_metadata=True,
         )
+    turn2_hit_token_limit = _record_generation_output_limit_events(
+        metadata=turn2_metadata,
+        case_ids=idxs,
+        field="completion_turn_2",
+        model_spec=model,
+        limit_event_tracker=limit_event_tracker,
+    )
 
     return pd.DataFrame(
         data={
             "instruction_index": idxs,
             "completion_turn_1": completions_turn_1,
             "completion_turn_2": completions_turn_2,
+            "generation_turn_1_prompt_truncated": turn1_prompt_truncated,
+            "generation_turn_1_finish_reason": [
+                metadata_row.get("finish_reason") for metadata_row in turn1_metadata
+            ],
+            "generation_turn_1_hit_token_limit": turn1_hit_token_limit,
+            "generation_turn_2_turn_1_prompt_truncated": turn2_turn1_truncated,
+            "generation_turn_2_turn_1_answer_truncated": turn2_answer_truncated,
+            "generation_turn_2_turn_1_answer_thinking_stripped": (
+                turn2_turn1_answer_thinking_stripped
+            ),
+            "generation_turn_2_prompt_truncated": turn2_prompt_truncated,
+            "generation_turn_2_finish_reason": [
+                metadata_row.get("finish_reason") for metadata_row in turn2_metadata
+            ],
+            "generation_turn_2_hit_token_limit": turn2_hit_token_limit,
         },
     )
 
@@ -218,25 +403,60 @@ def generate_base(
     truncate_input_chars: int | None = 8192,
     max_tokens: int | None = 32768,
     use_tqdm: bool = False,
+    limit_event_tracker: LimitEventTracker | None = None,
     **engine_kwargs,
 ) -> pd.DataFrame:
-    model = make_model(model, max_tokens=max_tokens, **engine_kwargs)
-
-    inputs = [
-        truncate(instruction, max_len=truncate_input_chars)
-        for instruction in instructions
-    ]
-
-    completions = model.batch(
-        inputs=inputs,
+    model_spec = model
+    model = make_model(
+        model_spec,
         max_tokens=max_tokens,
+        limit_event_tracker=limit_event_tracker,
+        limit_event_stage="generation_model_init",
+        limit_event_model_spec=model_spec,
+        **engine_kwargs,
     )
-    completions = [x.content if hasattr(x, "content") else x for x in completions]
+
+    prompt_truncated: list[bool] = []
+    case_ids = instructions.index.tolist()
+    inputs = []
+    for case_id, instruction in zip(case_ids, instructions, strict=True):
+        truncated_instruction, was_truncated = truncate_with_metadata(
+            instruction,
+            max_len=truncate_input_chars,
+            tracker=limit_event_tracker,
+            kind="generation_input_char_truncation",
+            stage="generation_input",
+            field="instruction",
+            case_id=case_id,
+            model_spec=model_spec,
+        )
+        prompt_truncated.append(was_truncated)
+        inputs.append(truncated_instruction)
+
+    completions, completion_metadata = do_inference(
+        chat_model=model,
+        inputs=inputs,
+        use_tqdm=use_tqdm,
+        return_metadata=True,
+    )
+    hit_token_limit = _record_generation_output_limit_events(
+        metadata=completion_metadata,
+        case_ids=case_ids,
+        field="completion",
+        model_spec=model_spec,
+        limit_event_tracker=limit_event_tracker,
+    )
 
     df_outputs = pd.DataFrame(
         data={
             "completion": completions,
-            "instruction_index": instructions.index.tolist(),
+            "instruction_index": case_ids,
+            "generation_prompt_truncated": prompt_truncated,
+            "generation_output_finish_reason": [
+                metadata_row.get("finish_reason")
+                for metadata_row in completion_metadata
+            ],
+            "generation_output_hit_token_limit": hit_token_limit,
         },
     )
 

--- a/judgearena/generate_and_evaluate.py
+++ b/judgearena/generate_and_evaluate.py
@@ -3,16 +3,23 @@ This script generates completions for a given task (dataset) and model,
 and then evaluates them using a judge model.
 """
 
+import argparse
+import hashlib
 import json
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
-from functools import partial
 from pathlib import Path
 
 import pandas as pd
 
-from judgearena.cli_common import BaseCliArgs
+from judgearena.cli_common import (
+    BaseCliArgs,
+    add_common_arguments,
+    parse_engine_kwargs,
+    parse_optional_bool,
+    resolve_verbosity,
+)
 from judgearena.evaluate import judge_and_parse_prefs, resolve_judge_prompts
 from judgearena.generate import generate_base, generate_instructions
 from judgearena.instruction_dataset import load_instructions
@@ -26,6 +33,7 @@ from judgearena.instruction_dataset.m_arenahard import (
     split_m_arena_hard_dataset,
 )
 from judgearena.instruction_dataset.mt_bench import MT_BENCH_BASELINES
+from judgearena.judge_prompt_presets import DEFAULT_JUDGE_PROMPT_PRESET
 from judgearena.log import (
     attach_file_handler,
     get_logger,
@@ -34,10 +42,13 @@ from judgearena.log import (
 from judgearena.mt_bench.mt_bench_utils import run_mt_bench
 from judgearena.repro import _to_jsonable, write_run_metadata
 from judgearena.utils import (
+    LimitEventTracker,
+    build_default_judge_model_kwargs,
     cache_function_dataframe,
     compute_pref_summary,
     data_root,
     download_hf,
+    is_thinking_model,
     make_model,
     read_df,
 )
@@ -107,10 +118,85 @@ class CliArgs(BaseCliArgs):
     model_B: str | None = None
     use_tqdm: bool = False
 
+    @classmethod
+    def parse_args(cls):
+        parser = argparse.ArgumentParser(
+            prog="Generate completion and evaluate with a judge",
+        )
+        parser.add_argument(
+            "--dataset",
+            help="The dataset to use. For instance `alpaca-eval`, `arena-hard-v2.0`, "
+            "`arena-hard-v0.1`, `m-arena-hard-v0.1-EU`, `m-arena-hard-v2.0-uk` for "
+            "instruction tuning cases or `french-contexts`, `spanish-contexts` for "
+            "base models.",
+        )
+        parser.add_argument(
+            "--model_A",
+            required=True,
+            help="Name of the LLM to use for a generation, must be a valid choice for `generation_provider`",
+        )
+        parser.add_argument(
+            "--model_B",
+            default=None,
+            help=(
+                "Name of the baseline LLM for a generation. Optional for Arena-Hard "
+                "datasets (which ship a dataset-native default per category; see "
+                "`ARENA_HARD_BASELINES`) and MT-Bench (see `MT_BENCH_BASELINES`, "
+                "defaults to `gpt-4`). Required for every other dataset."
+            ),
+        )
+        parser.add_argument(
+            "--use_tqdm",
+            nargs="?",
+            const=True,
+            default=False,
+            type=parse_optional_bool,
+            help="If specified, use tqdm, does not work with all model providers, vLLM in particular.",
+        )
+        add_common_arguments(parser)
+        args = parser.parse_args()
+
+        return cls(
+            task=args.dataset,
+            model_A=args.model_A,
+            model_B=args.model_B,
+            use_tqdm=args.use_tqdm,
+            judge_model=args.judge_model,
+            n_instructions=args.n_instructions,
+            provide_explanation=args.provide_explanation,
+            swap_mode=args.swap_mode,
+            ignore_cache=args.ignore_cache,
+            judge_prompt_preset=args.judge_prompt_preset,
+            mt_bench_judge_mode=args.mt_bench_judge_mode,
+            battle_thinking_token_budget=args.battle_thinking_token_budget,
+            strip_thinking_before_judging=args.strip_thinking_before_judging,
+            skip_judging=args.skip_judging,
+            truncate_all_input_chars=args.truncate_all_input_chars,
+            truncate_judge_input_chars=args.truncate_judge_input_chars,
+            max_out_tokens_models=args.max_out_tokens_models,
+            max_out_tokens_judge=args.max_out_tokens_judge,
+            max_model_len=args.max_model_len,
+            max_judge_model_len=args.max_judge_model_len,
+            chat_template=args.chat_template,
+            result_folder=args.result_folder,
+            engine_kwargs=parse_engine_kwargs(args.engine_kwargs),
+            judge_engine_kwargs=parse_engine_kwargs(args.judge_engine_kwargs),
+            verbosity=resolve_verbosity(args),
+            log_file=args.log_file,
+            no_log_file=args.no_log_file,
+        )
+
 
 @dataclass(frozen=True)
 class BaselinePlan:
-    """Row-aligned baseline assignment for native pairwise baselines."""
+    """Row-aligned baseline assignment for `--model_B`.
+
+    Mirrors upstream's `JUDGE_SETTINGS[question["category"]]["baseline"]` lookup
+    in `arena-hard-auto/gen_judgment.py`: a flat plan assigns one baseline to
+    every row, a per-row plan assigns a different baseline per category (v2.0
+    mixes `o3-mini-2025-01-31` on hard prompts with `gemini-2.0-flash-001` on
+    creative writing).
+    """
 
     baseline_by_index: pd.Series
 
@@ -135,7 +221,9 @@ class BaselinePlan:
     @property
     def single_model(self) -> str:
         if not self.is_flat:
-            raise ValueError("BaselinePlan has more than one model.")
+            raise ValueError(
+                "BaselinePlan is per-row; use baseline_by_index for row-level lookups"
+            )
         return self.unique_models[0]
 
     @property
@@ -146,23 +234,14 @@ class BaselinePlan:
         return self.baseline_by_index.loc[index]
 
 
-def native_pairwise_baseline(task: str) -> str | Mapping[str, str] | None:
-    """Return the dataset-native pairwise baseline, if the task defines one."""
-    if task in PAIRWISE_BASELINES:
-        return PAIRWISE_BASELINES[task]
-    parsed_m_arena_hard = split_m_arena_hard_dataset(task)
-    if parsed_m_arena_hard is not None:
-        version_key, _lang_or_subset = parsed_m_arena_hard
-        return PAIRWISE_BASELINES[version_key]
-    return None
-
-
 def _resolve_baseline_plan(
     args: CliArgs, instructions_df: pd.DataFrame
 ) -> BaselinePlan:
+    """Explicit `--model_B` wins; otherwise fall back to the dataset-native
+    assignment. Non-arena-hard datasets without an override raise.
+    """
     if args.model_B is not None:
         return BaselinePlan.flat(args.model_B, index=instructions_df.index)
-
     native = native_pairwise_baseline(args.task)
     if native is None:
         raise ValueError(
@@ -175,7 +254,8 @@ def _resolve_baseline_plan(
         if "category" not in instructions_df.columns:
             raise ValueError(
                 f"{args.task} requires a 'category' column for per-category "
-                "baseline routing."
+                "baseline routing; re-run dataset download to regenerate the "
+                "instructions table."
             )
         per_row = instructions_df["category"].map(native)
         if per_row.isna().any():
@@ -190,15 +270,69 @@ def _resolve_baseline_plan(
     raise ValueError(f"Unsupported baseline shape for dataset '{args.task}'.")
 
 
-def _build_judge_engine_kwargs(args: CliArgs) -> dict[str, object]:
-    judge_kwargs = dict(args.engine_kwargs)
-    judge_kwargs.update(args.judge_engine_kwargs)
-    return judge_kwargs
+def native_pairwise_baseline(task: str) -> str | Mapping[str, str] | None:
+    """Return the dataset-native pairwise baseline, if the task defines one."""
+    if task in PAIRWISE_BASELINES:
+        return PAIRWISE_BASELINES[task]
+    parsed_m_arena_hard = split_m_arena_hard_dataset(task)
+    if parsed_m_arena_hard is not None:
+        version_key, _lang_or_subset = parsed_m_arena_hard
+        return PAIRWISE_BASELINES[version_key]
+    return None
 
 
 def load_contexts(dataset: str) -> pd.Series:
     path = data_root / "contexts" / dataset
     return pd.read_csv(path).loc[:, "instruction"]
+
+
+def _build_generation_model_kwargs(
+    *, args: CliArgs, model_spec: str
+) -> dict[str, object]:
+    generation_model_kwargs = dict(args.engine_kwargs)
+    provider, _, model_name = model_spec.partition("/")
+    if (
+        args.battle_thinking_token_budget is not None
+        and provider == "VLLM"
+        and is_thinking_model(model_name)
+    ):
+        generation_model_kwargs["thinking_token_budget"] = min(
+            int(args.battle_thinking_token_budget),
+            int(args.max_out_tokens_models),
+        )
+    return generation_model_kwargs
+
+
+def _build_judge_model_kwargs(
+    *, args: CliArgs, limit_event_tracker: LimitEventTracker | None
+) -> dict[str, object]:
+    judge_model_kwargs = build_default_judge_model_kwargs(
+        args.judge_model,
+        args.engine_kwargs,
+        judge_engine_kwargs_override=args.judge_engine_kwargs,
+    )
+    if limit_event_tracker is not None:
+        judge_model_kwargs["limit_event_tracker"] = limit_event_tracker
+        judge_model_kwargs["limit_event_stage"] = "judge_model_init"
+        judge_model_kwargs["limit_event_model_spec"] = args.judge_model
+    return judge_model_kwargs
+
+
+def _generation_cache_name(args: CliArgs, *, model_spec: str) -> str:
+    generation_config = {
+        "truncate_all_input_chars": args.truncate_all_input_chars,
+        "max_out_tokens_models": args.max_out_tokens_models,
+        "max_model_len": args.max_model_len,
+        "chat_template": args.chat_template,
+        "battle_thinking_token_budget": args.battle_thinking_token_budget,
+        "engine_kwargs": _build_generation_model_kwargs(
+            args=args, model_spec=model_spec
+        ),
+    }
+    generation_config_hash = hashlib.sha256(
+        json.dumps(generation_config, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"{args.task}_{model_spec}_{args.n_instructions}_{generation_config_hash}"
 
 
 def print_results(results):
@@ -233,6 +367,7 @@ def main(args: CliArgs):
     """
 
     run_started_at = datetime.now(UTC)
+    limit_event_tracker = LimitEventTracker()
 
     # Not working with vllm, not detecting model changes and serving the same cache for two different models...
     # if not args.ignore_cache:
@@ -240,10 +375,9 @@ def main(args: CliArgs):
     ignore_cache = args.ignore_cache
 
     if args.task == "mt-bench":
-        model_b = args.model_B or native_pairwise_baseline(args.task)
-        if not isinstance(model_b, str):
-            raise ValueError("MT-Bench requires a flat native baseline.")
-        name = f"{args.task}-{args.model_A}-{model_b}-{args.judge_model}"
+        name = (
+            f"{args.task}-{args.model_A}-{args.model_B or 'native'}-{args.judge_model}"
+        )
         name += f"-{args.swap_mode}"
         name = name.replace("/", "_")
         run_ts = run_started_at.strftime("%Y%m%d_%H%M%S")
@@ -265,12 +399,13 @@ def main(args: CliArgs):
         # to match files in https://huggingface.co/datasets/geoalgo/multilingual-contexts-to-be-completed
         lang = args.task.split("-")[-1]
         instructions = load_contexts(f"{lang}-contexts.csv")
-        instructions_df = pd.DataFrame({"instruction": instructions})
+        instructions_df = pd.DataFrame({"instruction": instructions.values})
+        instructions_df.index = instructions.index
     else:
         instructions_df = load_instructions(
             dataset=args.task, n_instructions=args.n_instructions
         )
-        instructions = instructions_df.loc[:, "instruction"]
+        instructions = instructions_df["instruction"]
 
     n_instructions = args.n_instructions if args.n_instructions else len(instructions)
     if args.n_instructions is not None:
@@ -289,12 +424,11 @@ def main(args: CliArgs):
         attach_file_handler(make_run_log_path(res_folder))
 
     logger.info(
-        "Using task %s and evaluating %s against baseline %s.",
+        "Using task %s and evaluating %s vs baseline %s.",
         args.task,
         args.model_A,
         baseline_plan.display_name,
     )
-
     logger.info(
         "Generating completions for task %s with model %s and baseline %s "
         "(or loading them directly if present)",
@@ -303,46 +437,39 @@ def main(args: CliArgs):
         baseline_plan.display_name,
     )
 
-    # TODO currently we just support base models for fluency, we could also support instruction-tuned models
-    gen_fun = (
-        partial(
-            generate_base,
-            truncate_input_chars=args.truncate_all_input_chars,
-            max_tokens=args.max_out_tokens_models,
-            max_model_len=args.max_model_len,
-            chat_template=args.chat_template,
-            use_tqdm=args.use_tqdm,
-            **args.engine_kwargs,
-        )
-        if is_fluency_task
-        else partial(
-            generate_instructions,
-            truncate_input_chars=args.truncate_all_input_chars,
-            max_tokens=args.max_out_tokens_models,
-            max_model_len=args.max_model_len,
-            chat_template=args.chat_template,
-            use_tqdm=args.use_tqdm,
-            **args.engine_kwargs,
-        )
-    )
+    generation_function = generate_base if is_fluency_task else generate_instructions
 
-    def _align_completion_series(df: pd.DataFrame) -> pd.Series:
-        return df.set_index("instruction_index").loc[instructions.index, "completion"]
+    def _run_generation(model_spec: str) -> pd.DataFrame:
+        return generation_function(
+            instructions=instructions,
+            model=model_spec,
+            truncate_input_chars=args.truncate_all_input_chars,
+            max_tokens=args.max_out_tokens_models,
+            max_model_len=args.max_model_len,
+            chat_template=args.chat_template,
+            use_tqdm=args.use_tqdm,
+            limit_event_tracker=limit_event_tracker,
+            **_build_generation_model_kwargs(args=args, model_spec=model_spec),
+        )
+
+    def _align_completion_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+        return df.set_index("instruction_index").loc[instructions.index].reset_index()
 
     def _load_or_generate_completions(model_spec: str) -> pd.Series:
         preloaded = try_load_dataset_completions(args.task, model_spec, n_instructions)
         if preloaded is not None:
-            return _align_completion_series(preloaded)
-        generated = cache_function_dataframe(
-            lambda: gen_fun(
-                instructions=instructions,
-                model=model_spec,
-                use_tqdm=args.use_tqdm,
-            ),
-            ignore_cache=ignore_cache,
-            cache_name=f"{args.task}_{model_spec}_{args.n_instructions}",
-        )
-        return _align_completion_series(generated)
+            aligned = _align_completion_dataframe(preloaded)
+        else:
+            aligned = _align_completion_dataframe(
+                cache_function_dataframe(
+                    lambda: _run_generation(model_spec),
+                    ignore_cache=ignore_cache,
+                    cache_name=_generation_cache_name(args, model_spec=model_spec),
+                )
+            )
+        return aligned.set_index("instruction_index").loc[
+            instructions.index, "completion"
+        ]
 
     completions_A = _load_or_generate_completions(args.model_A)
 
@@ -350,14 +477,18 @@ def main(args: CliArgs):
     if baseline_plan.is_flat:
         completions_B = _load_or_generate_completions(baseline_plan.single_model)
     else:
-        per_baseline_completions = {
-            model: _load_or_generate_completions(model)
-            for model in baseline_plan.unique_models
-        }
+        # Per-row plan: fetch one completion set per unique baseline, then stitch
+        # them together so completions_B[uid] uses the baseline that
+        # ARENA_HARD_BASELINES routes uid's category to.
+        per_baseline_completions: dict[str, pd.Series] = {}
+        for baseline_model in baseline_plan.unique_models:
+            per_baseline_completions[baseline_model] = _load_or_generate_completions(
+                baseline_model
+            )
         completions_B = pd.Series(
             [
-                per_baseline_completions[model].loc[instruction_index]
-                for instruction_index, model in baseline_per_index.items()
+                per_baseline_completions[model].loc[uid]
+                for uid, model in baseline_per_index.items()
             ],
             index=instructions.index,
             name="completion",
@@ -370,6 +501,29 @@ def main(args: CliArgs):
         baseline_plan.display_name,
         completions_B.values[0],
     )
+    if args.skip_judging:
+        with open(res_folder / f"args-{name}.json", "w") as f:
+            json.dump(asdict(args), f, indent=2)
+        generation_summary = {
+            "task": args.task,
+            "model_A": args.model_A,
+            "model_B": baseline_plan.display_name,
+            "baseline_assignment": "per-row" if not baseline_plan.is_flat else "flat",
+            "baseline_models": baseline_plan.unique_models,
+            "judge_model": args.judge_model,
+            "n_instructions": n_instructions,
+            "battle_thinking_token_budget": args.battle_thinking_token_budget,
+            "strip_thinking_before_judging": args.strip_thinking_before_judging,
+            "limit_events": limit_event_tracker.build_summary(),
+            "skip_judging": True,
+        }
+        with open(res_folder / f"gen-results-{name}.json", "w") as f:
+            json.dump(_to_jsonable(generation_summary), f, indent=2, allow_nan=False)
+        logger.info(
+            "skip_judging=True: wrote gen-results-%s.json and returning before judge construction.",
+            name,
+        )
+        return None
     logger.info("Evaluating completions with judge %s.", args.judge_model)
 
     judge_chat_model = make_model(
@@ -377,8 +531,9 @@ def main(args: CliArgs):
         max_tokens=args.max_out_tokens_judge,
         max_model_len=args.max_judge_model_len,
         chat_template=args.chat_template,
-        **_build_judge_engine_kwargs(args),
+        **_build_judge_model_kwargs(args=args, limit_event_tracker=limit_event_tracker),
     )
+    judge_tokenizer = getattr(judge_chat_model, "tokenizer", None)
 
     # save argument for results analysis
     with open(res_folder / f"args-{name}.json", "w") as f:
@@ -396,7 +551,7 @@ def main(args: CliArgs):
         system_prompt = None
     resolved_prompt = resolve_judge_prompts(
         provide_explanation=args.provide_explanation,
-        prompt_preset=args.judge_prompt_preset,
+        prompt_preset=args.judge_prompt_preset or DEFAULT_JUDGE_PROMPT_PRESET,
         system_prompt=system_prompt,
     )
 
@@ -405,17 +560,25 @@ def main(args: CliArgs):
         instructions=instructions.head(n_instructions).tolist(),
         completions_A=completions_A.head(n_instructions).tolist(),
         completions_B=completions_B.head(n_instructions).tolist(),
+        case_ids=instructions.head(n_instructions).index.tolist(),
         swap_mode=args.swap_mode,
         provide_explanation=args.provide_explanation,
+        prompt_preset=resolved_prompt.preset_name,
+        parser_mode=resolved_prompt.parser_mode,
+        strip_thinking_before_judging=args.strip_thinking_before_judging,
         system_prompt=resolved_prompt.system_prompt,
         user_prompt_template=resolved_prompt.user_prompt_template,
-        prompt_preset=resolved_prompt.preset_name,
         truncate_input_chars=args.truncate_judge_input_chars,
         use_tqdm=args.use_tqdm,
+        limit_event_tracker=limit_event_tracker,
+        judge_tokenizer=judge_tokenizer,
+        max_judge_model_len=args.max_judge_model_len,
+        max_out_tokens_judge=args.max_out_tokens_judge,
     )
 
     eval_instruction_index = instructions.head(n_instructions).index.tolist()
     baseline_per_eval = baseline_per_index.loc[eval_instruction_index]
+
     df = pd.DataFrame(annotations)
     df["instruction_index"] = eval_instruction_index
     df["model_A"] = args.model_A
@@ -432,7 +595,6 @@ def main(args: CliArgs):
 
     df.to_csv(res_folder / f"{name}-annotations.csv", index=False)
 
-    # compute and report statistics
     summary = compute_pref_summary(prefs)
 
     results = {
@@ -443,7 +605,10 @@ def main(args: CliArgs):
         "baseline_models": baseline_plan.unique_models,
         "judge_model": args.judge_model,
         "judge_prompt_preset": resolved_prompt.preset_name,
+        "strip_thinking_before_judging": args.strip_thinking_before_judging,
+        "battle_thinking_token_budget": args.battle_thinking_token_budget,
         **summary,
+        "limit_events": limit_event_tracker.build_summary(),
         "preferences": prefs.tolist(),
     }
     logger.info(
@@ -453,7 +618,6 @@ def main(args: CliArgs):
         args.judge_model,
     )
     print_results(results)
-
     with open(res_folder / f"results-{name}.json", "w") as f:
         json.dump(_to_jsonable(results), f, indent=2, allow_nan=False)
 

--- a/judgearena/mt_bench/common.py
+++ b/judgearena/mt_bench/common.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import pandas as pd
 
-from judgearena.utils import safe_text
+from judgearena.utils import safe_text_with_metadata
 
 MT_BENCH_REFERENCE_CATEGORIES: set[str] = {
     "math",
@@ -27,6 +27,14 @@ class MTBenchPairwiseRow:
     answer_b_2: str
     ref_1: str
     ref_2: str
+    turn_1_question_truncated: bool = False
+    turn_2_question_truncated: bool = False
+    answer_a_1_truncated: bool = False
+    answer_a_2_truncated: bool = False
+    answer_b_1_truncated: bool = False
+    answer_b_2_truncated: bool = False
+    ref_1_truncated: bool = False
+    ref_2_truncated: bool = False
 
 
 def iter_mt_bench_pairwise_rows(
@@ -48,27 +56,55 @@ def iter_mt_bench_pairwise_rows(
             if question_id in completions_b.index
             else completions_b.iloc[0]
         )
+        turn_1_question, turn_1_question_truncated = safe_text_with_metadata(
+            row.get("turn_1"),
+            truncate_input_chars,
+        )
+        turn_2_question, turn_2_question_truncated = safe_text_with_metadata(
+            row.get("turn_2"),
+            truncate_input_chars,
+        )
+        answer_a_1, answer_a_1_truncated = safe_text_with_metadata(
+            comp_a_row.get("completion_turn_1", ""),
+            truncate_input_chars,
+        )
+        answer_a_2, answer_a_2_truncated = safe_text_with_metadata(
+            comp_a_row.get("completion_turn_2", ""),
+            truncate_input_chars,
+        )
+        answer_b_1, answer_b_1_truncated = safe_text_with_metadata(
+            comp_b_row.get("completion_turn_1", ""),
+            truncate_input_chars,
+        )
+        answer_b_2, answer_b_2_truncated = safe_text_with_metadata(
+            comp_b_row.get("completion_turn_2", ""),
+            truncate_input_chars,
+        )
+        ref_1, ref_1_truncated = safe_text_with_metadata(
+            row.get("reference_turn_1"),
+            truncate_input_chars,
+        )
+        ref_2, ref_2_truncated = safe_text_with_metadata(
+            row.get("reference_turn_2"),
+            truncate_input_chars,
+        )
         yield MTBenchPairwiseRow(
             question_id=question_id,
             category=row.get("category"),
-            turn_1_question=safe_text(row.get("turn_1"), truncate_input_chars),
-            turn_2_question=safe_text(row.get("turn_2"), truncate_input_chars),
-            answer_a_1=safe_text(
-                comp_a_row.get("completion_turn_1", ""),
-                truncate_input_chars,
-            ),
-            answer_a_2=safe_text(
-                comp_a_row.get("completion_turn_2", ""),
-                truncate_input_chars,
-            ),
-            answer_b_1=safe_text(
-                comp_b_row.get("completion_turn_1", ""),
-                truncate_input_chars,
-            ),
-            answer_b_2=safe_text(
-                comp_b_row.get("completion_turn_2", ""),
-                truncate_input_chars,
-            ),
-            ref_1=safe_text(row.get("reference_turn_1"), truncate_input_chars),
-            ref_2=safe_text(row.get("reference_turn_2"), truncate_input_chars),
+            turn_1_question=turn_1_question,
+            turn_2_question=turn_2_question,
+            answer_a_1=answer_a_1,
+            answer_a_2=answer_a_2,
+            answer_b_1=answer_b_1,
+            answer_b_2=answer_b_2,
+            ref_1=ref_1,
+            ref_2=ref_2,
+            turn_1_question_truncated=turn_1_question_truncated,
+            turn_2_question_truncated=turn_2_question_truncated,
+            answer_a_1_truncated=answer_a_1_truncated,
+            answer_a_2_truncated=answer_a_2_truncated,
+            answer_b_1_truncated=answer_b_1_truncated,
+            answer_b_2_truncated=answer_b_2_truncated,
+            ref_1_truncated=ref_1_truncated,
+            ref_2_truncated=ref_2_truncated,
         )

--- a/judgearena/mt_bench/fastchat_compat.py
+++ b/judgearena/mt_bench/fastchat_compat.py
@@ -4,14 +4,29 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Literal
 
 import pandas as pd
 from langchain_core.prompts import ChatPromptTemplate
 
-from judgearena.mt_bench.common import iter_mt_bench_pairwise_rows
-from judgearena.utils import do_inference
+from judgearena.judge_prompt_presets import (
+    DEFAULT_JUDGE_PROMPT_PRESET,
+    SKYWORK_JUDGE_PROMPT_PRESET,
+)
+from judgearena.mt_bench.common import (
+    MT_BENCH_REFERENCE_CATEGORIES,
+    iter_mt_bench_pairwise_rows,
+)
+from judgearena.mt_bench.prompt_templates import (
+    build_mt_bench_user_prompt_template,
+    render_mt_bench_prompt_text,
+)
+from judgearena.utils import (
+    LimitEventTracker,
+    do_inference,
+    strip_thinking_tags,
+    strip_thinking_tags_with_metadata,
+)
 
 FASTCHAT_TEMPERATURE_CONFIG: dict[str, float] = {
     "writing": 0.7,
@@ -23,13 +38,6 @@ FASTCHAT_TEMPERATURE_CONFIG: dict[str, float] = {
     "stem": 0.1,
     "humanities": 0.1,
     "arena-hard-200": 0.0,
-}
-
-FASTCHAT_NEED_REF_CATS: set[str] = {
-    "math",
-    "reasoning",
-    "coding",
-    "arena-hard-200",
 }
 
 FastChatVerdict = Literal["A", "B", "tie", "error"]
@@ -45,21 +53,7 @@ class FastChatPairwisePrompt:
     ref_based: bool
 
 
-_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts" / "mt_bench"
 _SYSTEM_BASE_FILE = "system-base.txt"
-_USER_SINGLE_BASE_FILE = "user-single-base.txt"
-_USER_MULTI_BASE_FILE = "user-multi-base.txt"
-_USER_SINGLE_REF_BLOCK_FILE = "user-single-reference-block.txt"
-_USER_MULTI_REF_BLOCK_FILE = "user-multi-reference-block.txt"
-
-
-def _load_prompt_text(filename: str) -> str:
-    path = _PROMPTS_DIR / filename
-    return path.read_text(encoding="utf-8")
-
-
-def _render_prompt_text(filename: str, **kwargs: str) -> str:
-    return _load_prompt_text(filename).format(**kwargs)
 
 
 def _build_system_prompt(
@@ -70,24 +64,13 @@ def _build_system_prompt(
     focus_line: str = "",
 ) -> str:
     focus_segment = f"{focus_line} " if focus_line else ""
-    return _render_prompt_text(
+    return render_mt_bench_prompt_text(
         _SYSTEM_BASE_FILE,
         user_subject=user_subject,
         task_description=task_description,
         focus_line=focus_segment,
         begin_instruction=begin_instruction,
     )
-
-
-def _build_user_prompt_template(*, multi_turn: bool, ref_based: bool) -> str:
-    base_filename = _USER_MULTI_BASE_FILE if multi_turn else _USER_SINGLE_BASE_FILE
-    reference_block = ""
-    if ref_based:
-        ref_block_filename = (
-            _USER_MULTI_REF_BLOCK_FILE if multi_turn else _USER_SINGLE_REF_BLOCK_FILE
-        )
-        reference_block = _load_prompt_text(ref_block_filename).rstrip("\n") + "\n\n"
-    return _render_prompt_text(base_filename, reference_block=reference_block)
 
 
 def _load_pairwise_prompt(
@@ -110,7 +93,7 @@ def _load_pairwise_prompt(
             begin_instruction=system_begin_instruction,
             focus_line=system_focus_line,
         ),
-        user_prompt_template=_build_user_prompt_template(
+        user_prompt_template=build_mt_bench_user_prompt_template(
             multi_turn=multi_turn,
             ref_based=ref_based,
         ),
@@ -179,12 +162,86 @@ _PAIR_MATH_V1_MULTI = _load_pairwise_prompt(
 )
 
 
+_SKYWORK_PAIR_V2 = _load_pairwise_prompt(
+    name="skywork-pair-v2",
+    multi_turn=False,
+    ref_based=False,
+    system_user_subject="prompt displayed below",
+    system_task_description=(
+        "You should choose the assistant that follows the user's instructions and "
+        "answers the user's prompt better. Your evaluation should consider factors "
+        "such as helpfulness, relevance, accuracy, depth, creativity, and level "
+        "of detail of the responses."
+    ),
+    system_begin_instruction="carefully comparing the two responses",
+)
+
+_SKYWORK_PAIR_V2_MULTI = _load_pairwise_prompt(
+    name="skywork-pair-v2-multi-turn",
+    multi_turn=True,
+    ref_based=False,
+    system_user_subject="questions",
+    system_task_description=(
+        "You should choose the assistant that follows the user's instructions and "
+        "answers the user's questions better. Your evaluation should consider "
+        "factors such as helpfulness, relevance, accuracy, depth, creativity, and "
+        "level of detail of the responses."
+    ),
+    system_focus_line=(
+        "You should focus on which assistant better answers the second user question."
+    ),
+    system_begin_instruction="carefully comparing the two conversations",
+)
+
+_SKYWORK_PAIR_MATH_V1 = _load_pairwise_prompt(
+    name="skywork-pair-math-v1",
+    multi_turn=False,
+    ref_based=True,
+    system_user_subject="prompt displayed below",
+    system_task_description=(
+        "You will be given a reference answer, assistant A's answer, and "
+        "assistant B's answer. Your evaluation should focus on correctness and "
+        "helpfulness while deciding which assistant is better."
+    ),
+    system_begin_instruction="carefully comparing both assistants' answers with the reference answer",
+)
+
+_SKYWORK_PAIR_MATH_V1_MULTI = _load_pairwise_prompt(
+    name="skywork-pair-math-v1-multi-turn",
+    multi_turn=True,
+    ref_based=True,
+    system_user_subject="questions",
+    system_task_description=(
+        "You will be given reference answers together with assistant A's and "
+        "assistant B's answers. Your evaluation should focus on correctness and "
+        "helpfulness while deciding which assistant better answers the second user question."
+    ),
+    system_begin_instruction="carefully comparing both assistants' answers with the reference answers",
+)
+
+_FASTCHAT_PROMPT_PRESET_REGISTRY: dict[str, dict[str, FastChatPairwisePrompt]] = {
+    DEFAULT_JUDGE_PROMPT_PRESET: {
+        "single": _PAIR_V2,
+        "multi": _PAIR_V2_MULTI,
+        "single_ref": _PAIR_MATH_V1,
+        "multi_ref": _PAIR_MATH_V1_MULTI,
+    },
+    SKYWORK_JUDGE_PROMPT_PRESET: {
+        "single": _SKYWORK_PAIR_V2,
+        "multi": _SKYWORK_PAIR_V2_MULTI,
+        "single_ref": _SKYWORK_PAIR_MATH_V1,
+        "multi_ref": _SKYWORK_PAIR_MATH_V1_MULTI,
+    },
+}
+
+
 def _parse_fastchat_verdict(judgment: str) -> FastChatVerdict:
-    if "[[A]]" in judgment:
+    stripped = strip_thinking_tags(judgment).strip()
+    if "[[A]]" in stripped:
         return "A"
-    if "[[B]]" in judgment:
+    if "[[B]]" in stripped:
         return "B"
-    if "[[C]]" in judgment:
+    if "[[C]]" in stripped:
         return "tie"
     return "error"
 
@@ -225,15 +282,26 @@ def _winner_to_preference(winner: PairwiseWinner) -> float:
     return math.nan
 
 
-def _select_prompt(category: str | None, multi_turn: bool) -> FastChatPairwisePrompt:
-    needs_ref = (category or "") in FASTCHAT_NEED_REF_CATS
+def _select_prompt(
+    category: str | None,
+    multi_turn: bool,
+    *,
+    prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
+) -> FastChatPairwisePrompt:
+    prompt_variants = _FASTCHAT_PROMPT_PRESET_REGISTRY.get(prompt_preset)
+    if prompt_variants is None:
+        supported = ", ".join(sorted(_FASTCHAT_PROMPT_PRESET_REGISTRY))
+        raise ValueError(
+            f"Unsupported MT-Bench prompt preset '{prompt_preset}'. Choose from: {supported}."
+        )
+    needs_ref = (category or "") in MT_BENCH_REFERENCE_CATEGORIES
     if needs_ref and multi_turn:
-        return _PAIR_MATH_V1_MULTI
+        return prompt_variants["multi_ref"]
     if needs_ref:
-        return _PAIR_MATH_V1
+        return prompt_variants["single_ref"]
     if multi_turn:
-        return _PAIR_V2_MULTI
-    return _PAIR_V2
+        return prompt_variants["multi"]
+    return prompt_variants["single"]
 
 
 def _group_indices_by_prompt(
@@ -304,8 +372,38 @@ def _build_fastchat_judge_items(
     eval_single: bool,
     eval_multi: bool,
     truncate_input_chars: int | None,
+    prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
+    strip_thinking_before_judging: bool = False,
+    limit_event_tracker: LimitEventTracker | None = None,
 ) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
+
+    def _record_mt_bench_truncation(
+        *, case_id: str, field: str, truncated: bool
+    ) -> None:
+        if truncated and limit_event_tracker is not None:
+            limit_event_tracker.record(
+                "mt_bench_field_char_truncation",
+                stage="judge_input",
+                field=field,
+                case_id=case_id,
+            )
+
+    def _prepare_answer(answer: str, *, case_id: str, field: str) -> tuple[str, bool]:
+        if not strip_thinking_before_judging:
+            return answer, False
+        stripped_answer, stripped = strip_thinking_tags_with_metadata(answer)
+        if stripped and limit_event_tracker is not None:
+            limit_event_tracker.record(
+                "thinking_trace_stripped_before_judging",
+                stage="judge_input",
+                field=field,
+                case_id=case_id,
+                original_length=len(answer),
+                final_length=len(stripped_answer),
+            )
+        return stripped_answer, stripped
+
     for pair_row in iter_mt_bench_pairwise_rows(
         questions=questions,
         completions_a=completions_a,
@@ -314,14 +412,51 @@ def _build_fastchat_judge_items(
     ):
         category = pair_row.category
         if eval_single:
-            prompt = _select_prompt(category, multi_turn=False)
+            case_id = f"{pair_row.question_id}:turn1"
+            prompt = _select_prompt(
+                category, multi_turn=False, prompt_preset=prompt_preset
+            )
+            answer_a, answer_a_stripped = _prepare_answer(
+                pair_row.answer_a_1, case_id=case_id, field="answer_a_1"
+            )
+            answer_b, answer_b_stripped = _prepare_answer(
+                pair_row.answer_b_1, case_id=case_id, field="answer_b_1"
+            )
+            _record_mt_bench_truncation(
+                case_id=case_id,
+                field="turn_1_question",
+                truncated=pair_row.turn_1_question_truncated,
+            )
+            _record_mt_bench_truncation(
+                case_id=case_id,
+                field="answer_a_1",
+                truncated=pair_row.answer_a_1_truncated,
+            )
+            _record_mt_bench_truncation(
+                case_id=case_id,
+                field="answer_b_1",
+                truncated=pair_row.answer_b_1_truncated,
+            )
             kwargs: dict[str, str] = {
                 "question": pair_row.turn_1_question,
-                "answer_a": pair_row.answer_a_1,
-                "answer_b": pair_row.answer_b_1,
+                "answer_a": answer_a,
+                "answer_b": answer_b,
+            }
+            limit_flags = {
+                "turn_1_question_truncated": pair_row.turn_1_question_truncated,
+                "answer_a_1_truncated": pair_row.answer_a_1_truncated,
+                "answer_b_1_truncated": pair_row.answer_b_1_truncated,
+                "answer_a_1_reasoning_stripped": answer_a_stripped,
+                "answer_b_1_reasoning_stripped": answer_b_stripped,
             }
             if prompt.ref_based:
+                _record_mt_bench_truncation(
+                    case_id=case_id,
+                    field="ref_1",
+                    truncated=pair_row.ref_1_truncated,
+                )
                 kwargs["ref_answer_1"] = pair_row.ref_1
+                limit_flags["ref_1_truncated"] = pair_row.ref_1_truncated
             items.append(
                 {
                     "question_id": pair_row.question_id,
@@ -330,22 +465,73 @@ def _build_fastchat_judge_items(
                     "prompt": prompt,
                     "prompt_name": prompt.name,
                     "prompt_kwargs": kwargs,
+                    "limit_flags": limit_flags,
                 }
             )
 
         if eval_multi and pair_row.turn_2_question:
-            prompt = _select_prompt(category, multi_turn=True)
+            case_id = f"{pair_row.question_id}:turn2"
+            prompt = _select_prompt(
+                category, multi_turn=True, prompt_preset=prompt_preset
+            )
+            answer_a_1, answer_a_1_stripped = _prepare_answer(
+                pair_row.answer_a_1, case_id=case_id, field="answer_a_1"
+            )
+            answer_a_2, answer_a_2_stripped = _prepare_answer(
+                pair_row.answer_a_2, case_id=case_id, field="answer_a_2"
+            )
+            answer_b_1, answer_b_1_stripped = _prepare_answer(
+                pair_row.answer_b_1, case_id=case_id, field="answer_b_1"
+            )
+            answer_b_2, answer_b_2_stripped = _prepare_answer(
+                pair_row.answer_b_2, case_id=case_id, field="answer_b_2"
+            )
+            for field, truncated in (
+                ("turn_1_question", pair_row.turn_1_question_truncated),
+                ("turn_2_question", pair_row.turn_2_question_truncated),
+                ("answer_a_1", pair_row.answer_a_1_truncated),
+                ("answer_a_2", pair_row.answer_a_2_truncated),
+                ("answer_b_1", pair_row.answer_b_1_truncated),
+                ("answer_b_2", pair_row.answer_b_2_truncated),
+            ):
+                _record_mt_bench_truncation(
+                    case_id=case_id, field=field, truncated=truncated
+                )
             kwargs = {
                 "question_1": pair_row.turn_1_question,
                 "question_2": pair_row.turn_2_question,
-                "answer_a_1": pair_row.answer_a_1,
-                "answer_a_2": pair_row.answer_a_2,
-                "answer_b_1": pair_row.answer_b_1,
-                "answer_b_2": pair_row.answer_b_2,
+                "answer_a_1": answer_a_1,
+                "answer_a_2": answer_a_2,
+                "answer_b_1": answer_b_1,
+                "answer_b_2": answer_b_2,
+            }
+            limit_flags = {
+                "turn_1_question_truncated": pair_row.turn_1_question_truncated,
+                "turn_2_question_truncated": pair_row.turn_2_question_truncated,
+                "answer_a_1_truncated": pair_row.answer_a_1_truncated,
+                "answer_a_2_truncated": pair_row.answer_a_2_truncated,
+                "answer_b_1_truncated": pair_row.answer_b_1_truncated,
+                "answer_b_2_truncated": pair_row.answer_b_2_truncated,
+                "answer_a_1_reasoning_stripped": answer_a_1_stripped,
+                "answer_a_2_reasoning_stripped": answer_a_2_stripped,
+                "answer_b_1_reasoning_stripped": answer_b_1_stripped,
+                "answer_b_2_reasoning_stripped": answer_b_2_stripped,
             }
             if prompt.ref_based:
+                _record_mt_bench_truncation(
+                    case_id=case_id,
+                    field="ref_1",
+                    truncated=pair_row.ref_1_truncated,
+                )
+                _record_mt_bench_truncation(
+                    case_id=case_id,
+                    field="ref_2",
+                    truncated=pair_row.ref_2_truncated,
+                )
                 kwargs["ref_answer_1"] = pair_row.ref_1
                 kwargs["ref_answer_2"] = pair_row.ref_2
+                limit_flags["ref_1_truncated"] = pair_row.ref_1_truncated
+                limit_flags["ref_2_truncated"] = pair_row.ref_2_truncated
             items.append(
                 {
                     "question_id": pair_row.question_id,
@@ -354,6 +540,7 @@ def _build_fastchat_judge_items(
                     "prompt": prompt,
                     "prompt_name": prompt.name,
                     "prompt_kwargs": kwargs,
+                    "limit_flags": limit_flags,
                 }
             )
     return items
@@ -390,6 +577,7 @@ def _resolve_fastchat_item_result(
         "g1_verdict": g1_verdict,
         "g1_winner": g1_winner,
     }
+    annotation_row.update(item.get("limit_flags", {}))
 
     if g2_raw is not None:
         g2_verdict = _parse_fastchat_verdict(g2_raw)
@@ -434,8 +622,11 @@ def judge_mt_bench_pairwise_fastchat(
     swap_mode: str,
     truncate_input_chars: int | None,
     use_tqdm: bool,
+    prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
+    strip_thinking_before_judging: bool = False,
+    limit_event_tracker: LimitEventTracker | None = None,
 ) -> tuple[pd.Series, list[dict[str, Any]], list[dict[str, object]], int]:
-    """Pairwise MT-Bench judging compatible with FastChat's `[[A]]/[[B]]/[[C]]` format."""
+    """Run FastChat-style MT-Bench pairwise judging with bracketed verdict outputs."""
     assert turns_mode in ("both", "single", "multi")
     assert swap_mode in ("fixed", "both")
 
@@ -449,6 +640,9 @@ def judge_mt_bench_pairwise_fastchat(
         eval_single=eval_single,
         eval_multi=eval_multi,
         truncate_input_chars=truncate_input_chars,
+        prompt_preset=prompt_preset,
+        strip_thinking_before_judging=strip_thinking_before_judging,
+        limit_event_tracker=limit_event_tracker,
     )
 
     g1_judgments = _infer_by_prompt_groups(

--- a/judgearena/mt_bench/mt_bench_utils.py
+++ b/judgearena/mt_bench/mt_bench_utils.py
@@ -6,10 +6,11 @@ and result saving for the MT-Bench benchmark.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from dataclasses import asdict
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -29,8 +30,15 @@ from judgearena.mt_bench.fastchat_compat import (
     judge_mt_bench_pairwise_fastchat,
 )
 from judgearena.mt_bench.preset_judging import judge_mt_bench_with_preset
-from judgearena.repro import _to_jsonable
-from judgearena.utils import cache_function_dataframe, compute_pref_summary, make_model
+from judgearena.repro import _to_jsonable, write_run_metadata
+from judgearena.utils import (
+    LimitEventTracker,
+    build_default_judge_model_kwargs,
+    cache_function_dataframe,
+    compute_pref_summary,
+    is_thinking_model,
+    make_model,
+)
 
 logger = get_logger(__name__)
 
@@ -38,12 +46,83 @@ if TYPE_CHECKING:
     from judgearena.generate_and_evaluate import CliArgs
 
 
+# Original MT-Bench prompts include a visible explanation before the final verdict.
+_MIN_MT_BENCH_JUDGE_TOKENS = 24576
+_MIN_MT_BENCH_JUDGE_MAX_MODEL_LEN = 28672
+
+
+def _build_mt_bench_generation_kwargs(
+    *, args: CliArgs, model_spec: str
+) -> dict[str, object]:
+    generation_model_kwargs = dict(args.engine_kwargs)
+    provider, _, model_name = model_spec.partition("/")
+    if (
+        args.battle_thinking_token_budget is not None
+        and provider == "VLLM"
+        and is_thinking_model(model_name)
+    ):
+        generation_model_kwargs["thinking_token_budget"] = min(
+            int(args.battle_thinking_token_budget),
+            int(args.max_out_tokens_models),
+        )
+    return generation_model_kwargs
+
+
+def _build_mt_bench_judge_model_kwargs(
+    *, args: CliArgs, limit_event_tracker: LimitEventTracker | None
+) -> dict[str, object]:
+    judge_model_kwargs = build_default_judge_model_kwargs(
+        args.judge_model,
+        args.engine_kwargs,
+        judge_engine_kwargs_override=args.judge_engine_kwargs,
+    )
+    if limit_event_tracker is not None:
+        judge_model_kwargs["limit_event_tracker"] = limit_event_tracker
+        judge_model_kwargs["limit_event_stage"] = "judge_model_init"
+        judge_model_kwargs["limit_event_model_spec"] = args.judge_model
+    return judge_model_kwargs
+
+
+def _mt_bench_generation_cache_name(args: CliArgs, *, model_name: str) -> str:
+    generation_config = {
+        "truncate_all_input_chars": args.truncate_all_input_chars,
+        "max_out_tokens_models": args.max_out_tokens_models,
+        "max_model_len": args.max_model_len,
+        "chat_template": args.chat_template,
+        "battle_thinking_token_budget": args.battle_thinking_token_budget,
+        "strip_thinking_before_judging": args.strip_thinking_before_judging,
+        "engine_kwargs": _build_mt_bench_generation_kwargs(
+            args=args, model_spec=model_name
+        ),
+    }
+    generation_config_hash = hashlib.sha256(
+        json.dumps(generation_config, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"mt-bench_{model_name}_{args.n_instructions}_{generation_config_hash}"
+
+
+def _align_mt_bench_completions(
+    *, questions_df: pd.DataFrame, completions: pd.DataFrame, model_name: str
+) -> pd.DataFrame:
+    """Align cached or generated MT-Bench completions to the question order."""
+    indexed = completions.set_index("instruction_index")
+    missing_ids = questions_df.index.difference(indexed.index)
+    if not missing_ids.empty:
+        missing_ids_preview = ", ".join(str(x) for x in missing_ids[:5])
+        raise ValueError(
+            f"MT-Bench completions for '{model_name}' are missing "
+            f"{len(missing_ids)} question(s). First missing ids: {missing_ids_preview}."
+        )
+    return indexed.loc[questions_df.index]
+
+
 def _generate_mt_bench_completions(
     args: CliArgs,
     questions_df: pd.DataFrame,
     ignore_cache: bool,
+    limit_event_tracker: LimitEventTracker | None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    cache_prefix = "mt-bench"
+    """Load baseline MT-Bench answers or generate fresh multi-turn outputs."""
 
     def _run_generation(model_name: str) -> pd.DataFrame:
         return generate_multiturn(
@@ -55,34 +134,62 @@ def _generate_mt_bench_completions(
             max_model_len=args.max_model_len,
             chat_template=args.chat_template,
             temperature_config=FASTCHAT_TEMPERATURE_CONFIG,
-            **args.engine_kwargs,
+            limit_event_tracker=limit_event_tracker,
+            strip_thinking_before_turn_2_prompt=args.strip_thinking_before_judging,
+            **_build_mt_bench_generation_kwargs(args=args, model_spec=model_name),
         )
 
     def _load_or_generate(model_name: str) -> pd.DataFrame:
-        preloaded = load_mt_bench_model_answers(
+        loaded_answers = load_mt_bench_model_answers(
             model_name, n_instructions=args.n_instructions
         )
-        if preloaded is not None:
-            return preloaded.set_index("instruction_index").loc[questions_df.index]
-        return (
-            cache_function_dataframe(
-                lambda: _run_generation(model_name),
-                ignore_cache=ignore_cache,
-                cache_name=f"{cache_prefix}_{model_name}_{args.n_instructions}",
+        if loaded_answers is not None:
+            print(f"Using pre-generated MT-Bench answers for '{model_name}'.")
+            return _align_mt_bench_completions(
+                questions_df=questions_df,
+                completions=loaded_answers,
+                model_name=model_name,
             )
-            .set_index("instruction_index")
-            .loc[questions_df.index]
+        generated_answers = cache_function_dataframe(
+            lambda: _run_generation(model_name),
+            ignore_cache=ignore_cache,
+            cache_name=_mt_bench_generation_cache_name(args, model_name=model_name),
+        )
+        return _align_mt_bench_completions(
+            questions_df=questions_df,
+            completions=generated_answers,
+            model_name=model_name,
         )
 
-    return _load_or_generate(args.model_A), _load_or_generate(args.model_B)
+    completions_a = _load_or_generate(args.model_A)
+    completions_b = _load_or_generate(args.model_B)
+    return completions_a, completions_b
 
 
 def _build_mt_bench_result_name(args: CliArgs, suffix: str | None = None) -> str:
+    """Build a filesystem-safe MT-Bench result artifact prefix."""
     name = f"{args.task}-{args.model_A}-{args.model_B}-{args.judge_model}"
     name += f"-{args.swap_mode}"
     if suffix:
         name += f"-{suffix}"
     return name.replace("/", "_")
+
+
+def _build_mt_bench_input_payloads(
+    *,
+    questions_df: pd.DataFrame,
+    completions_a: pd.DataFrame,
+    completions_b: pd.DataFrame,
+) -> dict[str, object]:
+    return {
+        "instruction_index": questions_df.index.tolist(),
+        "turn_1": questions_df["turn_1"].tolist(),
+        "turn_2": questions_df["turn_2"].tolist(),
+        "completion_turn_1_A": completions_a["completion_turn_1"].tolist(),
+        "completion_turn_2_A": completions_a["completion_turn_2"].tolist(),
+        "completion_turn_1_B": completions_b["completion_turn_1"].tolist(),
+        "completion_turn_2_B": completions_b["completion_turn_2"].tolist(),
+    }
 
 
 def _save_mt_bench_results(
@@ -92,7 +199,15 @@ def _save_mt_bench_results(
     result_name: str,
     results: dict[str, object],
     annotations_df: pd.DataFrame,
+    questions_df: pd.DataFrame,
+    started_at_utc: datetime,
+    input_payloads: dict[str, object] | None = None,
+    judge_system_prompt: str | None = None,
+    judge_user_prompt_template: str | None = None,
 ) -> None:
+    """Persist MT-Bench arguments, annotations, and aggregate results."""
+    res_folder.mkdir(parents=True, exist_ok=True)
+
     with open(res_folder / f"args-{result_name}.json", "w") as f:
         json.dump(_to_jsonable(asdict(args)), f, indent=2, allow_nan=False)
 
@@ -100,6 +215,22 @@ def _save_mt_bench_results(
 
     with open(res_folder / f"results-{result_name}.json", "w") as f:
         json.dump(_to_jsonable(results), f, indent=2, allow_nan=False)
+
+    write_run_metadata(
+        output_dir=res_folder,
+        entrypoint="judgearena.mt_bench.mt_bench_utils.run_mt_bench",
+        run=asdict(args),
+        results=results,
+        input_payloads=input_payloads
+        or {
+            "instruction_index": questions_df.index.tolist(),
+            "turn_1": questions_df["turn_1"].tolist(),
+            "turn_2": questions_df["turn_2"].tolist(),
+        },
+        judge_system_prompt=judge_system_prompt,
+        judge_user_prompt_template=judge_user_prompt_template,
+        started_at_utc=started_at_utc,
+    )
 
 
 def _run_mt_bench_fastchat(
@@ -112,7 +243,10 @@ def _run_mt_bench_fastchat(
     completions_b: pd.DataFrame,
     judge_chat_model,
     prompt_preset: str,
+    limit_event_tracker: LimitEventTracker | None,
+    started_at_utc: datetime,
 ) -> pd.Series:
+    """Run FastChat-style MT-Bench judging and save the resulting artifacts."""
     prefs, annotations, combined_metadata, num_inconsistent = (
         judge_mt_bench_pairwise_fastchat(
             judge_chat_model=judge_chat_model,
@@ -126,6 +260,9 @@ def _run_mt_bench_fastchat(
             swap_mode=args.swap_mode,
             truncate_input_chars=args.truncate_judge_input_chars,
             use_tqdm=args.use_tqdm,
+            prompt_preset=prompt_preset,
+            strip_thinking_before_judging=args.strip_thinking_before_judging,
+            limit_event_tracker=limit_event_tracker,
         )
     )
 
@@ -137,8 +274,13 @@ def _run_mt_bench_fastchat(
         "judge_model": args.judge_model,
         "judge_prompt_preset": prompt_preset,
         "mt_bench_judge_mode": args.mt_bench_judge_mode,
+        "strip_thinking_before_judging": args.strip_thinking_before_judging,
+        "battle_thinking_token_budget": args.battle_thinking_token_budget,
         "num_inconsistent": num_inconsistent,
         **stats,
+        "limit_events": limit_event_tracker.build_summary()
+        if limit_event_tracker is not None
+        else {},
         "per_category": _compute_grouped_stats(prefs, combined_metadata, "category"),
         "per_turn": _compute_grouped_stats(prefs, combined_metadata, "turn"),
         "preferences": prefs.tolist(),
@@ -152,6 +294,13 @@ def _run_mt_bench_fastchat(
         result_name=result_name,
         results=results,
         annotations_df=pd.DataFrame(annotations),
+        questions_df=questions_df,
+        started_at_utc=started_at_utc,
+        input_payloads=_build_mt_bench_input_payloads(
+            questions_df=questions_df,
+            completions_a=completions_a,
+            completions_b=completions_b,
+        ),
     )
     return prefs
 
@@ -166,6 +315,8 @@ def _run_mt_bench_preset(
     completions_b: pd.DataFrame,
     judge_chat_model,
     prompt_preset: str,
+    limit_event_tracker: LimitEventTracker | None,
+    started_at_utc: datetime,
 ) -> pd.Series:
     prefs, annotations, combined_metadata, _num_inconsistent = (
         judge_mt_bench_with_preset(
@@ -182,8 +333,14 @@ def _run_mt_bench_preset(
             use_tqdm=args.use_tqdm,
             prompt_preset=prompt_preset,
             provide_explanation=args.provide_explanation,
+            strip_thinking_before_judging=args.strip_thinking_before_judging,
+            judge_tokenizer=getattr(judge_chat_model, "tokenizer", None),
+            max_judge_model_len=args.max_judge_model_len,
+            max_out_tokens_judge=args.max_out_tokens_judge,
+            limit_event_tracker=limit_event_tracker,
         )
     )
+
     stats = compute_pref_summary(prefs)
     results = {
         "task": args.task,
@@ -192,7 +349,12 @@ def _run_mt_bench_preset(
         "judge_model": args.judge_model,
         "judge_prompt_preset": prompt_preset,
         "mt_bench_judge_mode": args.mt_bench_judge_mode,
+        "strip_thinking_before_judging": args.strip_thinking_before_judging,
+        "battle_thinking_token_budget": args.battle_thinking_token_budget,
         **stats,
+        "limit_events": limit_event_tracker.build_summary()
+        if limit_event_tracker is not None
+        else {},
         "per_category": _compute_grouped_stats(prefs, combined_metadata, "category"),
         "per_turn": _compute_grouped_stats(prefs, combined_metadata, "turn"),
         "preferences": prefs.tolist(),
@@ -200,12 +362,35 @@ def _run_mt_bench_preset(
         "user": os.getenv("USER", ""),
     }
     print_results(results)
+    unique_system_prompts = {
+        row.get("system_prompt")
+        for row in annotations
+        if row.get("system_prompt") is not None
+    }
+    unique_user_templates = {
+        row.get("user_prompt_template")
+        for row in annotations
+        if row.get("user_prompt_template") is not None
+    }
     _save_mt_bench_results(
         args=args,
         res_folder=res_folder,
         result_name=result_name,
         results=results,
         annotations_df=pd.DataFrame(annotations),
+        questions_df=questions_df,
+        started_at_utc=started_at_utc,
+        input_payloads=_build_mt_bench_input_payloads(
+            questions_df=questions_df,
+            completions_a=completions_a,
+            completions_b=completions_b,
+        ),
+        judge_system_prompt=next(iter(unique_system_prompts), None)
+        if len(unique_system_prompts) == 1
+        else None,
+        judge_user_prompt_template=next(iter(unique_user_templates), None)
+        if len(unique_user_templates) == 1
+        else None,
     )
     return prefs
 
@@ -214,16 +399,42 @@ def run_mt_bench(
     args: CliArgs,
     ignore_cache: bool,
     *,
-    res_folder: Path,
-    result_name: str,
+    res_folder: Path | None = None,
+    result_name: str | None = None,
 ):
     """MT-Bench pipeline with preset or FastChat-original pairwise judging."""
+    run_started_at = datetime.now(UTC)
+    limit_event_tracker = LimitEventTracker()
+    prompt_preset = args.judge_prompt_preset or DEFAULT_JUDGE_PROMPT_PRESET
+    fastchat_mode = args.mt_bench_judge_mode == "fastchat_original"
+    if (
+        fastchat_mode
+        and prompt_preset == DEFAULT_JUDGE_PROMPT_PRESET
+        and not args.provide_explanation
+    ):
+        logger.info(
+            "MT-Bench ignores provide_explanation=False and keeps the original "
+            "FastChat-style explanation-plus-verdict prompt."
+        )
     if args.model_B is None:
         args.model_B = mt_bench_native_baseline(args.task)
     if args.model_B is None:
         raise ValueError(
             f"--model_B is required for dataset '{args.task}'; "
             "no dataset-native baseline registered."
+        )
+    if result_name is None:
+        result_name = _build_mt_bench_result_name(args, suffix="mtbench")
+    if res_folder is None:
+        res_folder = Path(args.result_folder) / result_name
+        res_folder.mkdir(parents=True, exist_ok=True)
+    if fastchat_mode and args.max_out_tokens_judge < _MIN_MT_BENCH_JUDGE_TOKENS:
+        logger.warning(
+            "MT-Bench judge prompts request an explanation before the final "
+            "verdict; max_out_tokens_judge=%s may be too small "
+            "(recommended >= %s).",
+            args.max_out_tokens_judge,
+            _MIN_MT_BENCH_JUDGE_TOKENS,
         )
     questions_df = load_instructions("mt-bench", n_instructions=args.n_instructions)
     logger.info(
@@ -235,19 +446,60 @@ def run_mt_bench(
         args=args,
         questions_df=questions_df,
         ignore_cache=ignore_cache,
+        limit_event_tracker=limit_event_tracker,
     )
-    prompt_preset = args.judge_prompt_preset or DEFAULT_JUDGE_PROMPT_PRESET
-    fastchat_mode = args.mt_bench_judge_mode == "fastchat_original"
+    if args.skip_judging:
+        res_folder.mkdir(parents=True, exist_ok=True)
+        with open(res_folder / f"args-{result_name}.json", "w") as f:
+            json.dump(_to_jsonable(asdict(args)), f, indent=2, allow_nan=False)
+        generation_summary = {
+            "task": args.task,
+            "model_A": args.model_A,
+            "model_B": args.model_B,
+            "judge_model": args.judge_model,
+            "judge_prompt_preset": prompt_preset,
+            "mt_bench_judge_mode": args.mt_bench_judge_mode,
+            "n_instructions": args.n_instructions
+            if args.n_instructions is not None
+            else len(questions_df),
+            "battle_thinking_token_budget": args.battle_thinking_token_budget,
+            "strip_thinking_before_judging": args.strip_thinking_before_judging,
+            "limit_events": limit_event_tracker.build_summary(),
+            "skip_judging": True,
+        }
+        with open(res_folder / f"gen-results-{result_name}.json", "w") as f:
+            json.dump(_to_jsonable(generation_summary), f, indent=2, allow_nan=False)
+        logger.info(
+            "skip_judging=True: wrote gen-results-%s.json and returning before judge model construction.",
+            result_name,
+        )
+        return None
+    if fastchat_mode and (
+        args.max_judge_model_len is not None
+        and args.max_judge_model_len < _MIN_MT_BENCH_JUDGE_MAX_MODEL_LEN
+    ):
+        logger.warning(
+            "MT-Bench judge prompts request an explanation before the final "
+            "verdict; max_judge_model_len=%s may be too small for prompt plus "
+            "completion (recommended >= %s).",
+            args.max_judge_model_len,
+            _MIN_MT_BENCH_JUDGE_MAX_MODEL_LEN,
+        )
     judge_model_kwargs = {
         "model": args.judge_model,
         "max_tokens": args.max_out_tokens_judge,
         "max_model_len": args.max_judge_model_len,
         "chat_template": args.chat_template,
-        **{**args.engine_kwargs, **args.judge_engine_kwargs},
+        **_build_mt_bench_judge_model_kwargs(
+            args=args,
+            limit_event_tracker=limit_event_tracker,
+        ),
     }
     if fastchat_mode:
         judge_model_kwargs["temperature"] = 0.0
-    judge_chat_model = make_model(**judge_model_kwargs)
+    judge_chat_model = make_model(
+        **judge_model_kwargs,
+    )
     runner = _run_mt_bench_fastchat if fastchat_mode else _run_mt_bench_preset
     return runner(
         args=args,
@@ -258,4 +510,6 @@ def run_mt_bench(
         completions_b=completions_b,
         judge_chat_model=judge_chat_model,
         prompt_preset=prompt_preset,
+        limit_event_tracker=limit_event_tracker,
+        started_at_utc=run_started_at,
     )

--- a/judgearena/mt_bench/preset_judging.py
+++ b/judgearena/mt_bench/preset_judging.py
@@ -7,18 +7,34 @@ from typing import Any
 import pandas as pd
 from langchain_core.prompts import ChatPromptTemplate
 
-from judgearena.evaluate import PairScore
+from judgearena.evaluate import (
+    _PREFLIGHT_MAX_ITERATIONS,
+    _PREFLIGHT_MIN_COMPLETION_CHARS,
+    _PREFLIGHT_RESERVED_TOKENS,
+    PairScore,
+    _chars_per_token,
+    _count_chat_tokens,
+    _find_token_overflows,
+)
 from judgearena.judge_prompt_presets import (
     DEFAULT_JUDGE_PROMPT_PRESET,
     ResolvedJudgePrompt,
     resolve_pairwise_judge_prompt,
 )
+from judgearena.log import get_logger
 from judgearena.mt_bench.common import (
     MT_BENCH_REFERENCE_CATEGORIES,
     iter_mt_bench_pairwise_rows,
 )
 from judgearena.mt_bench.prompt_templates import build_mt_bench_user_prompt_template
-from judgearena.utils import do_inference
+from judgearena.utils import (
+    LimitEventTracker,
+    do_inference,
+    strip_thinking_tags_with_metadata,
+    truncate_with_metadata,
+)
+
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -127,19 +143,116 @@ def _build_chat_prompt_template(prompt: MTBenchPresetPrompt) -> ChatPromptTempla
     return ChatPromptTemplate.from_messages(message_templates)
 
 
+def _answer_field_names(prompt: MTBenchPresetPrompt) -> tuple[str, ...]:
+    if prompt.multi_turn:
+        return ("answer_a_1", "answer_a_2", "answer_b_1", "answer_b_2")
+    return ("answer_a", "answer_b")
+
+
+def _truncation_flag_name(field: str) -> str:
+    if field == "answer_a":
+        return "answer_a_1_truncated"
+    if field == "answer_b":
+        return "answer_b_1_truncated"
+    return f"{field}_truncated"
+
+
+def _preflight_prompt_group_to_judge_budget(
+    *,
+    prompt_template: ChatPromptTemplate,
+    prompt_kwargs_batch: list[dict[str, str]],
+    batch_items: list[dict[str, Any]],
+    judge_tokenizer: Any,
+    max_judge_model_len: int,
+    max_out_tokens_judge: int | None,
+    limit_event_tracker: LimitEventTracker | None,
+) -> list[Any]:
+    prompt_inputs = prompt_template.batch(prompt_kwargs_batch)
+    safe_budget = (
+        max_judge_model_len - (max_out_tokens_judge or 0) - _PREFLIGHT_RESERVED_TOKENS
+    )
+
+    for _ in range(_PREFLIGHT_MAX_ITERATIONS):
+        overflows = _find_token_overflows(prompt_inputs, judge_tokenizer, safe_budget)
+        if not overflows:
+            return prompt_inputs
+
+        for idx, _token_count in overflows:
+            prompt_kwargs = prompt_kwargs_batch[idx]
+            item = batch_items[idx]
+            answer_fields = item["answer_fields"]
+            if not answer_fields:
+                continue
+
+            empty_kwargs = dict(prompt_kwargs)
+            for field in answer_fields:
+                empty_kwargs[field] = ""
+            fixed_tokens = _count_chat_tokens(
+                prompt_template.invoke(empty_kwargs),
+                judge_tokenizer,
+            )
+            per_answer_budget = max(
+                256, (safe_budget - fixed_tokens) // len(answer_fields)
+            )
+
+            for field in answer_fields:
+                prompt_kwargs[field], shrunk = truncate_with_metadata(
+                    prompt_kwargs[field],
+                    max_len=max(
+                        _PREFLIGHT_MIN_COMPLETION_CHARS,
+                        int(
+                            per_answer_budget
+                            * _chars_per_token(prompt_kwargs[field], judge_tokenizer)
+                            * 0.9
+                        ),
+                    ),
+                    tracker=limit_event_tracker,
+                    kind="judge_input_token_truncation",
+                    stage="judge_input",
+                    field=field,
+                    case_id=item["case_id"],
+                )
+                if shrunk:
+                    item["limit_flags"][_truncation_flag_name(field)] = True
+
+        prompt_inputs = prompt_template.batch(prompt_kwargs_batch)
+
+    final_overflows = _find_token_overflows(prompt_inputs, judge_tokenizer, safe_budget)
+    for idx, token_count in final_overflows:
+        if limit_event_tracker is not None:
+            limit_event_tracker.record(
+                "judge_input_token_truncation_failed",
+                stage="judge_input",
+                case_id=batch_items[idx]["case_id"],
+                original_length=token_count,
+                final_length=safe_budget,
+                note=(
+                    f"{_PREFLIGHT_MAX_ITERATIONS} shrink iterations did not "
+                    f"bring tokens under {safe_budget}; falling through to "
+                    "vLLM validation."
+                ),
+            )
+    return prompt_inputs
+
+
 def _infer_by_prompt_groups(
     *,
     judge_chat_model,
     items: list[dict[str, Any]],
     use_tqdm: bool,
     swap_answers: bool,
+    judge_tokenizer: Any | None = None,
+    max_judge_model_len: int | None = None,
+    max_out_tokens_judge: int | None = None,
 ) -> tuple[list[str], list[dict[str, str]]]:
     judgments: list[str] = [""] * len(items)
     used_prompt_kwargs: list[dict[str, str]] = [{} for _ in items]
     for idxs in _group_indices_by_prompt(items).values():
         prompt: MTBenchPresetPrompt = items[idxs[0]]["prompt"]
         prompt_template = _build_chat_prompt_template(prompt)
+
         batch_kwargs: list[dict[str, str]] = []
+        batch_items = [items[item_index] for item_index in idxs]
         for item_index in idxs:
             prompt_kwargs = dict(items[item_index]["prompt_kwargs"])
             if swap_answers:
@@ -148,7 +261,19 @@ def _infer_by_prompt_groups(
                     multi_turn=prompt.multi_turn,
                 )
             batch_kwargs.append(prompt_kwargs)
-        prompt_inputs = prompt_template.batch(batch_kwargs)
+
+        if judge_tokenizer is not None and max_judge_model_len is not None:
+            prompt_inputs = _preflight_prompt_group_to_judge_budget(
+                prompt_template=prompt_template,
+                prompt_kwargs_batch=batch_kwargs,
+                batch_items=batch_items,
+                judge_tokenizer=judge_tokenizer,
+                max_judge_model_len=max_judge_model_len,
+                max_out_tokens_judge=max_out_tokens_judge,
+                limit_event_tracker=items[idxs[0]].get("limit_event_tracker"),
+            )
+        else:
+            prompt_inputs = prompt_template.batch(batch_kwargs)
         outputs = do_inference(
             chat_model=judge_chat_model,
             inputs=prompt_inputs,
@@ -172,8 +297,43 @@ def _build_mt_bench_preset_items(
     truncate_input_chars: int | None,
     prompt_preset: str,
     provide_explanation: bool,
+    strip_thinking_before_judging: bool,
+    limit_event_tracker: LimitEventTracker | None,
 ) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
+    truncated_field_count = 0
+
+    def _record_mt_bench_truncation(
+        *,
+        case_id: str,
+        field: str,
+        truncated: bool,
+    ) -> None:
+        nonlocal truncated_field_count
+        if truncated and limit_event_tracker is not None:
+            limit_event_tracker.record(
+                "judge_input_char_truncation",
+                stage="judge_input",
+                field=field,
+                case_id=case_id,
+            )
+        truncated_field_count += int(truncated)
+
+    def _prepare_answer(answer: str, *, case_id: str, field: str) -> tuple[str, bool]:
+        if not strip_thinking_before_judging:
+            return answer, False
+        stripped_answer, stripped = strip_thinking_tags_with_metadata(answer)
+        if stripped and limit_event_tracker is not None:
+            limit_event_tracker.record(
+                "thinking_trace_stripped_before_judging",
+                stage="judge_input",
+                field=field,
+                case_id=case_id,
+                original_length=len(answer),
+                final_length=len(stripped_answer),
+            )
+        return stripped_answer, stripped
+
     for pair_row in iter_mt_bench_pairwise_rows(
         questions=questions,
         completions_a=completions_a,
@@ -189,13 +349,51 @@ def _build_mt_bench_preset_items(
                 prompt_preset=prompt_preset,
                 provide_explanation=provide_explanation,
             )
+            answer_a, answer_a_stripped = _prepare_answer(
+                pair_row.answer_a_1,
+                case_id=case_id,
+                field="answer_a_1",
+            )
+            answer_b, answer_b_stripped = _prepare_answer(
+                pair_row.answer_b_1,
+                case_id=case_id,
+                field="answer_b_1",
+            )
+            _record_mt_bench_truncation(
+                case_id=case_id,
+                field="turn_1_question",
+                truncated=pair_row.turn_1_question_truncated,
+            )
+            _record_mt_bench_truncation(
+                case_id=case_id,
+                field="answer_a_1",
+                truncated=pair_row.answer_a_1_truncated,
+            )
+            _record_mt_bench_truncation(
+                case_id=case_id,
+                field="answer_b_1",
+                truncated=pair_row.answer_b_1_truncated,
+            )
             prompt_kwargs: dict[str, str] = {
                 "question": pair_row.turn_1_question,
-                "answer_a": pair_row.answer_a_1,
-                "answer_b": pair_row.answer_b_1,
+                "answer_a": answer_a,
+                "answer_b": answer_b,
+            }
+            limit_flags = {
+                "turn_1_question_truncated": pair_row.turn_1_question_truncated,
+                "answer_a_1_truncated": pair_row.answer_a_1_truncated,
+                "answer_b_1_truncated": pair_row.answer_b_1_truncated,
+                "answer_a_1_reasoning_stripped": answer_a_stripped,
+                "answer_b_1_reasoning_stripped": answer_b_stripped,
             }
             if prompt.ref_based:
+                _record_mt_bench_truncation(
+                    case_id=case_id,
+                    field="ref_1",
+                    truncated=pair_row.ref_1_truncated,
+                )
                 prompt_kwargs["ref_answer_1"] = pair_row.ref_1
+                limit_flags["ref_1_truncated"] = pair_row.ref_1_truncated
             items.append(
                 {
                     "case_id": case_id,
@@ -205,6 +403,9 @@ def _build_mt_bench_preset_items(
                     "prompt": prompt,
                     "prompt_name": prompt.name,
                     "prompt_kwargs": prompt_kwargs,
+                    "answer_fields": _answer_field_names(prompt),
+                    "limit_flags": limit_flags,
+                    "limit_event_tracker": limit_event_tracker,
                 }
             )
 
@@ -216,17 +417,74 @@ def _build_mt_bench_preset_items(
                 prompt_preset=prompt_preset,
                 provide_explanation=provide_explanation,
             )
+            answer_a_1, answer_a_1_stripped = _prepare_answer(
+                pair_row.answer_a_1,
+                case_id=case_id,
+                field="answer_a_1",
+            )
+            answer_a_2, answer_a_2_stripped = _prepare_answer(
+                pair_row.answer_a_2,
+                case_id=case_id,
+                field="answer_a_2",
+            )
+            answer_b_1, answer_b_1_stripped = _prepare_answer(
+                pair_row.answer_b_1,
+                case_id=case_id,
+                field="answer_b_1",
+            )
+            answer_b_2, answer_b_2_stripped = _prepare_answer(
+                pair_row.answer_b_2,
+                case_id=case_id,
+                field="answer_b_2",
+            )
+            for field, truncated in (
+                ("turn_1_question", pair_row.turn_1_question_truncated),
+                ("turn_2_question", pair_row.turn_2_question_truncated),
+                ("answer_a_1", pair_row.answer_a_1_truncated),
+                ("answer_a_2", pair_row.answer_a_2_truncated),
+                ("answer_b_1", pair_row.answer_b_1_truncated),
+                ("answer_b_2", pair_row.answer_b_2_truncated),
+            ):
+                _record_mt_bench_truncation(
+                    case_id=case_id,
+                    field=field,
+                    truncated=truncated,
+                )
             prompt_kwargs = {
                 "question_1": pair_row.turn_1_question,
                 "question_2": pair_row.turn_2_question,
-                "answer_a_1": pair_row.answer_a_1,
-                "answer_a_2": pair_row.answer_a_2,
-                "answer_b_1": pair_row.answer_b_1,
-                "answer_b_2": pair_row.answer_b_2,
+                "answer_a_1": answer_a_1,
+                "answer_a_2": answer_a_2,
+                "answer_b_1": answer_b_1,
+                "answer_b_2": answer_b_2,
+            }
+            limit_flags = {
+                "turn_1_question_truncated": pair_row.turn_1_question_truncated,
+                "turn_2_question_truncated": pair_row.turn_2_question_truncated,
+                "answer_a_1_truncated": pair_row.answer_a_1_truncated,
+                "answer_a_2_truncated": pair_row.answer_a_2_truncated,
+                "answer_b_1_truncated": pair_row.answer_b_1_truncated,
+                "answer_b_2_truncated": pair_row.answer_b_2_truncated,
+                "answer_a_1_reasoning_stripped": answer_a_1_stripped,
+                "answer_a_2_reasoning_stripped": answer_a_2_stripped,
+                "answer_b_1_reasoning_stripped": answer_b_1_stripped,
+                "answer_b_2_reasoning_stripped": answer_b_2_stripped,
             }
             if prompt.ref_based:
+                _record_mt_bench_truncation(
+                    case_id=case_id,
+                    field="ref_1",
+                    truncated=pair_row.ref_1_truncated,
+                )
+                _record_mt_bench_truncation(
+                    case_id=case_id,
+                    field="ref_2",
+                    truncated=pair_row.ref_2_truncated,
+                )
                 prompt_kwargs["ref_answer_1"] = pair_row.ref_1
                 prompt_kwargs["ref_answer_2"] = pair_row.ref_2
+                limit_flags["ref_1_truncated"] = pair_row.ref_1_truncated
+                limit_flags["ref_2_truncated"] = pair_row.ref_2_truncated
             items.append(
                 {
                     "case_id": case_id,
@@ -236,8 +494,17 @@ def _build_mt_bench_preset_items(
                     "prompt": prompt,
                     "prompt_name": prompt.name,
                     "prompt_kwargs": prompt_kwargs,
+                    "answer_fields": _answer_field_names(prompt),
+                    "limit_flags": limit_flags,
+                    "limit_event_tracker": limit_event_tracker,
                 }
             )
+    if truncated_field_count:
+        logger.warning(
+            "Warning: truncated %s judge inputs to %s characters before evaluation.",
+            truncated_field_count,
+            truncate_input_chars,
+        )
     return items
 
 
@@ -262,25 +529,39 @@ def judge_mt_bench_with_preset(
     use_tqdm: bool,
     prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
     provide_explanation: bool = False,
+    strip_thinking_before_judging: bool = False,
+    judge_tokenizer: Any | None = None,
+    max_judge_model_len: int | None = None,
+    max_out_tokens_judge: int | None = None,
+    limit_event_tracker: LimitEventTracker | None = None,
 ) -> tuple[pd.Series, list[dict[str, Any]], list[dict[str, object]], int]:
     assert turns_mode in ("both", "single", "multi")
     assert swap_mode in ("fixed", "both")
+
+    eval_single = turns_mode in ("both", "single")
+    eval_multi = turns_mode in ("both", "multi")
 
     items = _build_mt_bench_preset_items(
         questions=questions,
         completions_a=completions_a,
         completions_b=completions_b,
-        eval_single=turns_mode in ("both", "single"),
-        eval_multi=turns_mode in ("both", "multi"),
+        eval_single=eval_single,
+        eval_multi=eval_multi,
         truncate_input_chars=truncate_input_chars,
         prompt_preset=prompt_preset,
         provide_explanation=provide_explanation,
+        strip_thinking_before_judging=strip_thinking_before_judging,
+        limit_event_tracker=limit_event_tracker,
     )
+
     judgments, prompt_kwargs_used = _infer_by_prompt_groups(
         judge_chat_model=judge_chat_model,
         items=items,
         use_tqdm=use_tqdm,
         swap_answers=False,
+        judge_tokenizer=judge_tokenizer,
+        max_judge_model_len=max_judge_model_len,
+        max_out_tokens_judge=max_out_tokens_judge,
     )
 
     annotations: list[dict[str, Any]] = []
@@ -304,25 +585,25 @@ def judge_mt_bench_with_preset(
                 parsed_preference,
                 swapped=swapped,
             )
-            annotations.append(
-                {
-                    "question_id": item["question_id"],
-                    "category": item["category"],
-                    "turn": item["turn"],
-                    "model_A": model_b if swapped else model_a,
-                    "model_B": model_a if swapped else model_b,
-                    "judge": judge_model,
-                    "prompt_name": prompt.name,
-                    "prompt_preset": prompt.preset_name,
-                    "parser_mode": prompt.parser_mode,
-                    "system_prompt": prompt.system_prompt,
-                    "user_prompt_template": prompt.user_prompt_template,
-                    "user_prompt": prompt.user_prompt_template.format(**prompt_kwargs),
-                    "judge_completion": raw_judgment,
-                    "preference": normalized_preference,
-                    "swapped": swapped,
-                }
-            )
+            annotation_row = {
+                "question_id": item["question_id"],
+                "category": item["category"],
+                "turn": item["turn"],
+                "model_A": model_b if swapped else model_a,
+                "model_B": model_a if swapped else model_b,
+                "judge": judge_model,
+                "prompt_name": prompt.name,
+                "prompt_preset": prompt.preset_name,
+                "parser_mode": prompt.parser_mode,
+                "system_prompt": prompt.system_prompt,
+                "user_prompt_template": prompt.user_prompt_template,
+                "user_prompt": prompt.user_prompt_template.format(**prompt_kwargs),
+                "judge_completion": raw_judgment,
+                "preference": normalized_preference,
+                "swapped": swapped,
+            }
+            annotation_row.update(item.get("limit_flags", {}))
+            annotations.append(annotation_row)
             metadata.append(
                 {
                     "question_id": item["question_id"],
@@ -340,6 +621,9 @@ def judge_mt_bench_with_preset(
             items=items,
             use_tqdm=use_tqdm,
             swap_answers=True,
+            judge_tokenizer=judge_tokenizer,
+            max_judge_model_len=max_judge_model_len,
+            max_out_tokens_judge=max_out_tokens_judge,
         )
         _append_results(swapped_judgments, swapped_prompt_kwargs, swapped=True)
 

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -1,9 +1,13 @@
 import asyncio
 import os
+import re
 import time
 import warnings
+from collections import Counter
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 from huggingface_hub import snapshot_download
@@ -32,6 +36,164 @@ def _data_root_path() -> Path:
 
 data_root = _data_root_path()
 
+DEFAULT_VLLM_JUDGE_THINKING_TOKEN_BUDGET = 512
+VLLM_REASONING_START_STR = "<think>"
+VLLM_REASONING_END_STR = (
+    "I have to give the solution based on the thinking directly now.</think>"
+)
+_THINKING_MODEL_PARSER_BY_SUBSTRING = (
+    ("qwen3", "qwen3"),
+    ("smollm3", "qwen3"),
+    ("olmo-3-7b-think", "olmo3"),
+)
+
+
+def _split_model_spec(model_spec: str) -> tuple[str, str]:
+    provider, sep, model_name = model_spec.partition("/")
+    if not sep:
+        return model_spec, ""
+    return provider, model_name
+
+
+def is_thinking_model(model_name: str) -> bool:
+    """Return True for reasoning models that emit `<think>...</think>` traces.
+
+    Covers the Qwen3 family (e.g. `Qwen/Qwen3.5-9B`) and SmolLM3 (e.g.
+    `HuggingFaceTB/SmolLM3-3B`) plus `allenai/Olmo-3-7B-Think`; all emit
+    `<think>`/`</think>` traces so vLLM's budget enforcement and our
+    tag-stripping apply uniformly. Matching is case-insensitive to tolerate
+    mixed-case HF repo ids like `HuggingFaceTB/SmolLM3-3B`.
+    """
+    return _default_reasoning_parser_for_model(model_name) is not None
+
+
+def _default_reasoning_parser_for_model(model_name: str) -> str | None:
+    lowered = model_name.lower()
+    for token, reasoning_parser in _THINKING_MODEL_PARSER_BY_SUBSTRING:
+        if token in lowered:
+            return reasoning_parser
+    return None
+
+
+def build_default_judge_model_kwargs(
+    judge_model: str,
+    engine_kwargs: dict[str, object],
+    *,
+    judge_engine_kwargs_override: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Copy judge engine kwargs and add supported built-in defaults.
+
+    ``judge_engine_kwargs_override`` is layered on top of ``engine_kwargs``
+    so callers can pin judge-only tweaks (e.g. a higher tensor-parallel size
+    for a 70B judge) without poisoning the battle-model engine config, which
+    must often stay on TP=1 to dodge compile-time deadlocks on hybrid models
+    such as Qwen3.5.
+    """
+    provider, model_name = _split_model_spec(judge_model)
+    judge_model_kwargs = dict(engine_kwargs) if provider == "VLLM" else {}
+    if judge_engine_kwargs_override:
+        judge_model_kwargs.update(judge_engine_kwargs_override)
+    if provider == "VLLM":
+        if "thinking_token_budget" not in judge_model_kwargs and is_thinking_model(
+            model_name
+        ):
+            judge_model_kwargs["thinking_token_budget"] = (
+                DEFAULT_VLLM_JUDGE_THINKING_TOKEN_BUDGET
+            )
+        # FP8 weights leave little KV headroom on consumer-class GPUs; default
+        # to FP8 KV cache so judges like Skywork-70B-FP8 fit comfortably on
+        # 2x L40S at 32k context. Explicit caller overrides still win.
+        if "kv_cache_dtype" not in judge_model_kwargs and "fp8" in model_name.lower():
+            judge_model_kwargs["kv_cache_dtype"] = "fp8"
+    return judge_model_kwargs
+
+
+def _resolve_chat_template_kwargs(
+    *,
+    explicit_chat_template_kwargs: dict[str, object] | None,
+    disable_thinking: bool,
+) -> dict[str, object] | None:
+    chat_template_kwargs = dict(explicit_chat_template_kwargs or {})
+    if disable_thinking and "enable_thinking" not in chat_template_kwargs:
+        chat_template_kwargs["enable_thinking"] = False
+
+    return chat_template_kwargs or None
+
+
+@dataclass(frozen=True)
+class LimitEvent:
+    kind: str
+    stage: str
+    field: str | None = None
+    case_id: str | None = None
+    model_spec: str | None = None
+    original_length: int | None = None
+    final_length: int | None = None
+    note: str | None = None
+
+
+class LimitEventTracker:
+    def __init__(self) -> None:
+        self.events: list[LimitEvent] = []
+
+    def record(
+        self,
+        kind: str,
+        *,
+        stage: str,
+        field: str | None = None,
+        case_id: object | None = None,
+        model_spec: str | None = None,
+        original_length: int | None = None,
+        final_length: int | None = None,
+        note: str | None = None,
+    ) -> None:
+        self.events.append(
+            LimitEvent(
+                kind=kind,
+                stage=stage,
+                field=field,
+                case_id=None if case_id is None else str(case_id),
+                model_spec=model_spec,
+                original_length=original_length,
+                final_length=final_length,
+                note=note,
+            )
+        )
+
+    def build_summary(self) -> dict[str, Any]:
+        counts_by_kind: Counter[str] = Counter()
+        counts_by_stage: Counter[str] = Counter()
+        counts_by_kind_and_field: dict[str, Counter[str]] = {}
+        affected_cases_total: set[str] = set()
+        affected_cases_by_kind: dict[str, set[str]] = {}
+
+        for event in self.events:
+            counts_by_kind[event.kind] += 1
+            counts_by_stage[event.stage] += 1
+            field_key = event.field or "_all"
+            counts_by_kind_and_field.setdefault(event.kind, Counter())[field_key] += 1
+            if event.case_id is None:
+                continue
+            case_key = f"{event.stage}:{event.case_id}"
+            affected_cases_total.add(case_key)
+            affected_cases_by_kind.setdefault(event.kind, set()).add(case_key)
+
+        return {
+            "total_events": len(self.events),
+            "counts_by_kind": dict(sorted(counts_by_kind.items())),
+            "counts_by_stage": dict(sorted(counts_by_stage.items())),
+            "counts_by_kind_and_field": {
+                kind: dict(sorted(counter.items()))
+                for kind, counter in sorted(counts_by_kind_and_field.items())
+            },
+            "affected_cases_total": len(affected_cases_total),
+            "affected_cases_by_kind": {
+                kind: len(case_ids)
+                for kind, case_ids in sorted(affected_cases_by_kind.items())
+            },
+        }
+
 
 def set_langchain_cache():
     set_llm_cache(SQLiteCache(database_path=str(data_root / ".langchain.db")))
@@ -41,7 +203,7 @@ def download_hf(name: str, local_path: Path):
     local_path.mkdir(exist_ok=True, parents=True)
     # downloads the model from huggingface into `local_path` folder
     snapshot_download(
-        repo_id="geoalgo/llmjudge",
+        repo_id="judge-arena/judge-arena-dataset",
         repo_type="dataset",
         allow_patterns=f"*{name}*",
         local_dir=local_path,
@@ -113,6 +275,33 @@ def truncate(s: str, max_len: int | None = None) -> str:
     return s
 
 
+def truncate_with_metadata(
+    s: str | None,
+    max_len: int | None = None,
+    *,
+    tracker: LimitEventTracker | None = None,
+    kind: str | None = None,
+    stage: str | None = None,
+    field: str | None = None,
+    case_id: object | None = None,
+    model_spec: str | None = None,
+) -> tuple[str, bool]:
+    original = s if isinstance(s, str) else ""
+    truncated = truncate(original, max_len=max_len)
+    was_truncated = truncated != original
+    if was_truncated and tracker is not None and kind is not None and stage is not None:
+        tracker.record(
+            kind,
+            stage=stage,
+            field=field,
+            case_id=case_id,
+            model_spec=model_spec,
+            original_length=len(original),
+            final_length=len(truncated),
+        )
+    return truncated, was_truncated
+
+
 def safe_text(value: object, truncate_chars: int | None) -> str:
     """Coerce *value* to a string and optionally truncate.
 
@@ -127,17 +316,108 @@ def safe_text(value: object, truncate_chars: int | None) -> str:
     return truncate(str(value), max_len=truncate_chars)
 
 
-def do_inference(chat_model, inputs, use_tqdm: bool = False):
+def safe_text_with_metadata(
+    value: object,
+    truncate_chars: int | None,
+    *,
+    tracker: LimitEventTracker | None = None,
+    kind: str | None = None,
+    stage: str | None = None,
+    field: str | None = None,
+    case_id: object | None = None,
+    model_spec: str | None = None,
+) -> tuple[str, bool]:
+    if value is None:
+        return "", False
+    is_missing = pd.isna(value)
+    if isinstance(is_missing, bool) and is_missing:
+        return "", False
+    return truncate_with_metadata(
+        str(value),
+        max_len=truncate_chars,
+        tracker=tracker,
+        kind=kind,
+        stage=stage,
+        field=field,
+        case_id=case_id,
+        model_spec=model_spec,
+    )
+
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.IGNORECASE | re.DOTALL)
+
+
+def strip_thinking_tags(text: str | None) -> str:
+    """Remove full `<think>...</think>` blocks from raw model output."""
+    return strip_thinking_tags_with_metadata(text)[0]
+
+
+def strip_thinking_tags_with_metadata(text: str | None) -> tuple[str, bool]:
+    """Remove visible reasoning spans from raw model output."""
+    if not isinstance(text, str):
+        return "", False
+
+    cleaned = _THINK_BLOCK_RE.sub("", text)
+    if cleaned != text:
+        return cleaned.lstrip(), True
+
+    lowered = text.lower()
+    closing_tag = "</think>"
+    closing_idx = lowered.find(closing_tag)
+    if closing_idx != -1 and "<think>" not in lowered[:closing_idx]:
+        return text[closing_idx + len(closing_tag) :].lstrip(), True
+
+    forced_end_idx = text.find(VLLM_REASONING_END_STR)
+    if forced_end_idx != -1:
+        return (
+            text[forced_end_idx + len(VLLM_REASONING_END_STR) :].lstrip(),
+            True,
+        )
+
+    return text, False
+
+
+def _extract_ai_message_metadata(result: object) -> dict[str, Any]:
+    """Extract finish_reason/stop_reason from a LangChain AIMessage result.
+
+    LangChain chat models (ChatOpenAI for OpenRouter, Anthropic, etc.) return
+    AIMessage objects with a ``response_metadata`` dict. We propagate the
+    subset that downstream code consumes (finish_reason is critical: it gates
+    truncation detection in _record_generation_output_limit_events).
+    """
+    response_metadata = getattr(result, "response_metadata", None) or {}
+    finish_reason = response_metadata.get("finish_reason")
+    stop_reason = response_metadata.get("stop_reason")
+    if finish_reason is None and isinstance(result, dict):
+        finish_reason = result.get("finish_reason")
+        stop_reason = result.get("stop_reason", stop_reason)
+    return {"finish_reason": finish_reason, "stop_reason": stop_reason}
+
+
+def do_inference(
+    chat_model,
+    inputs,
+    use_tqdm: bool = False,
+    return_metadata: bool = False,
+):
     # Retries on rate-limit/server errors with exponential backoff.
     # Async path retries individual calls; batch path splits into 4^attempt chunks on failure.
     invoke_kwargs = {
         # "stop": ["```"],
         # "max_tokens": 100,
     }
+    metadata: list[dict[str, Any]] | None = None
     if use_tqdm:
         # perform inference asynchronously to be able to update tqdm, chat_model.batch does not work as it blocks until
         # all requests are received
+        # JUDGEARENA_JUDGE_MAX_CONCURRENCY caps simultaneous in-flight ainvokes
+        # (e.g. against OpenRouter). Unset = unbounded, preserving prior behaviour.
+        cap_raw = os.environ.get("JUDGEARENA_JUDGE_MAX_CONCURRENCY")
+        cap = int(cap_raw) if cap_raw and int(cap_raw) > 0 else None
+
         async def process_with_real_progress(chat_model, inputs, pbar):
+            sem = asyncio.Semaphore(cap) if cap else None
+
             async def process_single(input_item, max_retries=5, base_delay=1.0):
                 for attempt in range(max_retries):
                     try:
@@ -157,8 +437,14 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
                         )
                         await asyncio.sleep(delay)
 
+            async def gated(inp):
+                if sem is None:
+                    return await process_single(inp)
+                async with sem:
+                    return await process_single(inp)
+
             # asyncio.gather preserves order (unlike as_completed)
-            results = await asyncio.gather(*[process_single(inp) for inp in inputs])
+            results = await asyncio.gather(*[gated(inp) for inp in inputs])
             return results
 
         with logging_redirect_tqdm(), tqdm(total=len(inputs)) as pbar:
@@ -167,6 +453,9 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
                     chat_model=chat_model, inputs=inputs, pbar=pbar
                 )
             )
+        # Always materialize metadata; it is cheap and keeps return_metadata
+        # behavior consistent with the batch path.
+        metadata = [_extract_ai_message_metadata(r) for r in res]
     else:
 
         def batch_with_retry(batch_inputs, max_retries=5, base_delay=1.0):
@@ -179,9 +468,26 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
                 ]
                 try:
                     results = []
+                    results_metadata = []
                     for chunk in chunks:
-                        results.extend(chat_model.batch(inputs=chunk, **invoke_kwargs))
-                    return results
+                        if return_metadata and hasattr(
+                            chat_model, "batch_with_metadata"
+                        ):
+                            chunk_results, chunk_metadata = (
+                                chat_model.batch_with_metadata(
+                                    inputs=chunk, **invoke_kwargs
+                                )
+                            )
+                        else:
+                            chunk_results = chat_model.batch(
+                                inputs=chunk, **invoke_kwargs
+                            )
+                            chunk_metadata = [
+                                _extract_ai_message_metadata(r) for r in chunk_results
+                            ]
+                        results.extend(chunk_results)
+                        results_metadata.extend(chunk_metadata)
+                    return results, results_metadata
                 except Exception as e:
                     if attempt == max_retries - 1 or not _is_retryable_error(e):
                         raise
@@ -197,12 +503,14 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
                     )
                     time.sleep(delay)
 
-        res = batch_with_retry(inputs)
+        res, metadata = batch_with_retry(inputs)
 
     # Not sure why the API of Langchain returns sometime a string and sometimes an AIMessage object
     # is it because of using Chat and barebones models?
     # when using OpenAI, the output is AIMessage not a string...
     res = [x.content if hasattr(x, "content") else x for x in res]
+    if return_metadata:
+        return res, (metadata or [{} for _ in res])
     return res
 
 
@@ -219,6 +527,52 @@ class DummyModel:
 
     async def ainvoke(self, input, **invoke_kwargs):
         return self.message
+
+
+_VLLM_INIT_RETRY_SIGNATURES = (
+    "cudaErrorDevicesUnavailable",
+    "CUDA-capable device(s) is/are busy or unavailable",
+    "CUDA error: initialization error",
+)
+_VLLM_INIT_MAX_ATTEMPTS = int(os.getenv("JUDGEARENA_VLLM_INIT_MAX_ATTEMPTS", "4"))
+_VLLM_INIT_BACKOFF_SECONDS = int(
+    os.getenv("JUDGEARENA_VLLM_INIT_BACKOFF_SECONDS", "20")
+)
+
+
+def _init_llm_with_retry(llm_cls, **kwargs):
+    """Instantiate ``vllm.LLM`` with retries on transient GPU-init races.
+
+    On shared Slurm nodes with MaxGRESPerAccount throttling, freshly scheduled
+    jobs can hit ``cudaErrorDevicesUnavailable`` because the previous tenant's
+    driver cleanup has not finished when our process starts. This manifests as
+    an immediate engine-core init failure and is almost always resolved by a
+    15-30 s sleep + retry on the same GPU. We retry up to
+    ``JUDGEARENA_VLLM_INIT_MAX_ATTEMPTS`` times with exponential backoff before
+    giving up, which keeps persistent configuration errors from looping.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, _VLLM_INIT_MAX_ATTEMPTS + 1):
+        try:
+            return llm_cls(**kwargs)
+        except Exception as exc:
+            message = f"{type(exc).__name__}: {exc}"
+            if not any(sig in message for sig in _VLLM_INIT_RETRY_SIGNATURES):
+                raise
+            last_exc = exc
+            if attempt == _VLLM_INIT_MAX_ATTEMPTS:
+                break
+            delay = _VLLM_INIT_BACKOFF_SECONDS * (2 ** (attempt - 1))
+            warnings.warn(
+                f"vLLM init attempt {attempt}/{_VLLM_INIT_MAX_ATTEMPTS} failed "
+                f"with transient GPU-init signature ({message.splitlines()[0]}); "
+                f"sleeping {delay}s before retry.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            time.sleep(delay)
+    assert last_exc is not None
+    raise last_exc
 
 
 class ChatVLLM:
@@ -244,9 +598,27 @@ class ChatVLLM:
         **vllm_kwargs,
     ):
         from vllm import LLM, SamplingParams
+        from vllm.config.reasoning import ReasoningConfig
 
         self.model_path = model
         self.max_tokens = max_tokens
+        limit_event_tracker: LimitEventTracker | None = vllm_kwargs.pop(
+            "limit_event_tracker", None
+        )
+        limit_event_stage = str(vllm_kwargs.pop("limit_event_stage", "model_init"))
+        limit_event_model_spec = str(
+            vllm_kwargs.pop("limit_event_model_spec", f"VLLM/{model}")
+        )
+        disable_thinking = bool(vllm_kwargs.pop("disable_thinking", False))
+        thinking_token_budget = vllm_kwargs.pop("thinking_token_budget", None)
+        explicit_chat_template_kwargs = vllm_kwargs.pop("chat_template_kwargs", None)
+        explicit_reasoning_settings = (
+            "reasoning_parser" in vllm_kwargs or "reasoning_config" in vllm_kwargs
+        )
+        self._chat_template_kwargs = _resolve_chat_template_kwargs(
+            explicit_chat_template_kwargs=explicit_chat_template_kwargs,
+            disable_thinking=disable_thinking,
+        )
 
         # Cap max_model_len to the model's max_position_embeddings so that
         # vLLM doesn't reject an overly large context window.
@@ -258,6 +630,15 @@ class ChatVLLM:
                 config = AutoConfig.from_pretrained(model, trust_remote_code=True)
                 model_max_pos = getattr(config, "max_position_embeddings", None)
                 if model_max_pos is not None and max_model_len > model_max_pos:
+                    if limit_event_tracker is not None:
+                        limit_event_tracker.record(
+                            "max_model_len_clamped",
+                            stage=limit_event_stage,
+                            field="max_model_len",
+                            model_spec=limit_event_model_spec,
+                            original_length=int(max_model_len),
+                            final_length=int(model_max_pos),
+                        )
                     warnings.warn(
                         f"Capping max_model_len from {max_model_len} to "
                         f"{model_max_pos} (max_position_embeddings) for '{model}'.",
@@ -272,13 +653,56 @@ class ChatVLLM:
                     RuntimeWarning,
                     stacklevel=2,
                 )
+        self._sampling_params_kwargs = {
+            "max_tokens": max_tokens,
+            "temperature": float(vllm_kwargs.pop("temperature", 0.6)),
+            "top_p": float(vllm_kwargs.pop("top_p", 0.95)),
+        }
+        self._thinking_budget_marker: str | None = None
+        self._thinking_budget_value: int | None = None
+        if thinking_token_budget is not None:
+            if max_tokens is not None:
+                thinking_token_budget = min(int(thinking_token_budget), int(max_tokens))
+            if explicit_reasoning_settings:
+                self._sampling_params_kwargs["thinking_token_budget"] = int(
+                    thinking_token_budget
+                )
+                self._thinking_budget_marker = VLLM_REASONING_END_STR
+                self._thinking_budget_value = int(thinking_token_budget)
+            elif is_thinking_model(model):
+                reasoning_parser = _default_reasoning_parser_for_model(model)
+                assert reasoning_parser is not None  # guarded by is_thinking_model()
+                vllm_kwargs.setdefault(
+                    "reasoning_config",
+                    ReasoningConfig(
+                        reasoning_start_str=VLLM_REASONING_START_STR,
+                        # Keep the shared forced end marker for offline
+                        # `LLM.chat()` thinking-budget exhaustion detection.
+                        # The parser itself still varies by model family
+                        # (e.g. OLMo uses `olmo3`) on vLLM's OpenAI server.
+                        reasoning_end_str=VLLM_REASONING_END_STR,
+                    ),
+                )
+                vllm_kwargs.setdefault("reasoning_parser", reasoning_parser)
+                self._sampling_params_kwargs["thinking_token_budget"] = int(
+                    thinking_token_budget
+                )
+                self._thinking_budget_marker = VLLM_REASONING_END_STR
+                self._thinking_budget_value = int(thinking_token_budget)
+            else:
+                warnings.warn(
+                    f"Model '{model}' is not in JudgeArena's built-in thinking-model "
+                    "defaults (Qwen3/SmolLM3/Olmo-3-7B-Think). Ignoring "
+                    "thinking_token_budget unless reasoning_parser or "
+                    "reasoning_config is provided explicitly.",
+                    stacklevel=2,
+                )
+        self.sampling_params = SamplingParams(**self._sampling_params_kwargs)
 
-        self.llm = LLM(model=model, trust_remote_code=True, **vllm_kwargs)
-        self.sampling_params = SamplingParams(
-            max_tokens=max_tokens,
-            temperature=0.6,
-            top_p=0.95,
+        self.llm = _init_llm_with_retry(
+            LLM, model=model, trust_remote_code=True, **vllm_kwargs
         )
+        self.tokenizer = self.llm.get_tokenizer()
 
         # Resolve chat template:
         # 1. Explicit override always wins → use chat() with that template
@@ -289,8 +713,7 @@ class ChatVLLM:
             self._use_generate = False
             logger.info("ChatVLLM: using explicit chat template for '%s'", model)
         else:
-            tokenizer = self.llm.get_tokenizer()
-            if not getattr(tokenizer, "chat_template", None):
+            if not getattr(self.tokenizer, "chat_template", None):
                 warnings.warn(
                     f"Model '{model}' tokenizer does not define a chat template. "
                     f"Falling back to llm.generate() (no chat formatting). "
@@ -299,10 +722,22 @@ class ChatVLLM:
                 )
                 self.chat_template = None
                 self._use_generate = True
+                if disable_thinking:
+                    warnings.warn(
+                        f"Model '{model}' has no chat template, so disable_thinking "
+                        "cannot be applied when falling back to llm.generate().",
+                        stacklevel=2,
+                    )
             else:
                 self.chat_template = None  # let vLLM use the tokenizer's own
                 self._use_generate = False
                 logger.info("ChatVLLM: using tokenizer's chat template for '%s'", model)
+
+    def set_temperature(self, temperature: float) -> None:
+        from vllm import SamplingParams
+
+        self._sampling_params_kwargs["temperature"] = float(temperature)
+        self.sampling_params = SamplingParams(**self._sampling_params_kwargs)
 
     def _to_messages(self, input_item) -> list[dict]:
         """Convert LangChain prompt input to OpenAI-style messages."""
@@ -355,7 +790,7 @@ class ChatVLLM:
             return "\n".join(msg["content"] for msg in input_item)
         raise ValueError(f"Cannot extract raw text from: {type(input_item)}")
 
-    def batch(self, inputs: list, **invoke_kwargs) -> list[str]:
+    def _run_raw_batch(self, inputs: list):
         """Process a batch of inputs using vllm.LLM.chat() or llm.generate().
 
         Uses ``llm.chat()`` when a chat template is available (instruct models),
@@ -371,8 +806,39 @@ class ChatVLLM:
                 self.sampling_params,
                 add_generation_prompt=True,
                 chat_template=self.chat_template,
+                chat_template_kwargs=self._chat_template_kwargs,
             )
-        return [out.outputs[0].text for out in outputs]
+        return outputs
+
+    def batch_with_metadata(
+        self, inputs: list, **invoke_kwargs
+    ) -> tuple[list[str], list[dict[str, Any]]]:
+        outputs = self._run_raw_batch(inputs)
+        texts: list[str] = []
+        metadata: list[dict[str, Any]] = []
+        marker = self._thinking_budget_marker
+        for out in outputs:
+            first_output = out.outputs[0]
+            text = first_output.text
+            texts.append(text)
+            row: dict[str, Any] = {
+                "finish_reason": getattr(first_output, "finish_reason", None),
+                "stop_reason": getattr(first_output, "stop_reason", None),
+            }
+            if marker is not None:
+                # vLLM emits the forced reasoning-end marker verbatim when the
+                # per-request thinking-token budget is exhausted; the marker is
+                # absent otherwise. Detecting it here gives
+                # `_record_generation_output_limit_events` a deterministic
+                # signal to log a `generation_thinking_token_budget` event.
+                row["thinking_budget_exhausted"] = marker in text
+                row["thinking_token_budget"] = self._thinking_budget_value
+            metadata.append(row)
+        return texts, metadata
+
+    def batch(self, inputs: list, **invoke_kwargs) -> list[str]:
+        texts, _metadata = self.batch_with_metadata(inputs, **invoke_kwargs)
+        return texts
 
     def invoke(self, input_item, **invoke_kwargs) -> str:
         """Process a single input."""
@@ -402,29 +868,49 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
     # NOTE: this is a shallow copy since we are not modifying any
     # mutable objects in the dictionary.
     engine_kwargs = engine_kwargs.copy()
+    limit_event_tracker = engine_kwargs.pop("limit_event_tracker", None)
+    limit_event_stage = engine_kwargs.pop("limit_event_stage", None)
+    limit_event_model_spec = engine_kwargs.pop("limit_event_model_spec", None)
 
     # Dedicated arguments like max_tokens always win over engine_kwargs.
     engine_kwargs["max_tokens"] = max_tokens or 8192
 
-    model_provider = model.split("/")[0]
+    model_provider, model_name = _split_model_spec(model)
 
     # vLLM-engine-only kwargs must not leak to remote-API providers
     # (OpenRouter, OpenAI, Together): langchain-openai forwards unknown
     # kwargs via model_kwargs into chat.completions.create, which rejects them.
     if model_provider != "VLLM":
-        engine_kwargs.pop("max_model_len", None)
-        engine_kwargs.pop("chat_template", None)
+        for key in (
+            "max_model_len",
+            "chat_template",
+            "language_model_only",
+            "gpu_memory_utilization",
+            "enforce_eager",
+            "tensor_parallel_size",
+            "quantization",
+            "kv_cache_dtype",
+            "reasoning_parser",
+            "reasoning_config",
+            "trust_remote_code",
+        ):
+            engine_kwargs.pop(key, None)
 
     if model_provider == "Dummy":
         return DummyModel(model)
 
-    model_name = "/".join(model.split("/")[1:])
     logger.info("Loading %s(model=%s)", model_provider, model_name)
 
     # Use our custom ChatVLLM wrapper which properly applies chat templates
     if model_provider == "VLLM":
         engine_kwargs = {k: v for k, v in engine_kwargs.items() if v is not None}
         engine_kwargs["chat_template"] = engine_kwargs.get("chat_template", None)
+        if limit_event_tracker is not None:
+            engine_kwargs["limit_event_tracker"] = limit_event_tracker
+        if limit_event_stage is not None:
+            engine_kwargs["limit_event_stage"] = limit_event_stage
+        if limit_event_model_spec is not None:
+            engine_kwargs["limit_event_model_spec"] = limit_event_model_spec
 
         return ChatVLLM(
             model=model_name,
@@ -468,16 +954,33 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
         return model_cls_dict[model_provider](**engine_kwargs)
 
 
+def infer_model_spec_from_instance(model: object) -> str | None:
+    if isinstance(model, DummyModel):
+        return model.name
+    if isinstance(model, ChatVLLM):
+        return f"VLLM/{model.model_path}"
+    if isinstance(model, LlamaCpp):
+        model_path = getattr(model, "model_path", None)
+        if isinstance(model_path, str):
+            return f"LlamaCpp/{model_path}"
+    model_name = getattr(model, "model_name", None) or getattr(model, "model", None)
+    if isinstance(model_name, str):
+        return f"{model.__class__.__name__}/{model_name}"
+    return None
+
+
 def download_all():
+    from judgearena.instruction_dataset.m_arenahard import M_ARENA_HARD_BASELINES
+
     logger.info("Downloading all datasets in %s", data_root)
     local_path_tables = data_root / "tables"
-    for dataset in [
+    datasets = [
         "alpaca-eval",
         "arena-hard-v0.1",
         "arena-hard-v2.0",
-        "m-arena-hard-v0.1",
-        "m-arena-hard-v2.0",
-    ]:
+        *M_ARENA_HARD_BASELINES.keys(),
+    ]
+    for dataset in datasets:
         if is_arena_hard_dataset(dataset):
             download_arena_hard(dataset=dataset, local_tables_path=local_path_tables)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,23 @@ dev = [
     "ruff>=0.11.0",
     "slurmpilot @ git+https://github.com/geoalgo/slurmpilot.git@main",
 ]
+# `llmcompressor` pins older `compressed-tensors` / `transformers` that clash
+# with the `vllm` extra (vLLM 0.19.1 pulls `compressed-tensors==0.15.0.1` and
+# `transformers>=5.5.1` for Gemma-4). Keep it available under its own group so
+# quantization workflows can still install it, but mark it mutually exclusive
+# with the `vllm` extra via `[tool.uv] conflicts` so the universal lock can
+# still resolve both sides.
+quantize = [
+    "llmcompressor>=0.4.0",
+]
+
+[tool.uv]
+conflicts = [
+    [
+        { extra = "vllm" },
+        { group = "quantize" },
+    ],
+]
 
 [tool.ruff]
 target-version = "py312"
@@ -80,5 +97,14 @@ quote-style = "double"
 indent-style = "space"
 
 [project.optional-dependencies]
-vllm = ["vllm==0.10.2", "transformers>=4.55.2,<5.0.0"]
+# vLLM 0.19.1 is the pinned judge/battle runtime on this branch. Its own
+# Requires-Dist is `transformers!=5.0.*,...,!=5.5.0,>=4.56.0`, so the
+# only sub-range >=5.x that vLLM 0.19.1 accepts is >=5.5.1 — hence the
+# lower bound here. Qwen3.5 loading works under either 4.56.x or 5.5.x
+# because vLLM ships its own `qwen3_5` config shim and model impl and
+# registers them into `AutoConfig` at runtime.
+vllm = [
+    "vllm>=0.19.1,<1.0.0",
+    "transformers>=5.5.1,<6.0.0",
+]
 llamacpp = ["llama-cpp-python>=0.3.0"]

--- a/tests/test_chat_vllm.py
+++ b/tests/test_chat_vllm.py
@@ -1,0 +1,334 @@
+import sys
+from types import SimpleNamespace
+
+import judgearena.utils as utils
+
+
+def _install_fake_vllm(monkeypatch):
+    captured = {}
+
+    class FakeSamplingParams:
+        def __init__(self, **kwargs):
+            captured["sampling_kwargs"] = kwargs
+
+    class FakeReasoningConfig:
+        def __init__(self, **kwargs):
+            captured["reasoning_config_kwargs"] = kwargs
+
+    class FakeLLM:
+        def __init__(self, *, model, trust_remote_code, **kwargs):
+            captured["llm_init"] = {
+                "model": model,
+                "trust_remote_code": trust_remote_code,
+                "kwargs": kwargs,
+            }
+
+        def get_tokenizer(self):
+            return SimpleNamespace(chat_template="{{ messages }}")
+
+        def chat(self, messages, sampling_params, **kwargs):
+            captured["chat_call"] = {
+                "messages": messages,
+                "sampling_params": sampling_params,
+                "kwargs": kwargs,
+            }
+            return [SimpleNamespace(outputs=[SimpleNamespace(text="ok")])]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm",
+        SimpleNamespace(LLM=FakeLLM, SamplingParams=FakeSamplingParams),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.config.reasoning",
+        SimpleNamespace(ReasoningConfig=FakeReasoningConfig),
+    )
+    return captured, FakeReasoningConfig
+
+
+def test_chat_vllm_enables_reasoning_support_for_qwen_thinking_budget(monkeypatch):
+    captured, fake_reasoning_config = _install_fake_vllm(monkeypatch)
+
+    utils.ChatVLLM(
+        model="Qwen/Qwen3.5-9B",
+        max_tokens=128,
+        thinking_token_budget=64,
+        gpu_memory_utilization=0.7,
+    )
+
+    assert captured["sampling_kwargs"]["thinking_token_budget"] == 64
+    assert "structured_outputs" not in captured["sampling_kwargs"]
+    assert captured["reasoning_config_kwargs"] == {
+        "reasoning_start_str": utils.VLLM_REASONING_START_STR,
+        "reasoning_end_str": utils.VLLM_REASONING_END_STR,
+    }
+    llm_kwargs = captured["llm_init"]["kwargs"]
+    assert llm_kwargs["reasoning_parser"] == "qwen3"
+    assert isinstance(llm_kwargs["reasoning_config"], fake_reasoning_config)
+
+
+def test_chat_vllm_enables_reasoning_support_for_smollm3_thinking_budget(monkeypatch):
+    captured, fake_reasoning_config = _install_fake_vllm(monkeypatch)
+
+    utils.ChatVLLM(
+        model="HuggingFaceTB/SmolLM3-3B",
+        max_tokens=128,
+        thinking_token_budget=64,
+        gpu_memory_utilization=0.7,
+    )
+
+    assert captured["sampling_kwargs"]["thinking_token_budget"] == 64
+    assert captured["reasoning_config_kwargs"] == {
+        "reasoning_start_str": utils.VLLM_REASONING_START_STR,
+        "reasoning_end_str": utils.VLLM_REASONING_END_STR,
+    }
+    llm_kwargs = captured["llm_init"]["kwargs"]
+    assert llm_kwargs["reasoning_parser"] == "qwen3"
+    assert isinstance(llm_kwargs["reasoning_config"], fake_reasoning_config)
+
+
+def test_chat_vllm_uses_olmo3_reasoning_parser_for_olmo_think(monkeypatch):
+    captured, fake_reasoning_config = _install_fake_vllm(monkeypatch)
+
+    utils.ChatVLLM(
+        model="allenai/Olmo-3-7B-Think",
+        max_tokens=128,
+        thinking_token_budget=64,
+        gpu_memory_utilization=0.7,
+    )
+
+    assert captured["sampling_kwargs"]["thinking_token_budget"] == 64
+    assert captured["reasoning_config_kwargs"] == {
+        "reasoning_start_str": utils.VLLM_REASONING_START_STR,
+        "reasoning_end_str": utils.VLLM_REASONING_END_STR,
+    }
+    llm_kwargs = captured["llm_init"]["kwargs"]
+    assert llm_kwargs["reasoning_parser"] == "olmo3"
+    assert isinstance(llm_kwargs["reasoning_config"], fake_reasoning_config)
+
+
+def test_chat_vllm_clamps_thinking_budget_to_total_max_tokens(monkeypatch):
+    captured, _fake_reasoning_config = _install_fake_vllm(monkeypatch)
+
+    utils.ChatVLLM(
+        model="Qwen/Qwen3.5-9B",
+        max_tokens=32,
+        thinking_token_budget=64,
+        gpu_memory_utilization=0.7,
+    )
+
+    assert captured["sampling_kwargs"]["thinking_token_budget"] == 32
+
+
+def test_chat_vllm_passes_disable_thinking_via_chat_template_kwargs(monkeypatch):
+    captured, _fake_reasoning_config = _install_fake_vllm(monkeypatch)
+    chat_model = utils.ChatVLLM(
+        model="Qwen/Qwen3.5-9B",
+        max_tokens=16,
+        disable_thinking=True,
+        gpu_memory_utilization=0.7,
+    )
+
+    outputs = chat_model.batch(["hello"])
+
+    assert outputs == ["ok"]
+    assert captured["chat_call"]["kwargs"]["chat_template_kwargs"] == {
+        "enable_thinking": False
+    }
+
+
+def test_build_default_judge_model_kwargs_only_defaults_qwen_judges():
+    assert utils.build_default_judge_model_kwargs(
+        "VLLM/Qwen/Qwen3.5-9B",
+        {"gpu_memory_utilization": 0.7},
+    ) == {
+        "gpu_memory_utilization": 0.7,
+        "thinking_token_budget": 512,
+    }
+    assert utils.build_default_judge_model_kwargs(
+        "VLLM/allenai/Olmo-3-7B-Think",
+        {"gpu_memory_utilization": 0.7},
+    ) == {
+        "gpu_memory_utilization": 0.7,
+        "thinking_token_budget": 512,
+    }
+    assert utils.build_default_judge_model_kwargs(
+        "VLLM/meta-llama/Llama-3.3-70B-Instruct",
+        {"gpu_memory_utilization": 0.7},
+    ) == {"gpu_memory_utilization": 0.7}
+    assert (
+        utils.build_default_judge_model_kwargs(
+            "OpenRouter/qwen/qwen3-32b",
+            {},
+        )
+        == {}
+    )
+    assert (
+        utils.build_default_judge_model_kwargs(
+            "OpenRouter/google/gemma-4-31b-it",
+            {
+                "language_model_only": True,
+                "gpu_memory_utilization": 0.9,
+                "enforce_eager": True,
+            },
+        )
+        == {}
+    )
+
+
+def test_build_default_judge_model_kwargs_sets_fp8_kv_cache_for_fp8_judges():
+    fp8_defaults = utils.build_default_judge_model_kwargs(
+        "VLLM/Skywork/Skywork-Critic-Llama-3.1-70B-FP8",
+        {"gpu_memory_utilization": 0.9},
+    )
+    assert fp8_defaults["kv_cache_dtype"] == "fp8"
+    # FP8 Skywork judge is not Qwen3/SmolLM3 so no thinking-token default.
+    assert "thinking_token_budget" not in fp8_defaults
+
+    bf16_defaults = utils.build_default_judge_model_kwargs(
+        "VLLM/Skywork/Skywork-Critic-Llama-3.1-8B",
+        {"gpu_memory_utilization": 0.9},
+    )
+    assert "kv_cache_dtype" not in bf16_defaults
+
+    explicit_override = utils.build_default_judge_model_kwargs(
+        "VLLM/Skywork/Skywork-Critic-Llama-3.1-70B-FP8",
+        {"gpu_memory_utilization": 0.9, "kv_cache_dtype": "bfloat16"},
+    )
+    assert explicit_override["kv_cache_dtype"] == "bfloat16"
+
+    # Non-VLLM providers never receive the FP8 KV default even if the name
+    # happens to contain "fp8".
+    non_vllm = utils.build_default_judge_model_kwargs("OpenRouter/some/Model-fp8", {})
+    assert "kv_cache_dtype" not in non_vllm
+
+
+def test_build_default_judge_model_kwargs_overlays_judge_override():
+    """Judge-scoped overrides must win over shared ``engine_kwargs`` so the
+    battle engine can stay on TP=1 while the 70B FP8 judge pins TP=2."""
+    merged = utils.build_default_judge_model_kwargs(
+        "VLLM/Skywork/Skywork-Critic-Llama-3.1-70B-FP8",
+        {"gpu_memory_utilization": 0.9},
+        judge_engine_kwargs_override={"tensor_parallel_size": 2},
+    )
+    assert merged["tensor_parallel_size"] == 2
+    assert merged["gpu_memory_utilization"] == 0.9
+    assert merged["kv_cache_dtype"] == "fp8"
+
+    overridden = utils.build_default_judge_model_kwargs(
+        "VLLM/Skywork/Skywork-Critic-Llama-3.1-70B-FP8",
+        {"tensor_parallel_size": 1, "gpu_memory_utilization": 0.9},
+        judge_engine_kwargs_override={"tensor_parallel_size": 4},
+    )
+    assert overridden["tensor_parallel_size"] == 4
+    # FP8 weights + FP8 KV cache are a name-driven invariant; the TP override
+    # must not silently drop `kv_cache_dtype=fp8` because we run the Skywork
+    # 70B FP8 judge on TP=2 and TP=4 interchangeably depending on the cell.
+    assert overridden["kv_cache_dtype"] == "fp8"
+
+    empty_override = utils.build_default_judge_model_kwargs(
+        "VLLM/Skywork/Skywork-Critic-Llama-3.1-70B-FP8",
+        {"tensor_parallel_size": 1},
+        judge_engine_kwargs_override={},
+    )
+    assert empty_override["tensor_parallel_size"] == 1
+
+
+def test_is_thinking_model_matches_qwen3_and_smollm3_repo_ids():
+    assert utils.is_thinking_model("Qwen/Qwen3.5-9B")
+    assert utils.is_thinking_model("HuggingFaceTB/SmolLM3-3B")
+    assert utils.is_thinking_model("Qwen/Qwen3-7B")
+    assert utils.is_thinking_model("allenai/Olmo-3-7B-Think")
+    assert not utils.is_thinking_model("Qwen/Qwen2.5-7B")
+    assert not utils.is_thinking_model("allenai/Olmo-3-7B-Instruct")
+    assert not utils.is_thinking_model("CohereLabs/tiny-aya-global")
+    assert not utils.is_thinking_model("utter-project/EuroLLM-9B-Instruct")
+    assert not utils.is_thinking_model("meta-llama/Llama-3.1-8B")
+
+
+def test_chat_vllm_preserves_explicit_reasoning_settings_for_non_qwen(monkeypatch):
+    captured, _fake_reasoning_config = _install_fake_vllm(monkeypatch)
+    explicit_reasoning_config = object()
+
+    utils.ChatVLLM(
+        model="meta-llama/Llama-3.3-70B-Instruct",
+        max_tokens=16,
+        thinking_token_budget=32,
+        reasoning_parser="custom-parser",
+        reasoning_config=explicit_reasoning_config,
+        gpu_memory_utilization=0.7,
+    )
+
+    assert captured["sampling_kwargs"]["thinking_token_budget"] == 16
+    assert captured["llm_init"]["kwargs"]["reasoning_parser"] == "custom-parser"
+    assert (
+        captured["llm_init"]["kwargs"]["reasoning_config"] is explicit_reasoning_config
+    )
+
+
+def test_chat_vllm_records_thinking_budget_exhaustion_metadata(monkeypatch):
+    captured, _fake_reasoning_config = _install_fake_vllm(monkeypatch)
+
+    class FakeLLMWithMarker:
+        def __init__(self, *, model, trust_remote_code, **kwargs):
+            captured["llm_init"] = {"model": model, "kwargs": kwargs}
+
+        def get_tokenizer(self):
+            return SimpleNamespace(chat_template="{{ messages }}")
+
+        def chat(self, messages, sampling_params, **kwargs):
+            return [
+                SimpleNamespace(
+                    outputs=[
+                        SimpleNamespace(
+                            text=f"pre {utils.VLLM_REASONING_END_STR} answer",
+                            finish_reason="stop",
+                            stop_reason=None,
+                        )
+                    ]
+                ),
+                SimpleNamespace(
+                    outputs=[
+                        SimpleNamespace(
+                            text="clean answer",
+                            finish_reason="stop",
+                            stop_reason=None,
+                        )
+                    ]
+                ),
+            ]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm",
+        SimpleNamespace(
+            LLM=FakeLLMWithMarker,
+            SamplingParams=sys.modules["vllm"].SamplingParams,
+        ),
+    )
+
+    chat_model = utils.ChatVLLM(
+        model="Qwen/Qwen3.5-9B",
+        max_tokens=64,
+        thinking_token_budget=32,
+        gpu_memory_utilization=0.7,
+    )
+    _texts, metadata = chat_model.batch_with_metadata(["a", "b"])
+
+    assert metadata[0]["thinking_budget_exhausted"] is True
+    assert metadata[0]["thinking_token_budget"] == 32
+    assert metadata[1]["thinking_budget_exhausted"] is False
+    assert metadata[1]["thinking_token_budget"] == 32
+
+
+def test_chat_vllm_omits_thinking_budget_metadata_without_budget(monkeypatch):
+    _captured, _fake_reasoning_config = _install_fake_vllm(monkeypatch)
+
+    chat_model = utils.ChatVLLM(
+        model="Qwen/Qwen3.5-9B",
+        max_tokens=64,
+        gpu_memory_utilization=0.7,
+    )
+    assert chat_model._thinking_budget_marker is None
+    assert chat_model._thinking_budget_value is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def capture_mains(monkeypatch):
     [
         "alpaca-eval",
         "arena-hard-v2.0",
-        "m-arena-hard-v2.0-EU",
+        "m-arena-hard-EU",
         "fluency-french",
         "mt-bench",
     ],
@@ -108,7 +108,11 @@ def test_dataset_flag_is_deprecated_alias(capture_mains):
 
 
 def test_arena_flag_is_deprecated_alias_lowercases(capture_mains):
-    """`--arena ComparIA` must still route to the ComparIA ELO path."""
+    """`--arena ComparIA` must still route to the ComparIA ELO path.
+
+    The deprecated path is allowed to be case-insensitive because that was the
+    historical contract for ``judgearena-elo --arena LMArena-140k``.
+    """
     with pytest.warns(DeprecationWarning, match="--arena is deprecated"):
         cli_module.cli(
             [
@@ -122,6 +126,38 @@ def test_arena_flag_is_deprecated_alias_lowercases(capture_mains):
         )
     assert capture_mains["module"] == "elo"
     assert capture_mains["args"].arena == "ComparIA"
+
+
+def test_model_flag_is_deprecated_alias(capture_mains):
+    with pytest.warns(DeprecationWarning, match="--model is deprecated"):
+        cli_module.cli(
+            [
+                "--task",
+                "elo-comparia",
+                "--model",
+                "Dummy/X",
+                "--judge",
+                "Dummy/J",
+            ]
+        )
+    assert capture_mains["module"] == "elo"
+    assert capture_mains["args"].model == "Dummy/X"
+
+
+def test_model_and_model_a_collide_raises(capture_mains):
+    with pytest.raises(SystemExit, match="exactly one of --model_A/--model"):
+        cli_module.cli(
+            [
+                "--task",
+                "elo-comparia",
+                "--model",
+                "Dummy/X",
+                "--model_A",
+                "Dummy/Y",
+                "--judge",
+                "Dummy/J",
+            ]
+        )
 
 
 def test_missing_task_raises(capture_mains):
@@ -230,9 +266,7 @@ def test_pairwise_task_without_native_baseline_requires_model_a_and_b(capture_ma
     "task",
     [
         "alpaca-eval",
-        "arena-hard-v0.1",
         "m-arena-hard-v2.0-EU",
-        "mt-bench",
     ],
 )
 def test_pairwise_task_allows_missing_model_b_when_native_baseline_exists(
@@ -253,6 +287,26 @@ def test_pairwise_task_allows_missing_model_b_when_native_baseline_exists(
     assert ge_args.task == task
     assert ge_args.model_A == "Dummy/A"
     assert ge_args.model_B is None
+
+
+def test_deprecated_model_flag_routes_into_pairwise_task(capture_mains):
+    """`--model` is a deprecated alias for `--model_A` even on pairwise tasks."""
+    with pytest.warns(DeprecationWarning, match="--model is deprecated"):
+        cli_module.cli(
+            [
+                "--task",
+                "alpaca-eval",
+                "--model",
+                "Dummy/A",
+                "--model_B",
+                "Dummy/B",
+                "--judge",
+                "Dummy/J",
+            ]
+        )
+    assert capture_mains["module"] == "generate_and_evaluate"
+    assert capture_mains["args"].model_A == "Dummy/A"
+    assert capture_mains["args"].model_B == "Dummy/B"
 
 
 def test_elo_forwards_optional_flags(capture_mains):
@@ -304,25 +358,6 @@ def test_engine_kwargs_parsed_as_json(capture_mains):
     assert ge_args.engine_kwargs == {"tensor_parallel_size": 4}
 
 
-def test_judge_prompt_preset_is_forwarded(capture_mains):
-    cli_module.cli(
-        [
-            "--task",
-            "alpaca-eval",
-            "--model_A",
-            "Dummy/A",
-            "--model_B",
-            "Dummy/B",
-            "--judge",
-            "Dummy/J",
-            "--judge_prompt_preset",
-            "skywork",
-        ]
-    )
-    ge_args: CliArgs = capture_mains["args"]
-    assert ge_args.judge_prompt_preset == "skywork"
-
-
 def test_mt_bench_defaults_to_default_judge_mode(capture_mains):
     cli_module.cli(
         [
@@ -357,33 +392,3 @@ def test_mt_bench_forwards_fastchat_original_mode(capture_mains):
     )
     ge_args: CliArgs = capture_mains["args"]
     assert ge_args.mt_bench_judge_mode == "fastchat_original"
-
-
-def test_judge_side_kwargs_are_parsed_separately(capture_mains):
-    cli_module.cli(
-        [
-            "--task",
-            "arena-hard-v2.0",
-            "--model_A",
-            "Dummy/A",
-            "--judge",
-            "Dummy/J",
-            "--truncate_judge_input_chars",
-            "80000",
-            "--max_model_len",
-            "32768",
-            "--max_judge_model_len",
-            "65536",
-            "--engine_kwargs",
-            '{"tensor_parallel_size": 1}',
-            "--judge_engine_kwargs",
-            '{"tensor_parallel_size": 4}',
-        ]
-    )
-    ge_args: CliArgs = capture_mains["args"]
-    assert ge_args.model_B is None
-    assert ge_args.truncate_judge_input_chars == 80000
-    assert ge_args.max_model_len == 32768
-    assert ge_args.max_judge_model_len == 65536
-    assert ge_args.engine_kwargs == {"tensor_parallel_size": 1}
-    assert ge_args.judge_engine_kwargs == {"tensor_parallel_size": 4}

--- a/tests/test_generate_and_evaluate.py
+++ b/tests/test_generate_and_evaluate.py
@@ -89,6 +89,36 @@ def test_resolve_plan_v20_routes_per_category():
     assert plan.baseline_by_index.loc["qc"] == "gemini-2.0-flash-001"
 
 
+def test_resolve_plan_alpaca_eval_uses_native_baseline():
+    plan = _resolve_baseline_plan(
+        args=_make_args("alpaca-eval"),
+        instructions_df=_instructions(["q1", "q2"]),
+    )
+    assert plan.is_flat
+    assert plan.single_model == "gpt4_1106_preview"
+
+
+@pytest.mark.parametrize(
+    ("task", "expected"),
+    [
+        ("mt-bench", "gpt-4"),
+        ("m-arena-hard-v0.1-uk", "CohereLabs/aya-expanse-8b"),
+        ("m-arena-hard-v2.0-EU", "google/gemini-2.5-flash"),
+    ],
+)
+def test_native_pairwise_baseline_resolves_registered_tasks(task: str, expected: str):
+    assert native_pairwise_baseline(task) == expected
+
+
+def test_resolve_plan_m_arena_hard_uses_native_baseline():
+    plan = _resolve_baseline_plan(
+        args=_make_args("m-arena-hard-v2.0-EU"),
+        instructions_df=_instructions(["q1", "q2"]),
+    )
+    assert plan.is_flat
+    assert plan.single_model == "google/gemini-2.5-flash"
+
+
 def test_resolve_plan_explicit_model_b_overrides_native():
     plan = _resolve_baseline_plan(
         args=_make_args("arena-hard-v2.0", model_b="override"),
@@ -99,19 +129,6 @@ def test_resolve_plan_explicit_model_b_overrides_native():
     )
     assert plan.is_flat
     assert plan.single_model == "override"
-
-
-@pytest.mark.parametrize(
-    ("task", "expected"),
-    [
-        ("alpaca-eval", "gpt4_1106_preview"),
-        ("mt-bench", "gpt-4"),
-        ("m-arena-hard-v0.1-uk", "CohereLabs/aya-expanse-8b"),
-        ("m-arena-hard-v2.0-EU", "google/gemini-2.5-flash"),
-    ],
-)
-def test_native_pairwise_baseline_resolves_registered_tasks(task: str, expected: str):
-    assert native_pairwise_baseline(task) == expected
 
 
 def test_resolve_plan_task_without_native_baseline_requires_model_b():
@@ -128,6 +145,20 @@ def test_resolve_plan_v20_missing_category_raises():
             args=_make_args("arena-hard-v2.0"),
             instructions_df=_instructions(["q1"]),
         )
+
+
+def test_resolve_plan_v20_unknown_category_raises():
+    with pytest.raises(ValueError, match="brand_new"):
+        _resolve_baseline_plan(
+            args=_make_args("arena-hard-v2.0"),
+            instructions_df=_instructions(["q1"], categories=["brand_new"]),
+        )
+
+
+def test_baseline_plan_flat_repeats_model():
+    plan = BaselinePlan.flat("b", index=pd.Index(["a", "b"]))
+    assert plan.is_flat
+    assert plan.baseline_by_index.tolist() == ["b", "b"]
 
 
 def test_baseline_plan_per_row_preserves_order():
@@ -188,35 +219,23 @@ def test_generate_and_evaluate_correct_order_bias(tmp_path):
     assert avg_pref == 0.5
 
 
-def test_generate_and_evaluate_passes_judge_side_controls(monkeypatch, tmp_path):
-    captured = {}
-
-    def fake_make_model(**kwargs):
-        captured["make_model"] = kwargs
-
-        class FakeJudge:
-            def batch(self, inputs, **_kwargs):
-                return ["score A: 0 score B: 10"] * len(inputs)
-
-        return FakeJudge()
-
-    monkeypatch.setattr(generate_and_evaluate, "make_model", fake_make_model)
-
-    prefs = main_generate_and_eval(
-        CliArgs(
-            task="alpaca-eval",
-            model_A="Dummy/no answer",
-            model_B="Dummy/open is better than close isnt'it",
-            judge_model="Dummy/score A: 0 score B: 10",
-            n_instructions=2,
-            truncate_judge_input_chars=12,
-            max_judge_model_len=65536,
-            engine_kwargs={"tensor_parallel_size": 1},
-            judge_engine_kwargs={"tensor_parallel_size": 4},
-            result_folder=str(tmp_path),
-        )
+def test_cli_args_parse_optional_boolean_flags(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "generate_and_evaluate.py",
+            "--dataset=alpaca-eval",
+            "--model_A=Dummy/A",
+            "--model_B=Dummy/B",
+            "--judge_model=Dummy/Judge",
+            "--use_tqdm=True",
+            "--ignore_cache=True",
+            "--strip_thinking_before_judging=False",
+        ],
     )
 
-    assert len(prefs) == 2
-    assert captured["make_model"]["max_model_len"] == 65536
-    assert captured["make_model"]["tensor_parallel_size"] == 4
+    args = CliArgs.parse_args()
+
+    assert args.use_tqdm is True
+    assert args.ignore_cache is True
+    assert args.strip_thinking_before_judging is False

--- a/tests/test_mt_bench_downloads.py
+++ b/tests/test_mt_bench_downloads.py
@@ -1,9 +1,73 @@
+import importlib
+from types import SimpleNamespace
+
 import pandas as pd
 
 import judgearena.instruction_dataset.mt_bench as mt_bench
 import judgearena.mt_bench.mt_bench_utils as mt_bench_utils
 import judgearena.utils as utils
-from judgearena.generate_and_evaluate import CliArgs
+from judgearena.cli_common import BaseCliArgs
+from judgearena.judge_prompt_presets import SKYWORK_JUDGE_PROMPT_PRESET
+
+
+def _mt_bench_args(
+    *,
+    dataset: str,
+    model_A: str,
+    model_B: str,
+    use_tqdm: bool = False,
+    **base_overrides,
+) -> BaseCliArgs:
+    """Construct a ``BaseCliArgs`` with MT-Bench-specific extras attached."""
+    args = BaseCliArgs(**base_overrides)
+    args.task = dataset
+    args.model_A = model_A
+    args.model_B = model_B
+    args.use_tqdm = use_tqdm
+    return args
+
+
+def _single_mt_bench_question_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"turn_1": ["Q1"], "turn_2": ["Q1b"]},
+        index=pd.Index([1], name="instruction_index"),
+    )
+
+
+def _mt_bench_completion_pair(
+    questions_df: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    return (
+        pd.DataFrame(
+            {
+                "completion_turn_1": ["A1"],
+                "completion_turn_2": ["A2"],
+            },
+            index=questions_df.index,
+        ),
+        pd.DataFrame(
+            {
+                "completion_turn_1": ["B1"],
+                "completion_turn_2": ["B2"],
+            },
+            index=questions_df.index,
+        ),
+    )
+
+
+def _stub_run_mt_bench_inputs(monkeypatch, questions_df: pd.DataFrame) -> None:
+    monkeypatch.setattr(
+        mt_bench_utils,
+        "load_instructions",
+        lambda dataset, n_instructions=None: questions_df,
+    )
+    monkeypatch.setattr(
+        mt_bench_utils,
+        "_generate_mt_bench_completions",
+        lambda args, questions_df, ignore_cache, limit_event_tracker: (
+            _mt_bench_completion_pair(questions_df)
+        ),
+    )
 
 
 def test_download_mt_bench_skips_question_download_if_cached(tmp_path, monkeypatch):
@@ -111,13 +175,30 @@ def test_generate_mt_bench_completions_uses_pregenerated_baseline(monkeypatch):
         index=pd.Index([1, 2], name="instruction_index"),
     )
     generated_models = []
+    generation_kwargs = []
+    generation_strip_flags = []
 
     monkeypatch.setattr(
         mt_bench_utils, "cache_function_dataframe", lambda fun, **_kwargs: fun()
     )
 
-    def fake_generate_multiturn(**kwargs):
-        generated_models.append(kwargs["model"])
+    def fake_generate_multiturn(
+        *,
+        questions,
+        model,
+        truncate_input_chars,
+        max_tokens,
+        use_tqdm,
+        max_model_len,
+        chat_template,
+        temperature_config,
+        limit_event_tracker,
+        strip_thinking_before_turn_2_prompt,
+        **engine_kwargs,
+    ):
+        generated_models.append(model)
+        generation_kwargs.append(engine_kwargs)
+        generation_strip_flags.append(strip_thinking_before_turn_2_prompt)
         return pd.DataFrame(
             {
                 "instruction_index": [1, 2],
@@ -143,94 +224,309 @@ def test_generate_mt_bench_completions_uses_pregenerated_baseline(monkeypatch):
         ),
     )
 
-    args = CliArgs(
-        task="mt-bench",
+    args = SimpleNamespace(
         model_A="VLLM/example/model-a",
         model_B="gpt-4",
-        judge_model="Dummy/J",
         n_instructions=2,
-        engine_kwargs={"gpu_memory_utilization": 0.7},
+        truncate_all_input_chars=8192,
+        max_out_tokens_models=1024,
+        use_tqdm=False,
+        max_model_len=16384,
+        chat_template=None,
+        battle_thinking_token_budget=None,
+        strip_thinking_before_judging=True,
+        engine_kwargs={"gpu_memory_utilization": 0.7, "language_model_only": True},
     )
 
     completions_a, completions_b = mt_bench_utils._generate_mt_bench_completions(
         args=args,
         questions_df=questions_df,
         ignore_cache=False,
+        limit_event_tracker=None,
     )
 
     assert generated_models == ["VLLM/example/model-a"]
+    assert generation_kwargs == [
+        {"gpu_memory_utilization": 0.7, "language_model_only": True}
+    ]
+    assert generation_strip_flags == [True]
     assert completions_a.loc[1, "completion_turn_1"] == "Gen A1"
     assert completions_b.loc[1, "completion_turn_1"] == "Base A1"
     assert completions_b.loc[2, "completion_turn_2"] == "Base B2"
 
 
-def test_run_mt_bench_resolves_native_baseline_and_judge_controls(
-    monkeypatch, tmp_path
-):
-    questions_df = pd.DataFrame(
-        {"turn_1": ["Q1"], "turn_2": ["Q1b"]},
-        index=pd.Index([1], name="instruction_index"),
+def test_mt_bench_generation_cache_name_changes_when_strip_flag_flips():
+    args_on = _mt_bench_args(
+        dataset="mt-bench",
+        model_A="VLLM/Qwen/Qwen3.5-9B",
+        model_B="VLLM/Qwen/Qwen3.5-9B",
+        judge_model="OpenRouter/google/gemma-4-31b-it",
+        n_instructions=3,
+        truncate_all_input_chars=30000,
+        max_out_tokens_models=49152,
+        max_model_len=57344,
+        battle_thinking_token_budget=32768,
+        strip_thinking_before_judging=True,
     )
+    args_off = _mt_bench_args(
+        dataset="mt-bench",
+        model_A="VLLM/Qwen/Qwen3.5-9B",
+        model_B="VLLM/Qwen/Qwen3.5-9B",
+        judge_model="OpenRouter/google/gemma-4-31b-it",
+        n_instructions=3,
+        truncate_all_input_chars=30000,
+        max_out_tokens_models=49152,
+        max_model_len=57344,
+        battle_thinking_token_budget=32768,
+        strip_thinking_before_judging=False,
+    )
+
+    key_on = mt_bench_utils._mt_bench_generation_cache_name(
+        args_on,
+        model_name="VLLM/Qwen/Qwen3.5-9B",
+    )
+    key_off = mt_bench_utils._mt_bench_generation_cache_name(
+        args_off,
+        model_name="VLLM/Qwen/Qwen3.5-9B",
+    )
+
+    assert key_on != key_off
+    assert key_on.startswith("mt-bench_VLLM/Qwen/Qwen3.5-9B_3_")
+    assert key_off.startswith("mt-bench_VLLM/Qwen/Qwen3.5-9B_3_")
+
+
+def test_preset_judging_preflights_token_budget_for_default_mode(monkeypatch):
+    preset_judging = importlib.import_module("judgearena.mt_bench.preset_judging")
+    tracker = utils.LimitEventTracker()
     captured = {}
 
-    monkeypatch.setattr(
-        mt_bench_utils,
-        "load_instructions",
-        lambda dataset, n_instructions=None: questions_df,
-    )
-    monkeypatch.setattr(
-        mt_bench_utils,
-        "_generate_mt_bench_completions",
-        lambda args, questions_df, ignore_cache: (
-            pd.DataFrame(
-                {"completion_turn_1": ["A1"], "completion_turn_2": ["A2"]},
-                index=questions_df.index,
+    class FakeTokenizer:
+        def apply_chat_template(self, messages, tokenize=True):
+            text = "".join(
+                str(
+                    message["content"] if isinstance(message, dict) else message.content
+                )
+                for message in messages
+            )
+            return [0] * len(text)
+
+        def encode(self, text):
+            return [0] * len(text)
+
+    def fake_do_inference(*, inputs, **kwargs):
+        captured["inputs"] = inputs
+        return ["score_A: 8\nscore_B: 4"]
+
+    monkeypatch.setattr(preset_judging, "do_inference", fake_do_inference)
+
+    prefs, annotations, metadata, num_inconsistent = (
+        preset_judging.judge_mt_bench_with_preset(
+            judge_chat_model=object(),
+            judge_model="Dummy/J",
+            questions=pd.DataFrame(
+                {
+                    "category": ["writing"],
+                    "turn_1": ["Question"],
+                    "turn_2": [""],
+                    "reference_turn_1": [""],
+                    "reference_turn_2": [""],
+                },
+                index=pd.Index([1], name="question_id"),
             ),
-            pd.DataFrame(
-                {"completion_turn_1": ["B1"], "completion_turn_2": ["B2"]},
-                index=questions_df.index,
+            completions_a=pd.DataFrame(
+                {"completion_turn_1": ["A" * 1200], "completion_turn_2": [""]},
+                index=pd.Index([1], name="question_id"),
             ),
-        ),
+            completions_b=pd.DataFrame(
+                {"completion_turn_1": ["B" * 1200], "completion_turn_2": [""]},
+                index=pd.Index([1], name="question_id"),
+            ),
+            model_a="Model/A",
+            model_b="Model/B",
+            turns_mode="single",
+            swap_mode="fixed",
+            truncate_input_chars=None,
+            use_tqdm=False,
+            prompt_preset="default",
+            provide_explanation=False,
+            limit_event_tracker=tracker,
+            judge_tokenizer=FakeTokenizer(),
+            max_judge_model_len=2300,
+            max_out_tokens_judge=32,
+        )
     )
 
-    def fake_make_model(**kwargs):
-        captured["make_model"] = kwargs
+    prompt_value = captured["inputs"][0]
+    assert len(prefs) == 1
+    assert len(annotations) == 1
+    assert len(metadata) == 1
+    assert num_inconsistent == 0
+    assert len(FakeTokenizer().apply_chat_template(prompt_value.to_messages())) <= 2012
+    assert annotations[0]["answer_a_1_truncated"] is True
+    assert annotations[0]["answer_b_1_truncated"] is True
+    assert (
+        tracker.build_summary()["counts_by_kind"]["judge_input_token_truncation"] >= 1
+    )
+
+
+def test_run_mt_bench_forwards_engine_kwargs_to_judge(monkeypatch, caplog):
+    questions_df = _single_mt_bench_question_df()
+    captured = {}
+
+    _stub_run_mt_bench_inputs(monkeypatch, questions_df)
+
+    def fake_make_model(
+        *,
+        model,
+        max_tokens,
+        temperature=None,
+        max_model_len,
+        chat_template,
+        **kwargs,
+    ):
+        captured["make_model"] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "max_model_len": max_model_len,
+            "chat_template": chat_template,
+            "kwargs": kwargs,
+        }
         return object()
 
     monkeypatch.setattr(mt_bench_utils, "make_model", fake_make_model)
 
-    def fake_run_mt_bench_fastchat(**kwargs):
-        captured["fastchat"] = kwargs
+    def fake_run_mt_bench_preset(**kwargs):
+        captured["run_mt_bench_preset"] = kwargs
+        return pd.Series(
+            kwargs["questions_df"].index.to_list(),
+            dtype=float,
+        )
+
+    monkeypatch.setattr(
+        mt_bench_utils,
+        "_run_mt_bench_preset",
+        fake_run_mt_bench_preset,
+    )
+
+    args = _mt_bench_args(
+        dataset="mt-bench",
+        model_A="VLLM/example/model-a",
+        model_B="gpt-4",
+        judge_model="VLLM/Qwen/Qwen3.5-27B-FP8",
+        n_instructions=1,
+        truncate_all_input_chars=8192,
+        max_out_tokens_models=1024,
+        max_out_tokens_judge=256,
+        max_model_len=16384,
+        chat_template=None,
+        provide_explanation=False,
+        swap_mode="fixed",
+        judge_prompt_preset="default",
+        battle_thinking_token_budget=None,
+        strip_thinking_before_judging=False,
+        engine_kwargs={"gpu_memory_utilization": 0.7, "language_model_only": True},
+    )
+
+    caplog.set_level("WARNING", logger=mt_bench_utils.__name__)
+    mt_bench_utils.run_mt_bench(args, ignore_cache=False)
+
+    assert captured["make_model"]["max_tokens"] == 256
+    assert captured["make_model"]["max_model_len"] is None
+    assert captured["make_model"]["kwargs"]["limit_event_stage"] == "judge_model_init"
+    assert (
+        captured["make_model"]["kwargs"]["limit_event_model_spec"]
+        == "VLLM/Qwen/Qwen3.5-27B-FP8"
+    )
+    assert "limit_event_tracker" in captured["make_model"]["kwargs"]
+    assert captured["run_mt_bench_preset"]["prompt_preset"] == "default"
+    assert "MT-Bench ignores provide_explanation=False" not in caplog.text
+
+
+def test_run_mt_bench_keeps_skywork_prompt_preset(monkeypatch):
+    questions_df = _single_mt_bench_question_df()
+    captured = {}
+
+    _stub_run_mt_bench_inputs(monkeypatch, questions_df)
+    monkeypatch.setattr(mt_bench_utils, "make_model", lambda **kwargs: object())
+
+    def fake_run_mt_bench_preset(**kwargs):
+        captured["kwargs"] = kwargs
         return pd.Series([0.0], dtype=float)
 
     monkeypatch.setattr(
         mt_bench_utils,
-        "_run_mt_bench_fastchat",
-        fake_run_mt_bench_fastchat,
+        "_run_mt_bench_preset",
+        fake_run_mt_bench_preset,
     )
 
-    args = CliArgs(
-        task="mt-bench",
+    args = _mt_bench_args(
+        dataset="mt-bench",
         model_A="VLLM/example/model-a",
-        model_B=None,
-        judge_model="VLLM/Judge",
+        model_B="gpt-4",
+        judge_model="VLLM/Skywork/Skywork-Critic-Llama-3.1-8B",
         n_instructions=1,
+        truncate_all_input_chars=8192,
         truncate_judge_input_chars=80000,
+        max_out_tokens_models=1024,
+        max_out_tokens_judge=256,
+        max_model_len=16384,
         max_judge_model_len=65536,
-        mt_bench_judge_mode="fastchat_original",
-        engine_kwargs={"tensor_parallel_size": 1},
-        judge_engine_kwargs={"tensor_parallel_size": 4},
-        result_folder=str(tmp_path),
+        chat_template=None,
+        provide_explanation=False,
+        swap_mode="both",
+        judge_prompt_preset=SKYWORK_JUDGE_PROMPT_PRESET,
+        battle_thinking_token_budget=512,
+        strip_thinking_before_judging=True,
+        engine_kwargs={"gpu_memory_utilization": 0.7, "language_model_only": True},
     )
 
-    mt_bench_utils.run_mt_bench(
-        args,
-        ignore_cache=False,
-        res_folder=tmp_path,
-        result_name="mt-bench-test",
+    mt_bench_utils.run_mt_bench(args, ignore_cache=False)
+
+    assert captured["kwargs"]["prompt_preset"] == SKYWORK_JUDGE_PROMPT_PRESET
+    assert captured["kwargs"]["args"].strip_thinking_before_judging is True
+    assert captured["kwargs"]["args"].truncate_judge_input_chars == 80000
+    assert captured["kwargs"]["args"].max_judge_model_len == 65536
+
+
+def test_run_mt_bench_default_respects_judge_temperature_from_engine_kwargs(
+    monkeypatch,
+):
+    questions_df = _single_mt_bench_question_df()
+    captured = {}
+
+    _stub_run_mt_bench_inputs(monkeypatch, questions_df)
+
+    def fake_make_model(
+        *,
+        model,
+        max_tokens,
+        temperature=None,
+        max_model_len,
+        chat_template,
+        **kwargs,
+    ):
+        captured["temperature"] = temperature
+        return object()
+
+    monkeypatch.setattr(mt_bench_utils, "make_model", fake_make_model)
+    monkeypatch.setattr(
+        mt_bench_utils,
+        "_run_mt_bench_preset",
+        lambda **kwargs: pd.Series([0.0], dtype=float),
     )
 
-    assert args.model_B == "gpt-4"
-    assert captured["make_model"]["max_model_len"] == 65536
-    assert captured["make_model"]["tensor_parallel_size"] == 4
-    assert captured["fastchat"]["args"].truncate_judge_input_chars == 80000
+    args = _mt_bench_args(
+        dataset="mt-bench",
+        model_A="VLLM/example/model-a",
+        model_B="gpt-4",
+        judge_model="VLLM/Qwen/Qwen3.5-27B-FP8",
+        n_instructions=1,
+        max_out_tokens_judge=256,
+        engine_kwargs={"temperature": 0.8},
+        judge_engine_kwargs={"temperature": 0.4},
+    )
+
+    mt_bench_utils.run_mt_bench(args, ignore_cache=False)
+
+    assert captured["temperature"] == 0.4

--- a/tests/test_regexp.py
+++ b/tests/test_regexp.py
@@ -1,5 +1,6 @@
+import judgearena.mt_bench.fastchat_compat as fastchat_compat
 from judgearena.evaluate import PairScore
-from judgearena.judge_prompt_presets import resolve_pairwise_judge_prompt
+from judgearena.utils import strip_thinking_tags
 
 
 def test_pair_score():
@@ -41,8 +42,78 @@ def test_regexp():
     print(pref)
 
 
+def test_pair_score_ignores_scores_inside_thinking_tags():
+    raw_text = """
+    <think>
+    Early draft:
+    score_A: 2
+    score_B: 1
+    </think>
+    Explanation: Assistant B is clearly better overall.
+    score_A: 0
+    score_B: 10
+    """
+
+    scorer = PairScore()
+    pref = scorer.parse_model_raw(raw_text)
+
+    assert pref is not None
+    assert pref == 0.9525741268224333
+
+
+def test_pair_score_score_mode_does_not_parse_bracketed_verdicts():
+    scorer = PairScore()
+
+    assert scorer.parse_model_raw("Explanation: ok\n[[A]]") is None
+    assert scorer.parse_model_raw("Explanation: ok\n[[B]]") is None
+    assert scorer.parse_model_raw("Explanation: ok\n[[C]]") is None
+
+
+def test_pair_score_score_mode_ignores_bracketed_verdict_after_thinking():
+    raw_text = """
+    <think>
+    score_A: 0
+    score_B: 10
+    </think>
+    Concise verdict only.
+    [[B]]
+    """
+
+    scorer = PairScore()
+
+    assert scorer.parse_model_raw(raw_text) is None
+
+
+def test_parse_fastchat_verdict_accepts_bracketed_verdicts_after_thinking():
+    assert (
+        fastchat_compat._parse_fastchat_verdict(
+            "<think>Need a longer chain.</think>[[A]]"
+        )
+        == "A"
+    )
+    assert fastchat_compat._parse_fastchat_verdict("[[B]]") == "B"
+    assert fastchat_compat._parse_fastchat_verdict("[[C]]") == "tie"
+
+
+def test_parse_fastchat_verdict_marks_non_bracketed_outputs_as_error():
+    assert fastchat_compat._parse_fastchat_verdict("A") == "error"
+    assert fastchat_compat._parse_fastchat_verdict('{"verdict":"B"}') == "error"
+
+
+def test_strip_thinking_tags_handles_closing_tag_without_opening_tag():
+    raw_text = (
+        "Reasoning that started implicitly and kept going.\n"
+        "Still reasoning.\n"
+        "</think>\n"
+        "Final answer."
+    )
+
+    assert strip_thinking_tags(raw_text) == "Final answer."
+
+
 def test_pair_score_verdict_mode_uses_bracketed_verdicts():
     raw_text = "score_A: 10\nscore_B: 0\n[[B]]"
+
     scorer = PairScore(parser_mode="verdict")
 
     assert scorer.parse_model_raw(raw_text) == 1.0
@@ -50,16 +121,7 @@ def test_pair_score_verdict_mode_uses_bracketed_verdicts():
 
 def test_pair_score_verdict_mode_does_not_parse_score_only_outputs():
     raw_text = "score_A: 10\nscore_B: 0"
+
     scorer = PairScore(parser_mode="verdict")
 
     assert scorer.parse_model_raw(raw_text) is None
-
-
-def test_localized_prompt_preset_renders_translated_labels():
-    resolved = resolve_pairwise_judge_prompt(
-        prompt_preset="m-arena-hard-v2-localized-zh",
-        provide_explanation=False,
-    )
-
-    assert resolved.parser_mode == "score"
-    assert "<|助手 A 的 回答 开始|>" in resolved.user_prompt_template

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,46 +1,166 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
 import judgearena.utils as utils
 from judgearena.utils import make_model
 
 
-def test_download_all_dispatches_arena_hard_versions(monkeypatch, tmp_path):
-    calls: list[tuple[str, str, object]] = []
-
-    monkeypatch.setattr(utils, "data_root", tmp_path)
-    monkeypatch.setattr(
-        utils,
-        "download_hf",
-        lambda name, local_path: calls.append(("hf", name, local_path)),
+def test_extract_ai_message_metadata_reads_finish_reason():
+    ai_message = SimpleNamespace(
+        content="hi",
+        response_metadata={"finish_reason": "length", "stop_reason": None},
     )
-    monkeypatch.setattr(
-        utils,
-        "download_arena_hard",
-        lambda dataset, local_tables_path: calls.append(
-            ("arena", dataset, local_tables_path)
+    md = utils._extract_ai_message_metadata(ai_message)
+    assert md == {"finish_reason": "length", "stop_reason": None}
+
+
+def test_extract_ai_message_metadata_handles_missing_response_metadata():
+    bare_ai_message = SimpleNamespace(content="hello")
+    md = utils._extract_ai_message_metadata(bare_ai_message)
+    assert md == {"finish_reason": None, "stop_reason": None}
+
+
+def test_extract_ai_message_metadata_handles_plain_dict_fallback():
+    md = utils._extract_ai_message_metadata(
+        {"finish_reason": "stop", "stop_reason": "eos"}
+    )
+    assert md == {"finish_reason": "stop", "stop_reason": "eos"}
+
+
+def test_do_inference_async_path_propagates_finish_reason(monkeypatch):
+    async_results = [
+        SimpleNamespace(
+            content="out1",
+            response_metadata={"finish_reason": "stop"},
         ),
-    )
-    monkeypatch.setattr(
-        utils,
-        "snapshot_download",
-        lambda **kwargs: calls.append(
-            ("snapshot", kwargs["repo_id"], kwargs["local_dir"])
+        SimpleNamespace(
+            content="out2",
+            response_metadata={"finish_reason": "length"},
         ),
-    )
-
-    utils.download_all()
-
-    tables_dir = tmp_path / "tables"
-    assert calls[:5] == [
-        ("hf", "alpaca-eval", tables_dir),
-        ("arena", "arena-hard-v0.1", tables_dir),
-        ("arena", "arena-hard-v2.0", tables_dir),
-        ("hf", "m-arena-hard-v0.1", tables_dir),
-        ("hf", "m-arena-hard-v2.0", tables_dir),
     ]
-    assert calls[5] == (
-        "snapshot",
-        "geoalgo/multilingual-contexts-to-be-completed",
-        tmp_path / "contexts",
+
+    async def fake_ainvoke(_input, **_kwargs):
+        return async_results.pop(0)
+
+    chat_model = SimpleNamespace(ainvoke=fake_ainvoke)
+    texts, metadata = utils.do_inference(
+        chat_model=chat_model,
+        inputs=["prompt1", "prompt2"],
+        use_tqdm=True,
+        return_metadata=True,
     )
+    assert texts == ["out1", "out2"]
+    assert metadata == [
+        {"finish_reason": "stop", "stop_reason": None},
+        {"finish_reason": "length", "stop_reason": None},
+    ]
+
+
+def test_do_inference_batch_path_propagates_finish_reason_without_batch_with_metadata():
+    batch_results = [
+        SimpleNamespace(
+            content="a",
+            response_metadata={"finish_reason": "stop"},
+        ),
+        SimpleNamespace(
+            content="b",
+            response_metadata={"finish_reason": "length"},
+        ),
+    ]
+    chat_model = MagicMock()
+    chat_model.batch = MagicMock(return_value=batch_results)
+    # Ensure no batch_with_metadata attr so the else branch runs
+    if hasattr(chat_model, "batch_with_metadata"):
+        del chat_model.batch_with_metadata
+
+    texts, metadata = utils.do_inference(
+        chat_model=chat_model,
+        inputs=["p1", "p2"],
+        use_tqdm=False,
+        return_metadata=True,
+    )
+    assert [m["finish_reason"] for m in metadata] == ["stop", "length"]
+    assert texts == ["a", "b"]
+
+
+def _strip_then_cap(
+    answer: str, cap: int, *, strip: bool = True
+) -> tuple[str, bool, bool]:
+    if strip:
+        stripped_text, thinking_stripped = utils.strip_thinking_tags_with_metadata(
+            answer
+        )
+    else:
+        stripped_text, thinking_stripped = answer, False
+    truncated, was_truncated = utils.truncate_with_metadata(stripped_text, max_len=cap)
+    return truncated, was_truncated, thinking_stripped
+
+
+@pytest.mark.parametrize(
+    ("answer", "cap", "expected"),
+    [
+        (
+            f"<think>{'so let me think through this... ' * 400}</think>\n\n"
+            "The capital of France is Paris.",
+            1024,
+            "The capital of France is Paris.",
+        ),
+        (
+            f"<think>{'step 1... ' * 500}{utils.VLLM_REASONING_END_STR}"
+            "Final answer: 42.",
+            256,
+            "Final answer: 42.",
+        ),
+        (
+            f"{'leftover reasoning fragment ' * 100}</think>\nAnswer: yes.",
+            512,
+            "Answer: yes.",
+        ),
+    ],
+)
+def test_strip_then_cap_drops_reasoning_prefixes(answer: str, cap: int, expected: str):
+    truncated, was_truncated, thinking_stripped = _strip_then_cap(answer, cap)
+
+    assert thinking_stripped is True
+    assert was_truncated is False
+    assert truncated == expected
+    assert "<think>" not in truncated
+    assert "</think>" not in truncated
+
+
+def test_strip_then_cap_passthrough_without_thinking_tags():
+    visible = "Paris is the capital of France. " * 50
+
+    truncated, was_truncated, thinking_stripped = _strip_then_cap(visible, cap=512)
+
+    assert thinking_stripped is False
+    assert was_truncated is True
+    assert truncated == visible[:512]
+
+
+def test_strip_then_cap_unclosed_think_block_remains_truncated():
+    answer = f"<think>{'still reasoning ' * 1000}"
+
+    truncated, was_truncated, thinking_stripped = _strip_then_cap(answer, cap=256)
+
+    assert thinking_stripped is False
+    assert was_truncated is True
+    assert truncated.startswith("<think>")
+
+
+def test_strip_then_cap_disabled_preserves_pre_fix_behavior():
+    answer = f"<think>{'deep thinking ' * 400}</think>\nShort answer."
+
+    truncated, was_truncated, thinking_stripped = _strip_then_cap(
+        answer, cap=1024, strip=False
+    )
+
+    assert thinking_stripped is False
+    assert was_truncated is True
+    assert truncated.startswith("<think>")
+    assert "</think>" not in truncated
 
 
 def test_make_model_openrouter_strips_vllm_only_kwargs(monkeypatch):
@@ -58,10 +178,88 @@ def test_make_model_openrouter_strips_vllm_only_kwargs(monkeypatch):
         max_tokens=16,
         max_model_len=4096,
         chat_template="<ct>",
+        language_model_only=True,
+        gpu_memory_utilization=0.9,
+        enforce_eager=True,
         temperature=0.5,
     )
 
     assert "max_model_len" not in model.model_kwargs
     assert "chat_template" not in model.model_kwargs
+    assert "language_model_only" not in model.model_kwargs
+    assert "gpu_memory_utilization" not in model.model_kwargs
+    assert "enforce_eager" not in model.model_kwargs
     assert model.max_tokens == 16
     assert model.temperature == 0.5
+
+
+def test_init_llm_with_retry_recovers_from_transient_cuda_error(monkeypatch):
+    monkeypatch.setattr(utils, "_VLLM_INIT_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(utils, "_VLLM_INIT_BACKOFF_SECONDS", 0)
+    monkeypatch.setattr(utils.time, "sleep", lambda *_a, **_k: None)
+
+    calls: list[dict] = []
+
+    def fake_llm(**kwargs):
+        calls.append(kwargs)
+        if len(calls) < 3:
+            raise RuntimeError(
+                "CUDA error: CUDA-capable device(s) is/are busy or unavailable\n"
+                "Search for 'cudaErrorDevicesUnavailable' ..."
+            )
+        return "llm"
+
+    result = utils._init_llm_with_retry(fake_llm, model="m", trust_remote_code=True)
+    assert result == "llm"
+    assert len(calls) == 3
+
+
+def test_init_llm_with_retry_gives_up_after_max_attempts(monkeypatch):
+    monkeypatch.setattr(utils, "_VLLM_INIT_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(utils, "_VLLM_INIT_BACKOFF_SECONDS", 0)
+    monkeypatch.setattr(utils.time, "sleep", lambda *_a, **_k: None)
+
+    def always_fails(**_kwargs):
+        raise RuntimeError("cudaErrorDevicesUnavailable")
+
+    with pytest.raises(RuntimeError, match="cudaErrorDevicesUnavailable"):
+        utils._init_llm_with_retry(always_fails, model="m")
+
+
+def test_init_llm_with_retry_reraises_non_matching_errors_immediately(monkeypatch):
+    monkeypatch.setattr(utils, "_VLLM_INIT_MAX_ATTEMPTS", 4)
+    monkeypatch.setattr(utils, "_VLLM_INIT_BACKOFF_SECONDS", 0)
+
+    call_count = 0
+
+    def fails_once(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("bad config")
+
+    with pytest.raises(ValueError, match="bad config"):
+        utils._init_llm_with_retry(fails_once, model="m")
+    assert call_count == 1
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "CUDA error: unknown error",
+        "NCCL error",
+    ],
+)
+def test_init_llm_with_retry_does_not_retry_broad_runtime_errors(monkeypatch, message):
+    monkeypatch.setattr(utils, "_VLLM_INIT_MAX_ATTEMPTS", 4)
+    monkeypatch.setattr(utils, "_VLLM_INIT_BACKOFF_SECONDS", 0)
+
+    call_count = 0
+
+    def fails_once(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError(message)
+
+    with pytest.raises(RuntimeError, match=message):
+        utils._init_llm_with_retry(fails_once, model="m")
+    assert call_count == 1


### PR DESCRIPTION
## Summary
- Add generation/judge metadata propagation and limit-event tracking.
- Add thinking-model defaults, thinking-token budget handling, and optional stripping before judging.
- Keep prompt preset/localized prompt assets in the lower stack PR.

## Stack
- Base: `pr32-split-v2/02-prompt-presets-localized`.
- Next: `pr32-split-v2/04-elo-sampling-gemini`.
- Replaces old #44 after moving prompt preset work down-stack.

## Test plan
- `uv run pytest tests/test_utils.py tests/test_regexp.py tests/test_cli.py tests/test_generate_and_evaluate.py tests/test_mt_bench_downloads.py tests/test_chat_vllm.py`
- `uv run pytest tests`
- `uv run ruff check .`

Includes-AI-Code: true