### PR TITLE
5. Add Elo sampling and Gemini safety handling

### DIFF
--- a/judgearena/chat_models/__init__.py
+++ b/judgearena/chat_models/__init__.py
@@ -1,0 +1,15 @@
+"""Chat-model adapters with provider-specific hardening."""
+
+from judgearena.chat_models.openrouter_gemini import (
+    GEMINI_SAFETY_REFUSAL_MARKER,
+    OPENROUTER_GEMINI_SAFETY_REFUSAL_FINISH_REASON,
+    OpenRouterGeminiSafetyTolerantChatOpenAI,
+    is_openrouter_gemini_model,
+)
+
+__all__ = [
+    "GEMINI_SAFETY_REFUSAL_MARKER",
+    "OPENROUTER_GEMINI_SAFETY_REFUSAL_FINISH_REASON",
+    "OpenRouterGeminiSafetyTolerantChatOpenAI",
+    "is_openrouter_gemini_model",
+]

--- a/judgearena/chat_models/openrouter_gemini.py
+++ b/judgearena/chat_models/openrouter_gemini.py
@@ -1,0 +1,102 @@
+"""ChatOpenAI subclass tolerant to Gemini's PROHIBITED_CONTENT hard-refusals.
+
+Google's core policy filter rejects a small fraction of prompts (e.g. graphic
+violence, sexual content involving minors) with HTTP 403 ``PROHIBITED_CONTENT``
+*regardless* of the adjustable ``safety_settings`` thresholds. These refusals
+are legitimate, reproducible model behavior that a benchmark like
+``m-arena-hard-v2.0`` surfaces: the baseline should contain them so the judge
+can score them, not crash the run.
+
+The subclass intercepts the error response before LangChain raises, returns
+a stub assistant message with a clearly marked refusal payload and
+``finish_reason="content_filter"``, and lets the rest of the pipeline proceed
+unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+
+GEMINI_SAFETY_REFUSAL_MARKER = (
+    "[Gemini safety refusal: PROHIBITED_CONTENT — Google's core policy filter "
+    "blocked this prompt regardless of safety_settings.]"
+)
+OPENROUTER_GEMINI_SAFETY_REFUSAL_FINISH_REASON = "content_filter"
+
+_PROHIBITED_CONTENT_TOKEN = "PROHIBITED_CONTENT"
+
+
+def is_openrouter_gemini_model(model_spec: str) -> bool:
+    """Return True when ``model_spec`` targets a Gemini model via OpenRouter.
+
+    Matches ``OpenRouter/google/gemini-2.5-flash`` and related variants.
+    """
+    provider, sep, model_name = model_spec.partition("/")
+    if not sep:
+        return False
+    lowered = model_name.lower()
+    return provider == "OpenRouter" and (
+        lowered.startswith("google/gemini") or lowered.startswith("google/gemma")
+    )
+
+
+def _error_is_prohibited_content(error: object) -> bool:
+    if error is None:
+        return False
+    return _PROHIBITED_CONTENT_TOKEN in str(error)
+
+
+def _build_prohibited_content_stub_payload(
+    *, original_response: dict[str, Any], model_name: str
+) -> dict[str, Any]:
+    stub_message = {
+        "role": "assistant",
+        "content": GEMINI_SAFETY_REFUSAL_MARKER,
+    }
+    stub_choice = {
+        "index": 0,
+        "message": stub_message,
+        "finish_reason": OPENROUTER_GEMINI_SAFETY_REFUSAL_FINISH_REASON,
+    }
+    return {
+        "id": original_response.get("id") or "openrouter-gemini-safety-stub",
+        "object": "chat.completion",
+        "created": original_response.get("created") or 0,
+        "model": original_response.get("model") or model_name,
+        "choices": [stub_choice],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+    }
+
+
+class OpenRouterGeminiSafetyTolerantChatOpenAI(ChatOpenAI):
+    """ChatOpenAI that converts Gemini PROHIBITED_CONTENT errors to stubs.
+
+    Only intercepts the specific OpenRouter error surface for Gemini's core
+    policy filter; all other errors propagate unchanged. The stub message has
+    ``content == GEMINI_SAFETY_REFUSAL_MARKER`` and ``finish_reason ==
+    "content_filter"`` so upstream validators and judges see the refusal
+    explicitly rather than a silent drop.
+    """
+
+    def _create_chat_result(  # type: ignore[override]
+        self,
+        response,
+        generation_info: dict | None = None,
+    ):
+        response_dict = (
+            response if isinstance(response, dict) else response.model_dump()
+        )
+        error = response_dict.get("error")
+        if _error_is_prohibited_content(error):
+            stub = _build_prohibited_content_stub_payload(
+                original_response=response_dict,
+                model_name=self.model_name,
+            )
+            return super()._create_chat_result(stub, generation_info=generation_info)
+        return super()._create_chat_result(response, generation_info=generation_info)

--- a/judgearena/cli.py
+++ b/judgearena/cli.py
@@ -113,6 +113,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="[elo] Model anchored at 1000 ELO (ratings are reported relative to it).",
     )
+    parser.add_argument(
+        "--elo_random_battles",
+        type=int,
+        default=None,
+        help="[elo] Sample N arena rows uniformly at random using --seed.",
+    )
     add_common_arguments(parser)
     return parser
 
@@ -191,6 +197,7 @@ def _build_elo_args(
         n_bootstraps=args.n_bootstraps,
         seed=args.seed,
         baseline_model=args.baseline_model,
+        elo_random_battles=args.elo_random_battles,
         judge_model=args.judge_model,
         n_instructions=args.n_instructions,
         provide_explanation=args.provide_explanation,

--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -1,6 +1,9 @@
 import hashlib
+import json
+import re
 from dataclasses import dataclass
 from functools import partial
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -33,6 +36,7 @@ class CliEloArgs(BaseCliArgs):
     n_bootstraps: int = 20
     seed: int = 0
     baseline_model: str | None = None
+    elo_random_battles: int | None = None
 
 
 def compute_bradley_terry(
@@ -147,6 +151,103 @@ def compute_bradley_terry(
     return dict(pd.Series(elo_scores, index=models.index))
 
 
+def _sample_fingerprint(sampled: pd.DataFrame) -> str:
+    rows = []
+    for index, row in sampled.iterrows():
+        rows.append(
+            {
+                "index": int(index)
+                if isinstance(index, int | np.integer)
+                else str(index),
+                "question_id": str(row.get("question_id", "")),
+                "model_a": str(row["model_a"]),
+                "model_b": str(row["model_b"]),
+            }
+        )
+    return hashlib.sha256(json.dumps(rows, sort_keys=True).encode()).hexdigest()
+
+
+def select_seeded_random_arena_battles(
+    df_battles: pd.DataFrame,
+    *,
+    n_battles: int,
+    seed: int,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    """Select a shared random battle panel for outside-model Elo estimation."""
+    n = min(n_battles, len(df_battles))
+    sampled = df_battles.sample(n=n, random_state=seed, replace=False)
+    metadata: dict[str, object] = {
+        "sampling_mode": "seeded_random",
+        "random_seed": seed,
+        "requested_rows": n_battles,
+        "sampled_rows": len(sampled),
+        "sampled_original_indices": [
+            int(index) if isinstance(index, int | np.integer) else str(index)
+            for index in sampled.index
+        ],
+        "sampled_question_ids": [
+            str(value) for value in sampled["question_id"].tolist()
+        ],
+        "sample_fingerprint": _sample_fingerprint(sampled),
+    }
+    return sampled.reset_index(drop=True), metadata
+
+
+def _sampling_cache_token(
+    sampling_metadata: dict[str, object],
+    *,
+    n_instructions: int | None,
+    n_instructions_per_language: int | None,
+) -> str:
+    mode = sampling_metadata.get("sampling_mode")
+    if mode == "seeded_random":
+        return (
+            "seeded-random_"
+            f"{sampling_metadata['requested_rows']}_"
+            f"seed-{sampling_metadata['random_seed']}_"
+            f"{str(sampling_metadata['sample_fingerprint'])[:12]}"
+        )
+    return f"head_{n_instructions}_{n_instructions_per_language}"
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "model"
+
+
+def _jsonable(value):
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, tuple):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, float) and np.isnan(value):
+        return None
+    return value
+
+
+def write_elo_result(
+    *,
+    result_folder: str | Path,
+    summary: dict[str, object],
+    bootstrap_ratings: list[dict[str, float]],
+) -> Path:
+    model = str(summary["model_A"])
+    arena = str(summary["arena"])
+    output_dir = Path(result_folder) / f"elo-{_slugify(arena)}-{_slugify(model)}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"results-{_slugify(model)}.json"
+    payload = {
+        "summary": summary,
+        "bootstrap_ratings": bootstrap_ratings,
+    }
+    path.write_text(json.dumps(_jsonable(payload), indent=2) + "\n")
+    return path
+
+
 def main(args: CliEloArgs) -> dict:
     rng = np.random.default_rng(args.seed)
 
@@ -159,17 +260,34 @@ def main(args: CliEloArgs) -> dict:
     if args.languages:
         df_battles = df_battles[df_battles["lang"].isin(args.languages)]
 
-    # Keep at most n_instructions_per_language per language
-    if args.n_instructions_per_language is not None:
-        df_battles = (
-            df_battles.groupby("lang")
-            .head(args.n_instructions_per_language)
-            .reset_index(drop=True)
+    random_sampling = args.elo_random_battles is not None
+    sampling_metadata: dict[str, object] = {"sampling_mode": "head"}
+    if random_sampling:
+        if (
+            args.n_instructions is not None
+            or args.n_instructions_per_language is not None
+        ):
+            raise ValueError(
+                "n_instructions and n_instructions_per_language cannot be combined "
+                "with elo_random_battles."
+            )
+        df_battles, sampling_metadata = select_seeded_random_arena_battles(
+            df_battles,
+            n_battles=args.elo_random_battles,
+            seed=args.seed,
         )
+    else:
+        # Keep at most n_instructions_per_language per language
+        if args.n_instructions_per_language is not None:
+            df_battles = (
+                df_battles.groupby("lang")
+                .head(args.n_instructions_per_language)
+                .reset_index(drop=True)
+            )
 
-    # Keep at most n_instructions total (subset used for LLM-judge evaluation)
-    if args.n_instructions is not None:
-        df_battles = df_battles.head(args.n_instructions)
+        # Keep at most n_instructions total (subset used for LLM-judge evaluation)
+        if args.n_instructions is not None:
+            df_battles = df_battles.head(args.n_instructions)
 
     df_battles = df_battles.reset_index(drop=True)
     n = len(df_battles)
@@ -212,9 +330,14 @@ def main(args: CliEloArgs) -> dict:
         if extra_kwargs
         else ""
     )
+    sampling_cache_token = _sampling_cache_token(
+        sampling_metadata,
+        n_instructions=args.n_instructions,
+        n_instructions_per_language=args.n_instructions_per_language,
+    )
     cache_suffix = (
         f"{args.arena}_{replace_slash(args.model)}_"
-        f"{args.n_instructions}_{args.n_instructions_per_language}_"
+        f"{sampling_cache_token}_"
         f"{languages_str}_{args.truncate_all_input_chars}_{args.max_out_tokens_models}"
         + (f"_{extra_kwargs_str}" if extra_kwargs_str else "")
     )
@@ -273,8 +396,6 @@ def main(args: CliEloArgs) -> dict:
         judge_extra_kwargs["max_model_len"] = args.max_judge_model_len
     if args.chat_template is not None:
         judge_extra_kwargs["chat_template"] = args.chat_template
-    judge_extra_kwargs.update(args.engine_kwargs)
-    judge_extra_kwargs.update(args.judge_engine_kwargs)
 
     def run_judge() -> pd.DataFrame:
         judge_chat_model = make_model(
@@ -419,8 +540,38 @@ def main(args: CliEloArgs) -> dict:
     else:
         print("  Not enough data to compute ELO ratings.")
 
-    return {
+    model_rating_values = [
+        rating[model_name] for rating in bootstrap_ratings if model_name in rating
+    ]
+    elo_mean = (
+        float(np.mean(model_rating_values)) if model_rating_values else float("nan")
+    )
+    elo_std = (
+        float(np.std(model_rating_values)) if model_rating_values else float("nan")
+    )
+    result_summary = {
         **summary,
+        "arena": args.arena,
+        "model_A": model_name,
+        "judge_model": args.judge_model,
+        "num_battles": n,
+        "llm_judged_battles": n_llm,
+        "human_anchor_battles": n_human,
+        "sampling_metadata": sampling_metadata,
+        "elo_mean": elo_mean,
+        "elo_std": elo_std,
+        "elo_num_bootstraps": len(model_rating_values),
+        "source_battle_counts": battle_counts,
+    }
+    result_path = write_elo_result(
+        result_folder=args.result_folder,
+        summary=result_summary,
+        bootstrap_ratings=bootstrap_ratings,
+    )
+
+    return {
+        **result_summary,
         "bootstrap_ratings": bootstrap_ratings,
         "model_name": model_name,
+        "result_path": str(result_path),
     }

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -18,6 +18,10 @@ from langchain_openai import ChatOpenAI
 from tqdm.asyncio import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
+from judgearena.chat_models import (
+    OpenRouterGeminiSafetyTolerantChatOpenAI,
+    is_openrouter_gemini_model,
+)
 from judgearena.instruction_dataset.arena_hard import (
     download_arena_hard,
     is_arena_hard_dataset,
@@ -918,8 +922,16 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
         )
 
     if model_provider == "OpenRouter":
-        # Special case we need to override API url and key
-        return ChatOpenAI(
+        # Gemini's core policy filter rejects a small fraction of prompts with
+        # a hard PROHIBITED_CONTENT error that safety_settings cannot override;
+        # the subclass converts those into stub refusals so batch generation
+        # (e.g. benchmark baselines) completes instead of crashing.
+        chat_model_cls = (
+            OpenRouterGeminiSafetyTolerantChatOpenAI
+            if is_openrouter_gemini_model(model)
+            else ChatOpenAI
+        )
+        return chat_model_cls(
             api_key=os.getenv("OPENROUTER_API_KEY"),
             base_url="https://openrouter.ai/api/v1",
             model=model_name,


### PR DESCRIPTION
## Summary
- Add Elo sampling controls and CLI wiring.
- Add OpenRouter Gemini safety-tolerant chat handling.
- Keep this PR on top of the reordered prompt and inference stack.

## Stack
- Base: `pr32-split-v2/03-inference-metadata-thinking`.
- Next: `pr32-split-v2/05-paper-experiment-scripts`.
- Replaces old #46 on the reordered stack.

## Test plan
- `uv run pytest tests/test_estimate_elo_ratings.py tests/test_cli.py tests/test_utils.py`
- `uv run pytest tests`
- `uv run ruff check .`
