### PR TITLE
3.5. Add runtime robustness, judge-kwarg defaults, CLI/orchestration cleanup, point to judgearena hf

### DIFF
--- a/judgearena/cli.py
+++ b/judgearena/cli.py
@@ -75,6 +75,10 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Model B for generate+judge tasks (not yet supported for elo tasks).",
     )
     parser.add_argument(
+        "--model",
+        help="[DEPRECATED] Use `--model_A` instead.",
+    )
+    parser.add_argument(
         "--use_tqdm",
         action="store_true",
         help="[generate+judge] Use tqdm (not compatible with vLLM).",
@@ -150,6 +154,22 @@ def _resolve_task(args: argparse.Namespace) -> str:
         stacklevel=2,
     )
     return f"{ELO_TASK_PREFIX}{lower_arena}"
+
+
+def _resolve_model_a(args: argparse.Namespace) -> str | None:
+    """Collapse the deprecated --model flag into --model_A."""
+    if args.model is not None and args.model_A is not None:
+        raise SystemExit(
+            "Specify exactly one of --model_A/--model; --model is a deprecated alias."
+        )
+    if args.model is not None:
+        warnings.warn(
+            "--model is deprecated; use --model_A instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return args.model
+    return args.model_A
 
 
 def _build_elo_args(
@@ -236,20 +256,17 @@ def cli(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     configure_logging(resolve_verbosity(args), log_file=args.log_file)
     task = _resolve_task(args)
+    model_a = _resolve_model_a(args)
     if task.startswith(ELO_TASK_PREFIX):
         if task not in ELO_TASK_TO_ARENA:
             raise SystemExit(
                 f"Unknown elo task {task!r}; expected one of {list(ELO_TASK_TO_ARENA)}."
             )
-        elo_args = _build_elo_args(
-            args, arena=ELO_TASK_TO_ARENA[task], model_a=args.model_A
-        )
+        elo_args = _build_elo_args(args, arena=ELO_TASK_TO_ARENA[task], model_a=model_a)
         logger.debug("Running with CLI args: %s", elo_args.__dict__)
         main_elo(elo_args)
     else:
-        ge_args = _build_generate_and_evaluate_args(
-            args, task=task, model_a=args.model_A
-        )
+        ge_args = _build_generate_and_evaluate_args(args, task=task, model_a=model_a)
         logger.debug("Running with CLI args: %s", ge_args.__dict__)
         main_generate_and_evaluate(ge_args)
 

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -396,6 +396,7 @@ def judge_and_parse_prefs(
     system_prompt: str | None = None,
     user_prompt_template: str | None = None,
     prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
+    parser_mode: str = "score",
     truncate_input_chars: int = 8192,
     use_tqdm: bool = False,
 ) -> tuple[list[JudgeAnnotation], list[JudgeAnnotation] | None, pd.Series]:
@@ -416,22 +417,15 @@ def judge_and_parse_prefs(
             judge_chat_model,
         )
 
-    resolved_prompt = resolve_judge_prompts(
-        provide_explanation=provide_explanation,
-        prompt_preset=prompt_preset,
-        system_prompt=system_prompt,
-        user_prompt_template=user_prompt_template,
-    )
-
     annotations = annotate_battles(
         judge_chat_model=judge_chat_model,
         instructions=instructions,
         completions_A=completions_A,
         completions_B=completions_B,
         provide_explanation=provide_explanation,
-        system_prompt=resolved_prompt.system_prompt,
-        user_prompt_template=resolved_prompt.user_prompt_template,
-        prompt_preset=resolved_prompt.preset_name,
+        system_prompt=system_prompt,
+        user_prompt_template=user_prompt_template,
+        prompt_preset=prompt_preset,
         truncate_input_chars=truncate_input_chars,
         use_tqdm=use_tqdm,
     )
@@ -444,9 +438,9 @@ def judge_and_parse_prefs(
             completions_A=completions_B,
             completions_B=completions_A,
             provide_explanation=provide_explanation,
-            system_prompt=resolved_prompt.system_prompt,
-            user_prompt_template=resolved_prompt.user_prompt_template,
-            prompt_preset=resolved_prompt.preset_name,
+            system_prompt=system_prompt,
+            user_prompt_template=user_prompt_template,
+            prompt_preset=prompt_preset,
             truncate_input_chars=truncate_input_chars,
             use_tqdm=use_tqdm,
         )
@@ -454,7 +448,7 @@ def judge_and_parse_prefs(
     def _none_to_nan(x):
         return float("nan") if x is None else x
 
-    score_parser = PairScore(parser_mode=resolved_prompt.parser_mode)
+    score_parser = PairScore(parser_mode=parser_mode)
     prefs = pd.Series(
         [score_parser.parse_model_raw(a.judge_completion) for a in annotations]
     )

--- a/judgearena/generate_and_evaluate.py
+++ b/judgearena/generate_and_evaluate.py
@@ -7,7 +7,6 @@ import json
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
-from functools import partial
 from pathlib import Path
 
 import pandas as pd
@@ -34,6 +33,7 @@ from judgearena.log import (
 from judgearena.mt_bench.mt_bench_utils import run_mt_bench
 from judgearena.repro import _to_jsonable, write_run_metadata
 from judgearena.utils import (
+    build_default_judge_model_kwargs,
     cache_function_dataframe,
     compute_pref_summary,
     data_root,
@@ -110,7 +110,7 @@ class CliArgs(BaseCliArgs):
 
 @dataclass(frozen=True)
 class BaselinePlan:
-    """Row-aligned baseline assignment for native pairwise baselines."""
+    """Row-aligned baseline assignment for `--model_B`."""
 
     baseline_by_index: pd.Series
 
@@ -135,7 +135,9 @@ class BaselinePlan:
     @property
     def single_model(self) -> str:
         if not self.is_flat:
-            raise ValueError("BaselinePlan has more than one model.")
+            raise ValueError(
+                "BaselinePlan is per-row; use baseline_by_index for row-level lookups."
+            )
         return self.unique_models[0]
 
     @property
@@ -160,6 +162,7 @@ def native_pairwise_baseline(task: str) -> str | Mapping[str, str] | None:
 def _resolve_baseline_plan(
     args: CliArgs, instructions_df: pd.DataFrame
 ) -> BaselinePlan:
+    """Resolve explicit or dataset-native baseline assignment."""
     if args.model_B is not None:
         return BaselinePlan.flat(args.model_B, index=instructions_df.index)
 
@@ -175,7 +178,8 @@ def _resolve_baseline_plan(
         if "category" not in instructions_df.columns:
             raise ValueError(
                 f"{args.task} requires a 'category' column for per-category "
-                "baseline routing."
+                "baseline routing; re-run dataset download to regenerate the "
+                "instructions table."
             )
         per_row = instructions_df["category"].map(native)
         if per_row.isna().any():
@@ -191,9 +195,11 @@ def _resolve_baseline_plan(
 
 
 def _build_judge_engine_kwargs(args: CliArgs) -> dict[str, object]:
-    judge_kwargs = dict(args.engine_kwargs)
-    judge_kwargs.update(args.judge_engine_kwargs)
-    return judge_kwargs
+    return build_default_judge_model_kwargs(
+        args.judge_model,
+        args.engine_kwargs,
+        judge_engine_kwargs_override=args.judge_engine_kwargs,
+    )
 
 
 def load_contexts(dataset: str) -> pd.Series:
@@ -265,7 +271,8 @@ def main(args: CliArgs):
         # to match files in https://huggingface.co/datasets/geoalgo/multilingual-contexts-to-be-completed
         lang = args.task.split("-")[-1]
         instructions = load_contexts(f"{lang}-contexts.csv")
-        instructions_df = pd.DataFrame({"instruction": instructions})
+        instructions_df = pd.DataFrame({"instruction": instructions.values})
+        instructions_df.index = instructions.index
     else:
         instructions_df = load_instructions(
             dataset=args.task, n_instructions=args.n_instructions
@@ -304,9 +311,12 @@ def main(args: CliArgs):
     )
 
     # TODO currently we just support base models for fluency, we could also support instruction-tuned models
-    gen_fun = (
-        partial(
-            generate_base,
+    generation_function = generate_base if is_fluency_task else generate_instructions
+
+    def _run_generation(model_spec: str) -> pd.DataFrame:
+        return generation_function(
+            instructions=instructions,
+            model=model_spec,
             truncate_input_chars=args.truncate_all_input_chars,
             max_tokens=args.max_out_tokens_models,
             max_model_len=args.max_model_len,
@@ -314,17 +324,6 @@ def main(args: CliArgs):
             use_tqdm=args.use_tqdm,
             **args.engine_kwargs,
         )
-        if is_fluency_task
-        else partial(
-            generate_instructions,
-            truncate_input_chars=args.truncate_all_input_chars,
-            max_tokens=args.max_out_tokens_models,
-            max_model_len=args.max_model_len,
-            chat_template=args.chat_template,
-            use_tqdm=args.use_tqdm,
-            **args.engine_kwargs,
-        )
-    )
 
     def _align_completion_series(df: pd.DataFrame) -> pd.Series:
         return df.set_index("instruction_index").loc[instructions.index, "completion"]
@@ -334,11 +333,7 @@ def main(args: CliArgs):
         if preloaded is not None:
             return _align_completion_series(preloaded)
         generated = cache_function_dataframe(
-            lambda: gen_fun(
-                instructions=instructions,
-                model=model_spec,
-                use_tqdm=args.use_tqdm,
-            ),
+            lambda: _run_generation(model_spec),
             ignore_cache=ignore_cache,
             cache_name=f"{args.task}_{model_spec}_{args.n_instructions}",
         )
@@ -397,6 +392,7 @@ def main(args: CliArgs):
         system_prompt=resolved_prompt.system_prompt,
         user_prompt_template=resolved_prompt.user_prompt_template,
         prompt_preset=resolved_prompt.preset_name,
+        parser_mode=resolved_prompt.parser_mode,
         truncate_input_chars=args.truncate_judge_input_chars,
         use_tqdm=args.use_tqdm,
     )

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -4,6 +4,7 @@ import time
 import warnings
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 from huggingface_hub import snapshot_download
@@ -33,6 +34,41 @@ def _data_root_path() -> Path:
 data_root = _data_root_path()
 
 
+def _split_model_spec(model_spec: str) -> tuple[str, str]:
+    provider, sep, model_name = model_spec.partition("/")
+    if not sep:
+        return model_spec, ""
+    return provider, model_name
+
+
+def build_default_judge_model_kwargs(
+    judge_model: str,
+    engine_kwargs: dict[str, object],
+    *,
+    judge_engine_kwargs_override: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Copy judge engine kwargs and add supported built-in defaults."""
+    provider, model_name = _split_model_spec(judge_model)
+    judge_model_kwargs = dict(engine_kwargs) if provider == "VLLM" else {}
+    if judge_engine_kwargs_override:
+        judge_model_kwargs.update(judge_engine_kwargs_override)
+    if (
+        provider == "VLLM"
+        and "kv_cache_dtype" not in judge_model_kwargs
+        and "fp8" in model_name.lower()
+    ):
+        judge_model_kwargs["kv_cache_dtype"] = "fp8"
+    return judge_model_kwargs
+
+
+def _resolve_chat_template_kwargs(
+    *,
+    explicit_chat_template_kwargs: dict[str, object] | None,
+) -> dict[str, object] | None:
+    chat_template_kwargs = dict(explicit_chat_template_kwargs or {})
+    return chat_template_kwargs or None
+
+
 def set_langchain_cache():
     set_llm_cache(SQLiteCache(database_path=str(data_root / ".langchain.db")))
 
@@ -41,7 +77,7 @@ def download_hf(name: str, local_path: Path):
     local_path.mkdir(exist_ok=True, parents=True)
     # downloads the model from huggingface into `local_path` folder
     snapshot_download(
-        repo_id="geoalgo/llmjudge",
+        repo_id="judge-arena/judge-arena-dataset",
         repo_type="dataset",
         allow_patterns=f"*{name}*",
         local_dir=local_path,
@@ -127,17 +163,41 @@ def safe_text(value: object, truncate_chars: int | None) -> str:
     return truncate(str(value), max_len=truncate_chars)
 
 
-def do_inference(chat_model, inputs, use_tqdm: bool = False):
+def _extract_ai_message_metadata(result: object) -> dict[str, Any]:
+    """Extract provider finish metadata from LangChain-style message results."""
+    response_metadata = getattr(result, "response_metadata", None) or {}
+    finish_reason = response_metadata.get("finish_reason")
+    stop_reason = response_metadata.get("stop_reason")
+    if finish_reason is None and isinstance(result, dict):
+        finish_reason = result.get("finish_reason")
+        stop_reason = result.get("stop_reason", stop_reason)
+    return {"finish_reason": finish_reason, "stop_reason": stop_reason}
+
+
+def do_inference(
+    chat_model,
+    inputs,
+    use_tqdm: bool = False,
+    return_metadata: bool = False,
+):
     # Retries on rate-limit/server errors with exponential backoff.
     # Async path retries individual calls; batch path splits into 4^attempt chunks on failure.
     invoke_kwargs = {
         # "stop": ["```"],
         # "max_tokens": 100,
     }
+    metadata: list[dict[str, Any]] | None = None
     if use_tqdm:
         # perform inference asynchronously to be able to update tqdm, chat_model.batch does not work as it blocks until
         # all requests are received
+        # JUDGEARENA_JUDGE_MAX_CONCURRENCY caps simultaneous in-flight ainvokes
+        # (e.g. against OpenRouter). Unset = unbounded, preserving prior behaviour.
+        cap_raw = os.environ.get("JUDGEARENA_JUDGE_MAX_CONCURRENCY")
+        cap = int(cap_raw) if cap_raw and int(cap_raw) > 0 else None
+
         async def process_with_real_progress(chat_model, inputs, pbar):
+            sem = asyncio.Semaphore(cap) if cap else None
+
             async def process_single(input_item, max_retries=5, base_delay=1.0):
                 for attempt in range(max_retries):
                     try:
@@ -157,8 +217,14 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
                         )
                         await asyncio.sleep(delay)
 
+            async def gated(inp):
+                if sem is None:
+                    return await process_single(inp)
+                async with sem:
+                    return await process_single(inp)
+
             # asyncio.gather preserves order (unlike as_completed)
-            results = await asyncio.gather(*[process_single(inp) for inp in inputs])
+            results = await asyncio.gather(*[gated(inp) for inp in inputs])
             return results
 
         with logging_redirect_tqdm(), tqdm(total=len(inputs)) as pbar:
@@ -167,6 +233,7 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
                     chat_model=chat_model, inputs=inputs, pbar=pbar
                 )
             )
+        metadata = [_extract_ai_message_metadata(r) for r in res]
     else:
 
         def batch_with_retry(batch_inputs, max_retries=5, base_delay=1.0):
@@ -179,9 +246,26 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
                 ]
                 try:
                     results = []
+                    results_metadata = []
                     for chunk in chunks:
-                        results.extend(chat_model.batch(inputs=chunk, **invoke_kwargs))
-                    return results
+                        if return_metadata and hasattr(
+                            chat_model, "batch_with_metadata"
+                        ):
+                            chunk_results, chunk_metadata = (
+                                chat_model.batch_with_metadata(
+                                    inputs=chunk, **invoke_kwargs
+                                )
+                            )
+                        else:
+                            chunk_results = chat_model.batch(
+                                inputs=chunk, **invoke_kwargs
+                            )
+                            chunk_metadata = [
+                                _extract_ai_message_metadata(r) for r in chunk_results
+                            ]
+                        results.extend(chunk_results)
+                        results_metadata.extend(chunk_metadata)
+                    return results, results_metadata
                 except Exception as e:
                     if attempt == max_retries - 1 or not _is_retryable_error(e):
                         raise
@@ -197,12 +281,14 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
                     )
                     time.sleep(delay)
 
-        res = batch_with_retry(inputs)
+        res, metadata = batch_with_retry(inputs)
 
     # Not sure why the API of Langchain returns sometime a string and sometimes an AIMessage object
     # is it because of using Chat and barebones models?
     # when using OpenAI, the output is AIMessage not a string...
     res = [x.content if hasattr(x, "content") else x for x in res]
+    if return_metadata:
+        return res, (metadata or [{} for _ in res])
     return res
 
 
@@ -219,6 +305,43 @@ class DummyModel:
 
     async def ainvoke(self, input, **invoke_kwargs):
         return self.message
+
+
+_VLLM_INIT_RETRY_SIGNATURES = (
+    "cudaErrorDevicesUnavailable",
+    "CUDA-capable device(s) is/are busy or unavailable",
+    "CUDA error: initialization error",
+)
+_VLLM_INIT_MAX_ATTEMPTS = int(os.getenv("JUDGEARENA_VLLM_INIT_MAX_ATTEMPTS", "4"))
+_VLLM_INIT_BACKOFF_SECONDS = int(
+    os.getenv("JUDGEARENA_VLLM_INIT_BACKOFF_SECONDS", "20")
+)
+
+
+def _init_llm_with_retry(llm_cls, **kwargs):
+    """Instantiate ``vllm.LLM`` with retries on transient GPU-init races."""
+    last_exc: Exception | None = None
+    for attempt in range(1, _VLLM_INIT_MAX_ATTEMPTS + 1):
+        try:
+            return llm_cls(**kwargs)
+        except Exception as exc:
+            message = f"{type(exc).__name__}: {exc}"
+            if not any(sig in message for sig in _VLLM_INIT_RETRY_SIGNATURES):
+                raise
+            last_exc = exc
+            if attempt == _VLLM_INIT_MAX_ATTEMPTS:
+                break
+            delay = _VLLM_INIT_BACKOFF_SECONDS * (2 ** (attempt - 1))
+            warnings.warn(
+                f"vLLM init attempt {attempt}/{_VLLM_INIT_MAX_ATTEMPTS} failed "
+                f"with transient GPU-init signature ({message.splitlines()[0]}); "
+                f"sleeping {delay}s before retry.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            time.sleep(delay)
+    assert last_exc is not None
+    raise last_exc
 
 
 class ChatVLLM:
@@ -247,6 +370,10 @@ class ChatVLLM:
 
         self.model_path = model
         self.max_tokens = max_tokens
+        explicit_chat_template_kwargs = vllm_kwargs.pop("chat_template_kwargs", None)
+        self._chat_template_kwargs = _resolve_chat_template_kwargs(
+            explicit_chat_template_kwargs=explicit_chat_template_kwargs,
+        )
 
         # Cap max_model_len to the model's max_position_embeddings so that
         # vLLM doesn't reject an overly large context window.
@@ -273,12 +400,17 @@ class ChatVLLM:
                     stacklevel=2,
                 )
 
-        self.llm = LLM(model=model, trust_remote_code=True, **vllm_kwargs)
-        self.sampling_params = SamplingParams(
-            max_tokens=max_tokens,
-            temperature=0.6,
-            top_p=0.95,
+        self._sampling_params_kwargs = {
+            "max_tokens": max_tokens,
+            "temperature": float(vllm_kwargs.pop("temperature", 0.6)),
+            "top_p": float(vllm_kwargs.pop("top_p", 0.95)),
+        }
+        self.sampling_params = SamplingParams(**self._sampling_params_kwargs)
+
+        self.llm = _init_llm_with_retry(
+            LLM, model=model, trust_remote_code=True, **vllm_kwargs
         )
+        self.tokenizer = self.llm.get_tokenizer()
 
         # Resolve chat template:
         # 1. Explicit override always wins → use chat() with that template
@@ -289,8 +421,7 @@ class ChatVLLM:
             self._use_generate = False
             logger.info("ChatVLLM: using explicit chat template for '%s'", model)
         else:
-            tokenizer = self.llm.get_tokenizer()
-            if not getattr(tokenizer, "chat_template", None):
+            if not getattr(self.tokenizer, "chat_template", None):
                 warnings.warn(
                     f"Model '{model}' tokenizer does not define a chat template. "
                     f"Falling back to llm.generate() (no chat formatting). "
@@ -303,6 +434,12 @@ class ChatVLLM:
                 self.chat_template = None  # let vLLM use the tokenizer's own
                 self._use_generate = False
                 logger.info("ChatVLLM: using tokenizer's chat template for '%s'", model)
+
+    def set_temperature(self, temperature: float) -> None:
+        from vllm import SamplingParams
+
+        self._sampling_params_kwargs["temperature"] = float(temperature)
+        self.sampling_params = SamplingParams(**self._sampling_params_kwargs)
 
     def _to_messages(self, input_item) -> list[dict]:
         """Convert LangChain prompt input to OpenAI-style messages."""
@@ -355,7 +492,7 @@ class ChatVLLM:
             return "\n".join(msg["content"] for msg in input_item)
         raise ValueError(f"Cannot extract raw text from: {type(input_item)}")
 
-    def batch(self, inputs: list, **invoke_kwargs) -> list[str]:
+    def _run_raw_batch(self, inputs: list):
         """Process a batch of inputs using vllm.LLM.chat() or llm.generate().
 
         Uses ``llm.chat()`` when a chat template is available (instruct models),
@@ -371,8 +508,30 @@ class ChatVLLM:
                 self.sampling_params,
                 add_generation_prompt=True,
                 chat_template=self.chat_template,
+                chat_template_kwargs=self._chat_template_kwargs,
             )
-        return [out.outputs[0].text for out in outputs]
+        return outputs
+
+    def batch_with_metadata(
+        self, inputs: list, **invoke_kwargs
+    ) -> tuple[list[str], list[dict[str, Any]]]:
+        outputs = self._run_raw_batch(inputs)
+        texts: list[str] = []
+        metadata: list[dict[str, Any]] = []
+        for out in outputs:
+            first_output = out.outputs[0]
+            texts.append(first_output.text)
+            metadata.append(
+                {
+                    "finish_reason": getattr(first_output, "finish_reason", None),
+                    "stop_reason": getattr(first_output, "stop_reason", None),
+                }
+            )
+        return texts, metadata
+
+    def batch(self, inputs: list, **invoke_kwargs) -> list[str]:
+        texts, _metadata = self.batch_with_metadata(inputs, **invoke_kwargs)
+        return texts
 
     def invoke(self, input_item, **invoke_kwargs) -> str:
         """Process a single input."""
@@ -406,19 +565,30 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
     # Dedicated arguments like max_tokens always win over engine_kwargs.
     engine_kwargs["max_tokens"] = max_tokens or 8192
 
-    model_provider = model.split("/")[0]
+    model_provider, model_name = _split_model_spec(model)
 
     # vLLM-engine-only kwargs must not leak to remote-API providers
     # (OpenRouter, OpenAI, Together): langchain-openai forwards unknown
     # kwargs via model_kwargs into chat.completions.create, which rejects them.
     if model_provider != "VLLM":
-        engine_kwargs.pop("max_model_len", None)
-        engine_kwargs.pop("chat_template", None)
+        for key in (
+            "max_model_len",
+            "chat_template",
+            "language_model_only",
+            "gpu_memory_utilization",
+            "enforce_eager",
+            "tensor_parallel_size",
+            "quantization",
+            "kv_cache_dtype",
+            "reasoning_parser",
+            "reasoning_config",
+            "trust_remote_code",
+        ):
+            engine_kwargs.pop(key, None)
 
     if model_provider == "Dummy":
         return DummyModel(model)
 
-    model_name = "/".join(model.split("/")[1:])
     logger.info("Loading %s(model=%s)", model_provider, model_name)
 
     # Use our custom ChatVLLM wrapper which properly applies chat templates
@@ -469,15 +639,16 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
 
 
 def download_all():
+    from judgearena.instruction_dataset.m_arenahard import M_ARENA_HARD_BASELINES
+
     logger.info("Downloading all datasets in %s", data_root)
     local_path_tables = data_root / "tables"
-    for dataset in [
+    for dataset in (
         "alpaca-eval",
         "arena-hard-v0.1",
         "arena-hard-v2.0",
-        "m-arena-hard-v0.1",
-        "m-arena-hard-v2.0",
-    ]:
+        *M_ARENA_HARD_BASELINES,
+    ):
         if is_arena_hard_dataset(dataset):
             download_arena_hard(dataset=dataset, local_tables_path=local_path_tables)
         else:

--- a/tests/test_generate_and_evaluate.py
+++ b/tests/test_generate_and_evaluate.py
@@ -89,6 +89,15 @@ def test_resolve_plan_v20_routes_per_category():
     assert plan.baseline_by_index.loc["qc"] == "gemini-2.0-flash-001"
 
 
+def test_resolve_plan_alpaca_eval_uses_native_baseline():
+    plan = _resolve_baseline_plan(
+        args=_make_args("alpaca-eval"),
+        instructions_df=_instructions(["q1", "q2"]),
+    )
+    assert plan.is_flat
+    assert plan.single_model == "gpt4_1106_preview"
+
+
 def test_resolve_plan_explicit_model_b_overrides_native():
     plan = _resolve_baseline_plan(
         args=_make_args("arena-hard-v2.0", model_b="override"),
@@ -128,6 +137,20 @@ def test_resolve_plan_v20_missing_category_raises():
             args=_make_args("arena-hard-v2.0"),
             instructions_df=_instructions(["q1"]),
         )
+
+
+def test_resolve_plan_v20_unknown_category_raises():
+    with pytest.raises(ValueError, match="brand_new"):
+        _resolve_baseline_plan(
+            args=_make_args("arena-hard-v2.0"),
+            instructions_df=_instructions(["q1"], categories=["brand_new"]),
+        )
+
+
+def test_baseline_plan_flat_repeats_model():
+    plan = BaselinePlan.flat("b", index=pd.Index(["a", "b"]))
+    assert plan.is_flat
+    assert plan.baseline_by_index.tolist() == ["b", "b"]
 
 
 def test_baseline_plan_per_row_preserves_order():
@@ -207,7 +230,7 @@ def test_generate_and_evaluate_passes_judge_side_controls(monkeypatch, tmp_path)
             task="alpaca-eval",
             model_A="Dummy/no answer",
             model_B="Dummy/open is better than close isnt'it",
-            judge_model="Dummy/score A: 0 score B: 10",
+            judge_model="VLLM/score A: 0 score B: 10",
             n_instructions=2,
             truncate_judge_input_chars=12,
             max_judge_model_len=65536,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,90 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
 import judgearena.utils as utils
 from judgearena.utils import make_model
+
+
+def test_extract_ai_message_metadata_reads_finish_reason():
+    ai_message = SimpleNamespace(
+        content="hi",
+        response_metadata={"finish_reason": "length", "stop_reason": None},
+    )
+    assert utils._extract_ai_message_metadata(ai_message) == {
+        "finish_reason": "length",
+        "stop_reason": None,
+    }
+
+
+def test_extract_ai_message_metadata_handles_missing_response_metadata():
+    bare_ai_message = SimpleNamespace(content="hello")
+    assert utils._extract_ai_message_metadata(bare_ai_message) == {
+        "finish_reason": None,
+        "stop_reason": None,
+    }
+
+
+def test_extract_ai_message_metadata_handles_plain_dict_fallback():
+    assert utils._extract_ai_message_metadata(
+        {"finish_reason": "stop", "stop_reason": "eos"}
+    ) == {"finish_reason": "stop", "stop_reason": "eos"}
+
+
+def test_do_inference_async_path_propagates_finish_reason():
+    async_results = [
+        SimpleNamespace(
+            content="out1",
+            response_metadata={"finish_reason": "stop"},
+        ),
+        SimpleNamespace(
+            content="out2",
+            response_metadata={"finish_reason": "length"},
+        ),
+    ]
+
+    async def fake_ainvoke(_input, **_kwargs):
+        return async_results.pop(0)
+
+    chat_model = SimpleNamespace(ainvoke=fake_ainvoke)
+    texts, metadata = utils.do_inference(
+        chat_model=chat_model,
+        inputs=["prompt1", "prompt2"],
+        use_tqdm=True,
+        return_metadata=True,
+    )
+    assert texts == ["out1", "out2"]
+    assert metadata == [
+        {"finish_reason": "stop", "stop_reason": None},
+        {"finish_reason": "length", "stop_reason": None},
+    ]
+
+
+def test_do_inference_batch_path_propagates_finish_reason_without_batch_with_metadata():
+    batch_results = [
+        SimpleNamespace(
+            content="a",
+            response_metadata={"finish_reason": "stop"},
+        ),
+        SimpleNamespace(
+            content="b",
+            response_metadata={"finish_reason": "length"},
+        ),
+    ]
+    chat_model = MagicMock()
+    chat_model.batch = MagicMock(return_value=batch_results)
+    if hasattr(chat_model, "batch_with_metadata"):
+        del chat_model.batch_with_metadata
+
+    texts, metadata = utils.do_inference(
+        chat_model=chat_model,
+        inputs=["p1", "p2"],
+        use_tqdm=False,
+        return_metadata=True,
+    )
+    assert texts == ["a", "b"]
+    assert [m["finish_reason"] for m in metadata] == ["stop", "length"]
 
 
 def test_download_all_dispatches_arena_hard_versions(monkeypatch, tmp_path):
@@ -58,10 +143,88 @@ def test_make_model_openrouter_strips_vllm_only_kwargs(monkeypatch):
         max_tokens=16,
         max_model_len=4096,
         chat_template="<ct>",
+        language_model_only=True,
+        gpu_memory_utilization=0.9,
+        enforce_eager=True,
         temperature=0.5,
     )
 
     assert "max_model_len" not in model.model_kwargs
     assert "chat_template" not in model.model_kwargs
+    assert "language_model_only" not in model.model_kwargs
+    assert "gpu_memory_utilization" not in model.model_kwargs
+    assert "enforce_eager" not in model.model_kwargs
     assert model.max_tokens == 16
     assert model.temperature == 0.5
+
+
+def test_init_llm_with_retry_recovers_from_transient_cuda_error(monkeypatch):
+    monkeypatch.setattr(utils, "_VLLM_INIT_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(utils, "_VLLM_INIT_BACKOFF_SECONDS", 0)
+    monkeypatch.setattr(utils.time, "sleep", lambda *_a, **_k: None)
+
+    calls: list[dict] = []
+
+    def fake_llm(**kwargs):
+        calls.append(kwargs)
+        if len(calls) < 3:
+            raise RuntimeError(
+                "CUDA error: CUDA-capable device(s) is/are busy or unavailable\n"
+                "Search for 'cudaErrorDevicesUnavailable' ..."
+            )
+        return "llm"
+
+    result = utils._init_llm_with_retry(fake_llm, model="m", trust_remote_code=True)
+    assert result == "llm"
+    assert len(calls) == 3
+
+
+def test_init_llm_with_retry_gives_up_after_max_attempts(monkeypatch):
+    monkeypatch.setattr(utils, "_VLLM_INIT_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(utils, "_VLLM_INIT_BACKOFF_SECONDS", 0)
+    monkeypatch.setattr(utils.time, "sleep", lambda *_a, **_k: None)
+
+    def always_fails(**_kwargs):
+        raise RuntimeError("cudaErrorDevicesUnavailable")
+
+    with pytest.raises(RuntimeError, match="cudaErrorDevicesUnavailable"):
+        utils._init_llm_with_retry(always_fails, model="m")
+
+
+def test_init_llm_with_retry_reraises_non_matching_errors_immediately(monkeypatch):
+    monkeypatch.setattr(utils, "_VLLM_INIT_MAX_ATTEMPTS", 4)
+    monkeypatch.setattr(utils, "_VLLM_INIT_BACKOFF_SECONDS", 0)
+
+    call_count = 0
+
+    def fails_once(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("bad config")
+
+    with pytest.raises(ValueError, match="bad config"):
+        utils._init_llm_with_retry(fails_once, model="m")
+    assert call_count == 1
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "CUDA error: unknown error",
+        "NCCL error",
+    ],
+)
+def test_init_llm_with_retry_does_not_retry_broad_runtime_errors(monkeypatch, message):
+    monkeypatch.setattr(utils, "_VLLM_INIT_MAX_ATTEMPTS", 4)
+    monkeypatch.setattr(utils, "_VLLM_INIT_BACKOFF_SECONDS", 0)
+
+    call_count = 0
+
+    def fails_once(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError(message)
+
+    with pytest.raises(RuntimeError, match=message):
+        utils._init_llm_with_retry(fails_once, model="m")
+    assert call_count == 1


### PR DESCRIPTION
## Summary

Runtime, CLI, and orchestration follow-ups split out of the closed PR #52. This intentionally excludes truncation/limit tracking, generation cache-key hashing, `skip_judging`, and the MT-Bench-specific changes (now in PR #55).

## Changes

- **Runtime / model robustness** (`utils.py`)
  - `_init_llm_with_retry`: retry vLLM construction on transient GPU-init signatures (e.g. `cudaErrorDevicesUnavailable`) with bounded backoff; reraise everything else immediately.
  - `make_model`: strip all vLLM-only engine kwargs (`max_model_len`, `gpu_memory_utilization`, `tensor_parallel_size`, `kv_cache_dtype`, …) for non-vLLM providers so remote APIs don't reject them.
  - `ChatVLLM`: configurable `temperature`/`top_p` with `set_temperature`, exposed tokenizer, and `chat_template_kwargs` plumbing.
- **Metadata propagation bugfix** (`utils.py`)
  - `_extract_ai_message_metadata` + `do_inference(return_metadata=...)` and `ChatVLLM.batch_with_metadata` so `finish_reason`/`stop_reason` are preserved on both the async (`use_tqdm`) and batch paths.
  - Optional `JUDGEARENA_JUDGE_MAX_CONCURRENCY` cap on in-flight async invokes (unset = unbounded, prior behavior).
- **Judge engine defaults** (`utils.py`, `generate_and_evaluate.py`)
  - `build_default_judge_model_kwargs` centralizes judge engine kwargs and adds an FP8 KV-cache default for FP8 judges; `_build_judge_engine_kwargs` now delegates to it.
- **CLI compatibility** (`cli.py`)
  - Restore the deprecated `--model` alias, collapsed into `--model_A` via `_resolve_model_a` (errors if both are given).
- **Generation / evaluation orchestration** (`generate_and_evaluate.py`, `evaluate.py`)
  - Replace `functools.partial` generation wiring with a single `_run_generation` helper; preserve the fluency instruction index; pass an explicit `parser_mode` into `judge_and_parse_prefs`.
- **Dataset/download maintenance** (`utils.py`)
  - `download_hf` points at `judge-arena/judge-arena-dataset`; `download_all` is driven by `M_ARENA_HARD_BASELINES`.
- **Tests**: metadata extraction, async/batch `finish_reason` propagation, vLLM init retry behavior, expanded `make_model` kwarg stripping, and baseline-plan resolution cases.
