### PR TITLE
Use strip-thinking and thinking budget in LMArena Elo path

### DIFF
--- a/judgearena/cli_common.py
+++ b/judgearena/cli_common.py
@@ -13,6 +13,26 @@ from dataclasses import dataclass, field
 
 from judgearena.prompts.registry import JUDGE_PROMPT_PRESETS
 
+_TRUE_TOKENS = {"true", "t", "yes", "y", "1"}
+_FALSE_TOKENS = {"false", "f", "no", "n", "0"}
+
+
+def str2bool(value: str | bool) -> bool:
+    """Parse a CLI boolean supplied either as a bare flag or an explicit value.
+
+    Slurmpilot serialises ``python_args`` dicts as ``--key=value``, so boolean
+    flags reach the CLI as ``--flag=True`` / ``--flag=False`` instead of bare
+    switches. Accept both forms so launcher-driven and interactive use agree.
+    """
+    if isinstance(value, bool):
+        return value
+    normalized = value.strip().lower()
+    if normalized in _TRUE_TOKENS:
+        return True
+    if normalized in _FALSE_TOKENS:
+        return False
+    raise argparse.ArgumentTypeError(f"Expected a boolean value, got {value!r}.")
+
 
 @dataclass
 class BaseCliArgs:
@@ -71,12 +91,16 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--provide_explanation",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        type=str2bool,
         help=(
             "Equivalent to --judge_prompt_preset default_with_explanation. "
             "If specified, judge will provide explanation before making a "
             "judgement. Does not necessarily improve the accuracy of the judge "
-            "but enables some result interpretation."
+            "but enables some result interpretation. Accepts a bare flag or an "
+            "explicit --provide_explanation=true/false value."
         ),
     )
     parser.add_argument(
@@ -136,10 +160,14 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--strip_thinking_before_judging",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        type=str2bool,
         help=(
             "If specified, strip visible reasoning traces from model completions "
-            "before sending them to the judge."
+            "before sending them to the judge. Accepts a bare flag or an "
+            "explicit --strip_thinking_before_judging=true/false value."
         ),
     )
     parser.add_argument(

--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -13,6 +13,7 @@ from judgearena.arenas_utils import _extract_instruction_text, load_arena_datafr
 from judgearena.cli_common import BaseCliArgs
 from judgearena.evaluate import judge_and_parse_prefs, resolve_run_judge_prompt
 from judgearena.generate import generate_instructions
+from judgearena.generate_and_evaluate import _build_generation_engine_kwargs
 from judgearena.log import get_logger
 from judgearena.repro import _to_jsonable
 from judgearena.utils import cache_function_dataframe, compute_pref_summary, make_model
@@ -293,8 +294,10 @@ def main(args: CliEloArgs) -> dict:
     # Step 2: Generate completions for the model under evaluation
     logger.info("Step 2: Generating completions with %s", args.model)
 
-    # Only pass extra engine kwargs that are not None
-    extra_kwargs = dict(args.engine_kwargs)
+    # Mirror the benchmark generation path: inject the reasoning-token
+    # sub-budget for thinking models so the Elo battles use the same
+    # generation protocol as the rest of the benchmarks.
+    extra_kwargs = _build_generation_engine_kwargs(args, args.model)
     if args.max_model_len is not None:
         extra_kwargs["max_model_len"] = args.max_model_len
     if args.chat_template is not None:
@@ -400,6 +403,7 @@ def main(args: CliEloArgs) -> dict:
             completions_B=completions_B,
             swap_mode=args.swap_mode,
             provide_explanation=args.provide_explanation,
+            strip_thinking_before_judging=args.strip_thinking_before_judging,
             system_prompt=resolved_prompt.system_prompt,
             user_prompt_template=resolved_prompt.user_prompt_template,
             prompt_preset=resolved_prompt.preset_name,
@@ -419,7 +423,12 @@ def main(args: CliEloArgs) -> dict:
             }
         )
 
+    # Stripping reasoning traces changes the judged text but not the cached
+    # completions, so it must be part of the judge cache key. Only append when
+    # enabled so prior (non-stripped) runs keep their existing cache hashes.
     judge_cache_suffix = f"judge_{cache_suffix}"
+    if args.strip_thinking_before_judging:
+        judge_cache_suffix += "_stripthinking"
     df_judge = cache_function_dataframe(
         run_judge,
         ignore_cache=args.ignore_cache,

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import re
 import time
@@ -165,6 +166,13 @@ def _is_retryable_error(e: Exception) -> bool:
     # langchain-openai raises ValueError(response_dict.get("error")) where the
     # error value is a dict like {'message': '...', 'code': 408}
     _RETRYABLE_CODES = {408, 429, 502, 503, 504}
+    # A gateway/proxy that returns a non-JSON body (an HTML 5xx page, an empty
+    # body, or a truncated/streamed chunk) makes the HTTP client raise
+    # JSONDecodeError while parsing the response. These are transient and safe
+    # to retry. JSONDecodeError subclasses ValueError but carries a string arg,
+    # so it must be matched before the dict-arg branch below.
+    if isinstance(e, json.JSONDecodeError):
+        return True
     if isinstance(e, ValueError) and e.args:
         arg = e.args[0]
         if isinstance(arg, dict) and arg.get("code") in _RETRYABLE_CODES:
@@ -174,6 +182,8 @@ def _is_retryable_error(e: Exception) -> bool:
     return (
         any(str(code) in error_str for code in _RETRYABLE_CODES)
         or "rate" in error_str.lower()
+        or "Expecting value" in error_str
+        or "JSONDecodeError" in error_str
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,6 +294,45 @@ def test_elo_forwards_optional_flags(capture_mains):
     assert elo_args.judge_user_prompt_file == "user.txt"
 
 
+def test_boolean_flags_accept_explicit_values(capture_mains):
+    """Slurmpilot serialises dict python_args as --key=value, so the boolean
+    flags must accept --flag=True/False (not only bare store_true switches)."""
+    cli_module.cli(
+        [
+            "--task",
+            "elo-lmarena-140k",
+            "--model_A",
+            "Dummy/X",
+            "--judge",
+            "Dummy/J",
+            "--provide_explanation=False",
+            "--strip_thinking_before_judging=True",
+        ]
+    )
+    elo_args: CliEloArgs = capture_mains["args"]
+    assert elo_args.provide_explanation is False
+    assert elo_args.strip_thinking_before_judging is True
+
+
+def test_boolean_flags_work_as_bare_switches(capture_mains):
+    """Interactive bare-flag usage stays True (const) for backward compatibility."""
+    cli_module.cli(
+        [
+            "--task",
+            "elo-lmarena-140k",
+            "--model_A",
+            "Dummy/X",
+            "--judge",
+            "Dummy/J",
+            "--provide_explanation",
+            "--strip_thinking_before_judging",
+        ]
+    )
+    elo_args: CliEloArgs = capture_mains["args"]
+    assert elo_args.provide_explanation is True
+    assert elo_args.strip_thinking_before_judging is True
+
+
 def test_engine_kwargs_parsed_as_json(capture_mains):
     cli_module.cli(
         [

--- a/tests/test_estimate_elo_ratings.py
+++ b/tests/test_estimate_elo_ratings.py
@@ -219,6 +219,121 @@ def test_main_swap_mode_forwarded_to_judge(monkeypatch):
     assert captured.get("swap_mode") == "both"
 
 
+def test_main_strip_thinking_forwarded_to_judge(monkeypatch):
+    """strip_thinking_before_judging from CliEloArgs must reach the judge.
+
+    Regression test: the Elo path previously ignored
+    --strip_thinking_before_judging, so reasoning traces were judged verbatim
+    even though the benchmark path stripped them.
+    """
+    captured = {}
+
+    def spy_judge(
+        judge_chat_model,
+        instructions,
+        completions_A,
+        completions_B,
+        swap_mode="fixed",
+        strip_thinking_before_judging=False,
+        **kwargs,
+    ):
+        captured["strip_thinking_before_judging"] = strip_thinking_before_judging
+        n = len(instructions)
+        dummy = JudgeAnnotation(
+            judge_completion="score A: 0 score B: 10",
+            instruction="",
+            completion_A="",
+            completion_B="",
+        )
+        return [dummy] * n, None, pd.Series([1.0] * n)
+
+    monkeypatch.setattr(estimate_elo_ratings, "judge_and_parse_prefs", spy_judge)
+    main(_default_args(strip_thinking_before_judging=True))
+    assert captured.get("strip_thinking_before_judging") is True
+
+
+def test_main_thinking_budget_injected_for_thinking_model(monkeypatch):
+    """A thinking battle model gets a reasoning sub-budget capped by max_out_tokens.
+
+    Regression test: the Elo path previously ignored
+    --battle_thinking_token_budget, so reasoning generation was unbounded.
+    """
+    captured = {}
+
+    def spy_generate(instructions, model, **kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame(
+            {
+                "completion": [
+                    f"Synthetic completion {i}" for i in range(len(instructions))
+                ],
+                "instruction_index": range(len(instructions)),
+            }
+        )
+
+    monkeypatch.setattr(estimate_elo_ratings, "generate_instructions", spy_generate)
+    main(
+        _default_args(
+            model="VLLM/Qwen/Qwen3.5-9B",
+            battle_thinking_token_budget=32768,
+            max_out_tokens_models=49152,
+        )
+    )
+    assert captured.get("thinking_token_budget") == 32768
+
+
+def test_main_thinking_budget_capped_by_max_out_tokens(monkeypatch):
+    """The reasoning sub-budget never exceeds max_out_tokens_models."""
+    captured = {}
+
+    def spy_generate(instructions, model, **kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame(
+            {
+                "completion": [
+                    f"Synthetic completion {i}" for i in range(len(instructions))
+                ],
+                "instruction_index": range(len(instructions)),
+            }
+        )
+
+    monkeypatch.setattr(estimate_elo_ratings, "generate_instructions", spy_generate)
+    main(
+        _default_args(
+            model="VLLM/Qwen/Qwen3.5-9B",
+            battle_thinking_token_budget=100000,
+            max_out_tokens_models=4096,
+        )
+    )
+    assert captured.get("thinking_token_budget") == 4096
+
+
+def test_main_thinking_budget_absent_for_nonthinking_model(monkeypatch):
+    """Non-thinking battle models never receive a thinking_token_budget."""
+    captured = {}
+
+    def spy_generate(instructions, model, **kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame(
+            {
+                "completion": [
+                    f"Synthetic completion {i}" for i in range(len(instructions))
+                ],
+                "instruction_index": range(len(instructions)),
+            }
+        )
+
+    monkeypatch.setattr(estimate_elo_ratings, "generate_instructions", spy_generate)
+    main(
+        _default_args(
+            model="VLLM/allenai/Olmo-3-7B-Instruct",
+            battle_thinking_token_budget=32768,
+            max_out_tokens_models=49152,
+        )
+    )
+    assert "thinking_token_budget" not in captured
+
+
 def test_judge_and_parse_prefs_none_prefs_swap_mode_both():
     """swap_mode='both' must not raise when judge output is unparseable (None prefs).
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 import judgearena.instruction_dataset.mt_bench as mt_bench_mod
@@ -25,6 +27,32 @@ def test_safe_parse_int(monkeypatch, raw, expected):
     else:
         monkeypatch.setenv(var, raw)
     assert safe_parse_int(var) == expected
+
+
+def test_is_retryable_error_retries_jsondecodeerror():
+    err = json.JSONDecodeError("Expecting value", "<html>503</html>", 0)
+    assert utils._is_retryable_error(err) is True
+
+
+def test_is_retryable_error_retries_jsondecodeerror_by_message():
+    # Wrapped/re-raised variants may surface only via the string representation.
+    assert (
+        utils._is_retryable_error(
+            Exception("Expecting value: line 739 column 1 (char 4059)")
+        )
+        is True
+    )
+
+
+def test_is_retryable_error_retries_transient_http_codes():
+    assert utils._is_retryable_error(Exception("HTTP 503 Service Unavailable")) is True
+    assert (
+        utils._is_retryable_error(ValueError({"message": "slow", "code": 429})) is True
+    )
+
+
+def test_is_retryable_error_does_not_retry_auth_failure():
+    assert utils._is_retryable_error(Exception("401 User not found.")) is False
 
 
 def test_download_all_dispatches_arena_hard_versions(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- The LMArena Elo entrypoint (`estimate_elo_ratings.py`) accepted `--strip_thinking_before_judging` and `--battle_thinking_token_budget` via `CliEloArgs` but **silently ignored both**: generation built engine kwargs without the thinking-token sub-budget, and the judge call omitted the strip flag. This made Elo inconsistent with the benchmark path and produced ranking anomalies (e.g. Olmo-3-7B-Think below Olmo-3-7B-Instruct).
- Generation now reuses `_build_generation_engine_kwargs` to inject the thinking-token budget for VLLM thinking models (capped by `max_out_tokens_models`).
- The judge call forwards `strip_thinking_before_judging`.
- The judge cache suffix gains a `_stripthinking` marker (only when enabled) so prior non-stripped caches invalidate while existing hashes are preserved.
- `_is_retryable_error` now retries transient `json.JSONDecodeError` raised when an OpenRouter gateway returns non-JSON (HTML) error bodies.
- `--provide_explanation` / `--strip_thinking_before_judging` accept explicit `true/false` via `str2bool`, keeping bare-flag behavior.

## Why stacked here
This depends on the Elo entrypoint introduced in `pr32-split-v3/05.5-elo-sampling`, which is not yet in `main`, so the PR targets that branch.

## Test plan
- [x] `tests/test_estimate_elo_ratings.py` — strip flag forwarded, thinking-budget injected/capped, absent for non-thinking models (15 passed)
- [x] `tests/test_cli.py` — `str2bool` flag parsing (30 passed)
- [x] `tests/test_utils.py` — `_is_retryable_error` retries JSONDecodeError / transient HTTP, not auth (passed)
- [x] `ruff check` + `ruff-format` clean

Includes-AI-Code: true