### PR TITLE
Honor strip-thinking and thinking budget in LMArena Elo path

### DIFF
--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -18,6 +18,7 @@ from judgearena.evaluate import (
     resolve_run_judge_prompt,
 )
 from judgearena.generate import generate_instructions
+from judgearena.generate_and_evaluate import _build_generation_kwargs
 from judgearena.log import get_logger
 from judgearena.models import build_default_judge_model_kwargs, make_model
 from judgearena.repro import _to_jsonable
@@ -301,7 +302,11 @@ def main(cfg: "RunConfig") -> dict:
     # Step 2: Generate completions for the model under evaluation
     logger.info("Step 2: Generating completions with %s", cfg.model.name)
 
-    extra_kwargs = cfg.model.evaluated_generation_kwargs()
+    # Mirror the benchmark generation path so Elo battles honor the
+    # thinking-token sub-budget for thinking models (the Elo entrypoint
+    # previously called evaluated_generation_kwargs() directly and silently
+    # dropped battle_thinking_token_budget).
+    extra_kwargs = _build_generation_kwargs(cfg, cfg.model.name, role="A")
     use_tqdm = False
     gen_fun = partial(
         generate_instructions,
@@ -401,6 +406,7 @@ def main(cfg: "RunConfig") -> dict:
             completions_B=completions_B,
             swap_mode=cfg.judge.swap_mode,
             provide_explanation=cfg.judge.provide_explanation,
+            strip_thinking_before_judging=cfg.judge.strip_thinking_before_judging,
             system_prompt=resolved_prompt.system_prompt,
             user_prompt_template=resolved_prompt.user_prompt_template,
             prompt_preset=resolved_prompt.preset_name,
@@ -437,7 +443,12 @@ def main(cfg: "RunConfig") -> dict:
             }
         )
 
+    # Stripping reasoning traces changes the judged text but not the cached
+    # completions, so it must be part of the judge cache key. Only append when
+    # enabled so prior (non-stripped) runs keep their existing cache hashes.
     judge_cache_suffix = f"judge_{cache_suffix}"
+    if cfg.judge.strip_thinking_before_judging:
+        judge_cache_suffix += "_stripthinking"
     df_judge = cache_function_dataframe(
         run_judge,
         ignore_cache=cfg.run.ignore_cache,

--- a/judgearena/models.py
+++ b/judgearena/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import time
 import warnings
@@ -105,9 +106,10 @@ def _resolve_chat_template_kwargs(
 def _is_retryable_error(e: Exception) -> bool:
     """Return True if the exception is a transient server error that should be retried.
 
-    Handles two formats:
+    Handles three formats:
     - String representation contains the HTTP code (most providers)
     - ValueError raised by langchain-openai with a dict arg: {'message': ..., 'code': 429}
+    - json.JSONDecodeError when a gateway returns a non-JSON (e.g. HTML) body
     """
     # langchain-openai raises ValueError(response_dict.get("error")) where the
     # error value is a dict like {'message': '...', 'code': 408}
@@ -117,10 +119,19 @@ def _is_retryable_error(e: Exception) -> bool:
         if isinstance(arg, dict) and arg.get("code") in _RETRYABLE_CODES:
             return True
 
+    # Gateways (e.g. OpenRouter) intermittently return non-JSON error bodies that
+    # surface as JSONDecodeError while parsing the response. These are transient
+    # and safe to retry. JSONDecodeError subclasses ValueError but carries a
+    # string arg, so it bypasses the dict-code check above.
+    if isinstance(e, json.JSONDecodeError):
+        return True
+
     error_str = str(e)
     return (
         any(str(code) in error_str for code in _RETRYABLE_CODES)
         or "rate" in error_str.lower()
+        or "Expecting value" in error_str
+        or "JSONDecodeError" in error_str
     )
 
 

--- a/tests/test_chat_vllm.py
+++ b/tests/test_chat_vllm.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from types import SimpleNamespace
 
@@ -265,3 +266,29 @@ def test_chat_vllm_preserves_explicit_reasoning_settings_for_non_qwen(monkeypatc
     assert (
         captured["llm_init"]["kwargs"]["reasoning_config"] is explicit_reasoning_config
     )
+
+
+def test_is_retryable_error_retries_jsondecodeerror():
+    err = json.JSONDecodeError("Expecting value", "<html>503</html>", 0)
+    assert models._is_retryable_error(err) is True
+
+
+def test_is_retryable_error_retries_jsondecodeerror_by_message():
+    # Wrapped/re-raised variants may surface only via the string representation.
+    assert (
+        models._is_retryable_error(
+            Exception("Expecting value: line 739 column 1 (char 4059)")
+        )
+        is True
+    )
+
+
+def test_is_retryable_error_retries_transient_http_codes():
+    assert models._is_retryable_error(Exception("HTTP 503 Service Unavailable")) is True
+    assert (
+        models._is_retryable_error(ValueError({"message": "slow", "code": 429})) is True
+    )
+
+
+def test_is_retryable_error_does_not_retry_auth_failure():
+    assert models._is_retryable_error(Exception("401 User not found.")) is False

--- a/tests/test_estimate_elo_ratings.py
+++ b/tests/test_estimate_elo_ratings.py
@@ -90,11 +90,20 @@ def _default_args(**kwargs) -> RunConfig:
     n_bootstraps = kwargs.pop("n_bootstraps", 3)
     languages = kwargs.pop("languages", None)
     swap_mode = kwargs.pop("swap_mode", "fixed")
+    strip_thinking_before_judging = kwargs.pop("strip_thinking_before_judging", False)
+    battle_thinking_token_budget = kwargs.pop("battle_thinking_token_budget", None)
     assert not kwargs, f"unexpected kwargs: {kwargs}"
+    judge: dict[str, object] = {
+        "model": judge_model,
+        "swap_mode": swap_mode,
+        "strip_thinking_before_judging": strip_thinking_before_judging,
+    }
+    if battle_thinking_token_budget is not None:
+        judge["battle_thinking_token_budget"] = battle_thinking_token_budget
     return RunConfig(
         task="elo-comparia",
         model={"name": model},
-        judge={"model": judge_model, "swap_mode": swap_mode},
+        judge=judge,
         generation={"n_instructions": n_instructions},
         elo={"arena": arena, "n_bootstraps": n_bootstraps, "languages": languages},
     )
@@ -249,6 +258,98 @@ def test_main_swap_mode_forwarded_to_judge(monkeypatch):
     monkeypatch.setattr(estimate_elo_ratings, "judge_and_parse_prefs", spy_judge)
     main(_default_args(swap_mode="both"))
     assert captured.get("swap_mode") == "both"
+
+
+def _spy_judge_capturing(captured):
+    def spy_judge(
+        judge_chat_model,
+        instructions,
+        completions_A,
+        completions_B,
+        swap_mode="fixed",
+        strip_thinking_before_judging=False,
+        **kwargs,
+    ):
+        captured["strip_thinking_before_judging"] = strip_thinking_before_judging
+        n = len(instructions)
+        dummy = JudgeAnnotation(
+            judge_completion="score A: 0 score B: 10",
+            instruction="",
+            completion_A="",
+            completion_B="",
+        )
+        return [dummy] * n, None, pd.Series([1.0] * n)
+
+    return spy_judge
+
+
+def test_main_strip_thinking_forwarded_to_judge(monkeypatch):
+    """strip_thinking_before_judging from the run config must reach the judge.
+
+    Regression test: the Elo entrypoint accepted the flag but never forwarded it
+    to judge_and_parse_prefs, so reasoning traces were judged verbatim.
+    """
+    captured = {}
+    monkeypatch.setattr(
+        estimate_elo_ratings, "judge_and_parse_prefs", _spy_judge_capturing(captured)
+    )
+    main(_default_args(strip_thinking_before_judging=True))
+    assert captured.get("strip_thinking_before_judging") is True
+
+
+def test_main_strip_thinking_defaults_off(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        estimate_elo_ratings, "judge_and_parse_prefs", _spy_judge_capturing(captured)
+    )
+    main(_default_args())
+    assert captured.get("strip_thinking_before_judging") is False
+
+
+def _spy_generate_capturing(captured):
+    def spy_generate(instructions, model, **kwargs):
+        captured["gen_kwargs"] = kwargs
+        return pd.DataFrame(
+            {
+                "completion": [f"c{i}" for i in range(len(instructions))],
+                "instruction_index": range(len(instructions)),
+            }
+        )
+
+    return spy_generate
+
+
+def test_main_thinking_budget_injected_for_thinking_model(monkeypatch):
+    """battle_thinking_token_budget must reach generation for VLLM thinking models."""
+    captured = {}
+    monkeypatch.setattr(
+        estimate_elo_ratings, "generate_instructions", _spy_generate_capturing(captured)
+    )
+    main(_default_args(model="VLLM/Qwen/Qwen3.5-9B", battle_thinking_token_budget=128))
+    assert captured["gen_kwargs"].get("thinking_token_budget") == 128
+
+
+def test_main_thinking_budget_capped_by_max_out_tokens(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        estimate_elo_ratings, "generate_instructions", _spy_generate_capturing(captured)
+    )
+    cfg = _default_args(
+        model="VLLM/Qwen/Qwen3.5-9B", battle_thinking_token_budget=10**9
+    )
+    main(cfg)
+    assert (
+        captured["gen_kwargs"].get("thinking_token_budget") == cfg.model.max_out_tokens
+    )
+
+
+def test_main_thinking_budget_absent_for_nonthinking_model(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        estimate_elo_ratings, "generate_instructions", _spy_generate_capturing(captured)
+    )
+    main(_default_args(model="Dummy/my model", battle_thinking_token_budget=128))
+    assert "thinking_token_budget" not in captured["gen_kwargs"]
 
 
 def test_judge_and_parse_prefs_none_prefs_swap_mode_both():


### PR DESCRIPTION
## Summary
The LMArena Elo entrypoint (`estimate_elo_ratings.py`) exposed `strip_thinking_before_judging` and `battle_thinking_token_budget` (via `cfg.judge`) but **silently ignored both**: generation called `cfg.model.evaluated_generation_kwargs()` directly (no thinking-token sub-budget) and the judge call omitted the strip flag. This made Elo inconsistent with the benchmark path and produced ranking anomalies (e.g. Olmo-3-7B-Think below Olmo-3-7B-Instruct).

- Generation reuses `_build_generation_kwargs(cfg, ..., role="A")` so VLLM thinking models receive the thinking-token budget (capped by `max_out_tokens`), matching `generate_and_evaluate` and `mt_bench`.
- The judge call forwards `strip_thinking_before_judging` (already supported by `judge_and_parse_prefs`).
- The judge cache suffix gains a `_stripthinking` marker (only when enabled) so prior non-stripped caches invalidate while existing hashes are preserved.
- `models._is_retryable_error` now retries transient `json.JSONDecodeError` raised when an OpenRouter gateway returns non-JSON (HTML) error bodies.

## Notes
- Supersedes #69, which targeted the now-merged `pr32-split-v3/05.5-elo-sampling` (PR #58). This PR is rebased onto current `main` and adapted to the post-refactor structure (`cfg`/pydantic config, `models.py`, `utils/` package). The earlier `str2bool`/`cli_common` changes are obsolete because pydantic already coerces `--flag=true/false`.

## Test plan
- [x] `tests/test_estimate_elo_ratings.py` — strip flag forwarded (on/off), thinking-budget injected/capped/absent (passed)
- [x] `tests/test_chat_vllm.py` — `_is_retryable_error` retries JSONDecodeError / transient HTTP, not auth (passed)
- [x] 31 passed across both files; `ruff check` + `ruff-format` clean; pre-commit hooks pass

Includes-AI-Code: true