### PR TITLE
Add meta evaluation task

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Task names follow [LMHarness](https://github.com/EleutherAI/lm-evaluation-harnes
 | `m-arena-hard-v2.0-EU`       | All EU v2.0 languages combined                                                                                                                                                  |
 | `mt-bench`                   | Multi-turn benchmark with FastChat-compatible pairwise judging                                                                                                                  |
 | `fluency-{lang}`             | Fluency evaluation for pretrained models across 43 languages from `geoalgo/multilingual-fluency` (e.g. `fluency-french`, `fluency-mandarin-chinese`, `fluency-standard-arabic`) |
+| `meta-eval`                  | Judge meta-evaluation against human-labeled arena battles (not generator ELO)                                                                                                   |
 
 For MT-Bench, the default pairwise baseline is `gpt-4`.
 We diverge from FastChat's own `pairwise-baseline` default (`gpt-3.5-turbo`) to keep
@@ -283,6 +284,59 @@ For m-Arena-Hard, baseline completions are tied to the benchmark release:
 | `elo-lmarena-140k`  | Battles sampled from `lmarena-ai/arena-human-preference-140k`      |
 | `elo-lmarena`       | Union of all `LMArena-*` variants                                  |
 | `elo-comparia`      | Battles sampled from the ComparIA arena                            |
+
+## Judge meta-evaluation (`meta-eval`)
+
+`meta-eval` measures how well an LLM judge agrees with **human-labeled arena battles**.
+It does **not** generate model completions and does **not** estimate a generator model's ELO rating.
+Use `elo-*` tasks for generator ELO estimation instead.
+
+The task samples battles from a reference arena (default `LMArena-140k`), asks the judge to label fixed human battles, and reports accuracy, Cohen's kappa, Bradley-Terry ranking agreement, Spearman correlation, ELO MAE, bootstrap uncertainty, and ELO-gap analyses.
+
+```bash
+judgearena \
+  --task meta-eval \
+  --judge_model OpenRouter/deepseek/deepseek-v3.2 \
+  --reference_arena LMArena-140k \
+  --prompt_mode standard \
+  --languages en es \
+  --top_models 20 \
+  --battles_per_model 50 \
+  --n_bootstraps 1000 \
+  --seed 0
+```
+
+### Prompt modes
+
+Only named prompt modes are supported (no custom prompt files):
+
+| `--prompt_mode`           | Description                                      |
+|---------------------------|--------------------------------------------------|
+| `standard`                | Default PairScore judge prompt                   |
+| `arena-hard`              | Arena-Hard Likert verdict parsing                  |
+| `alpaca-eval`             | Alpaca-Eval JSON ordering prompt                 |
+| `alpaca-eval-pair-score`  | Alpaca-Eval prompt with PairScore output           |
+
+PairScore meta-eval uses temperature `0.5` (paper setting). The standard generate+judge benchmark path keeps PairScore temperature `0.3`.
+
+Language filters use ISO 639-1 codes such as `en es fr`.
+
+With `--swap_mode both`, overall accuracy and kappa use both judge orderings
+(the reversed verdict is inverted), while language, ranking, and ELO-gap analyses
+retain one forward-order row per sampled battle to match the reference
+meta-evaluation methodology. `annotations.parquet` stores one row per judge pass
+with an `orientation` column; swapped winners and preferences are normalized
+back to the original model ordering. Cost totals include both passes.
+
+Results are written under `[result_folder]/meta-eval-*` as `args.json`,
+`annotations.parquet`, `results.json`, `summary.csv`, logs, and
+`run-metadata.v1.json`. Judge annotations are cached per battle in
+`$JUDGEARENA_DATA/cache/db/{benchmark}/{judge}.db`. This temporary SQLite WAL
+cache should only be used by a single host; do not share the same database
+concurrently across NFS-mounted compute nodes. Annotation artifacts include
+character-based token estimates. Equivalent OpenRouter cost is reported only
+when `[data_root]/cache/openrouter_pricing.json` already contains the judge
+model; meta-eval never fetches pricing from compute nodes.
 
 ## 📈 Estimating ELO Ratings
 

--- a/judgearena/arenas_utils.py
+++ b/judgearena/arenas_utils.py
@@ -11,8 +11,8 @@ from judgearena.log import get_logger
 logger = get_logger(__name__)
 
 
-def _extract_instruction_text(turn: dict) -> str:
-    """Extract plain instruction text from a conversation first turn.
+def extract_turn_text(turn: dict) -> str:
+    """Extract plain text from an arena conversation turn.
 
     Handles both the 100k schema (content is a plain string) and the 140k
     schema (content is an array of {type, text, ...} objects).
@@ -20,7 +20,13 @@ def _extract_instruction_text(turn: dict) -> str:
     content = turn["content"]
     if isinstance(content, str):
         return content
-    return " ".join(block["text"] for block in content if block.get("type") == "text")
+    if isinstance(content, (list, tuple)):
+        return " ".join(
+            str(block.get("text", ""))
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+    return str(content)
 
 
 KNOWN_ARENAS = ["LMArena-100k", "LMArena-55k", "LMArena-140k", "ComparIA"]
@@ -144,7 +150,7 @@ def _load_arena_dataframe(
         df["question_id"] = df["id"]
 
     df["lang"] = df["conversation_a"].apply(
-        lambda conv: detect_language(_extract_instruction_text(conv[0])).lower()
+        lambda conv: detect_language(extract_turn_text(conv[0])).lower()
     )
 
     cols = [

--- a/judgearena/cli.py
+++ b/judgearena/cli.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 from pydantic import ValidationError
 
 from judgearena.config import build_run_config
-from judgearena.constants import ELO_TASK_PREFIX
+from judgearena.constants import ELO_TASK_PREFIX, META_EVAL_TASK
 from judgearena.estimate_elo_ratings import main as main_elo
 from judgearena.generate_and_evaluate import main as main_generate_and_evaluate
 from judgearena.log import configure_logging, get_logger
+from judgearena.meta_eval.cli_args import meta_eval_args_from_config
+from judgearena.meta_eval.runner import run_or_exit as main_meta_eval
 
 logger = get_logger(__name__)
 
@@ -34,7 +36,9 @@ def cli(argv: list[str] | None = None) -> None:
 
     configure_logging(cfg.run.verbosity, log_file=cfg.run.log_file)
     logger.debug("Running with config: %s", cfg.model_dump())
-    if cfg.task.startswith(ELO_TASK_PREFIX):
+    if cfg.task == META_EVAL_TASK:
+        main_meta_eval(meta_eval_args_from_config(cfg))
+    elif cfg.task.startswith(ELO_TASK_PREFIX):
         main_elo(cfg)
     else:
         main_generate_and_evaluate(cfg)

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -17,7 +17,7 @@ from pydantic_settings import (
 )
 
 from judgearena.baselines import native_pairwise_baseline
-from judgearena.constants import ELO_TASK_PREFIX, ELO_TASK_TO_ARENA
+from judgearena.constants import ELO_TASK_PREFIX, ELO_TASK_TO_ARENA, META_EVAL_TASK
 
 # Set by build_run_config() for the duration of RunConfig() construction.
 _ACTIVE_CONFIG_PATH: str | None = None
@@ -328,6 +328,47 @@ class EloArgs(BaseModel):
     Defaults to all. Requires ``calibrate_temperature``."""
 
 
+class MetaEvalArgs(BaseModel):
+    """Settings for judge meta-evaluation against human arena labels."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    reference_arena: str = "LMArena-140k"
+    """Human-labeled reference arena to sample battles from."""
+
+    prompt_mode: Literal[
+        "standard",
+        "arena-hard",
+        "alpaca-eval",
+        "alpaca-eval-pair-score",
+    ] = "standard"
+    """Named judge prompt and parser mode."""
+
+    top_models: int = 20
+    """Number of top models by battle count to include."""
+
+    battles_per_model: int = 50
+    """Battles sampled per top model."""
+
+    batch_size: int = Field(default=50, gt=0)
+    """Annotation batch size."""
+
+    languages: list[str] | None = None
+    """Restrict reference battles to ISO 639-1 language codes."""
+
+    n_bootstraps: int = 20
+    """Bootstrap samples used for uncertainty estimates."""
+
+    elo_gap_battles: list[int] = Field(default_factory=lambda: [10, 20, 30, 40, 50])
+    """Battle counts included in the ELO-gap analysis."""
+
+    elo_gap_seeds: int = 10
+    """Random seeds used for ELO-gap subsampling."""
+
+    include_human_ties: bool = False
+    """Include human-labeled ties in the primary agreement view."""
+
+
 class RunArgs(BaseModel):
     """Run-level settings: seed, output location, caching, and logging."""
 
@@ -367,8 +408,9 @@ class RunConfig(BaseSettings):
 
     task: str
     """Benchmark to run. Generate+judge: ``alpaca-eval``, ``arena-hard-v2.0``,
-    ``m-arena-hard-*``, ``mt-bench``, ``fluency-*``. ELO: ``elo-lmarena-100k``,
-    ``elo-lmarena-140k``, ``elo-lmarena``, ``elo-comparia``."""
+    ``m-arena-hard-*``, ``mt-bench``, ``fluency-*``. Meta-evaluation:
+    ``meta-eval``. ELO: ``elo-lmarena-100k``, ``elo-lmarena-140k``,
+    ``elo-lmarena``, ``elo-comparia``."""
 
     model: ModelArgs = Field(default_factory=ModelArgs)
     """Model(s) under evaluation and their generation settings."""
@@ -382,11 +424,39 @@ class RunConfig(BaseSettings):
     elo: EloArgs | None = None
     """ELO-task settings (only for ``elo-*`` tasks)."""
 
+    meta_eval: MetaEvalArgs | None = None
+    """Judge meta-evaluation settings (only for ``meta-eval``)."""
+
     run: RunArgs = Field(default_factory=RunArgs)
     """Run-level settings (seed, output, caching, logging)."""
 
     @model_validator(mode="after")
     def _validate(self) -> RunConfig:
+        if self.task == META_EVAL_TASK:
+            if self.meta_eval is None:
+                self.meta_eval = MetaEvalArgs()
+            if self.elo is not None:
+                raise ValueError("elo config is only valid for elo-* tasks.")
+            if self.model.name is not None or self.model.baseline is not None:
+                raise ValueError(
+                    "model config is not used for meta-eval; "
+                    "only judge.model is required."
+                )
+            if self.model.max_out_tokens != ModelArgs().max_out_tokens:
+                raise ValueError(
+                    "model.max_out_tokens is not used for meta-eval because "
+                    "no model completions are generated."
+                )
+            if self.generation.n_instructions is not None:
+                raise ValueError(
+                    "generation.n_instructions is not used for meta-eval; use "
+                    "meta_eval.top_models and meta_eval.battles_per_model."
+                )
+            return self
+
+        if self.meta_eval is not None:
+            raise ValueError("meta_eval config is only valid for the meta-eval task.")
+
         is_elo = self.task.startswith(ELO_TASK_PREFIX)
         if is_elo:
             if self.elo is None:

--- a/judgearena/constants.py
+++ b/judgearena/constants.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 ELO_TASK_PREFIX = "elo-"
 """Prefix marking a task as an ELO-rating run (e.g. ``elo-lmarena-100k``)."""
 
+META_EVAL_TASK = "meta-eval"
+"""Task identifier for judge meta-evaluation against human arena labels."""
+
 # Lowercase CLI task name -> canonical arena identifier used inside
 # the arena loaders and the ``benchmark`` column of saved battle dataframes.
 # The CLI stays lowercase (matching ``alpaca-eval`` conventions) while internal

--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 
-from judgearena.arenas_utils import _extract_instruction_text, load_arena_dataframe
+from judgearena.arenas_utils import extract_turn_text, load_arena_dataframe
 from judgearena.battles import Leaderboard, summarize_bootstrap, write_battles
 from judgearena.benchmark import build_generation_kwargs
 from judgearena.evaluate import (
@@ -402,7 +402,7 @@ def main(cfg: "RunConfig") -> dict:
     # Extract user instructions (first turn of conversation_a)
     instructions = pd.Series(
         [
-            _extract_instruction_text(row["conversation_a"][0])
+            extract_turn_text(row["conversation_a"][0])
             for _, row in df_battles.iterrows()
         ],
         name="instruction",
@@ -473,9 +473,9 @@ def main(cfg: "RunConfig") -> dict:
 
     opponent_completions = [
         (
-            _extract_instruction_text(row["conversation_a"][1])
+            extract_turn_text(row["conversation_a"][1])
             if use_model_a_as_opponent[i]
-            else _extract_instruction_text(row["conversation_b"][1])
+            else extract_turn_text(row["conversation_b"][1])
         )
         for i, (_, row) in enumerate(df_battles.iterrows())
     ]
@@ -641,15 +641,15 @@ def main(cfg: "RunConfig") -> dict:
             )
 
             cal_instructions = [
-                _extract_instruction_text(df_arena_all.loc[i, "conversation_a"][0])
+                extract_turn_text(df_arena_all.loc[i, "conversation_a"][0])
                 for i in cal_battles.index
             ]
             cal_completions_a = [
-                _extract_instruction_text(df_arena_all.loc[i, "conversation_a"][1])
+                extract_turn_text(df_arena_all.loc[i, "conversation_a"][1])
                 for i in cal_battles.index
             ]
             cal_completions_b = [
-                _extract_instruction_text(df_arena_all.loc[i, "conversation_b"][1])
+                extract_turn_text(df_arena_all.loc[i, "conversation_b"][1])
                 for i in cal_battles.index
             ]
 

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -262,7 +262,7 @@ def annotate_battles(
     ):
         annotations.append(
             JudgeAnnotation(
-                judge_input=judge_input,
+                judge_input=judge_input.to_string(),
                 judge_completion=judge_completion,
                 instruction=instruction,
                 completion_A=completion_A,

--- a/judgearena/meta_eval/__init__.py
+++ b/judgearena/meta_eval/__init__.py
@@ -1,0 +1,1 @@
+"""Judge meta-evaluation against human-labeled arena battles."""

--- a/judgearena/meta_eval/annotate.py
+++ b/judgearena/meta_eval/annotate.py
@@ -1,0 +1,273 @@
+"""Run LLM judge annotations for meta-evaluation battles."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from judgearena.arenas_utils import extract_turn_text
+from judgearena.evaluate import JudgeAnnotation, annotate_battles
+from judgearena.meta_eval.cache import (
+    AnnotationCache,
+    AnnotationEntry,
+    AnnotationKey,
+)
+from judgearena.meta_eval.cli_args import CliMetaEvalArgs
+from judgearena.meta_eval.cost import (
+    estimate_annotation_cost_usd,
+    estimate_token_count,
+)
+from judgearena.meta_eval.parsers import add_parsed_columns, invert_winner
+
+
+def _battle_texts(df_batch: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:
+    instructions = [extract_turn_text(conv[0]) for conv in df_batch["conversation_a"]]
+    completions_a = [
+        extract_turn_text(conv[1]) if len(conv) > 1 else ""
+        for conv in df_batch["conversation_a"]
+    ]
+    completions_b = [
+        extract_turn_text(conv[1]) if len(conv) > 1 else ""
+        for conv in df_batch["conversation_b"]
+    ]
+    return instructions, completions_a, completions_b
+
+
+def _swap_batch(df_batch: pd.DataFrame) -> pd.DataFrame:
+    swapped = df_batch.copy()
+    swapped["conversation_a"] = df_batch["conversation_b"]
+    swapped["conversation_b"] = df_batch["conversation_a"]
+    swapped["model_a"] = df_batch["model_b"]
+    swapped["model_b"] = df_batch["model_a"]
+    return swapped
+
+
+def _annotations_to_frame(
+    df_batch: pd.DataFrame,
+    annotations,
+    *,
+    prompt_mode: str,
+    judge_model: str,
+) -> pd.DataFrame:
+    rows = []
+    for ann, (_, battle) in zip(annotations, df_batch.iterrows(), strict=True):
+        judge_input = ann.judge_input or ""
+        cost_usd, cost_source = estimate_annotation_cost_usd(
+            judge_input=judge_input,
+            judge_completion=ann.judge_completion,
+            judge_model=judge_model,
+        )
+        rows.append(
+            {
+                "question_id": battle["question_id"],
+                "model_a": battle["model_a"],
+                "model_b": battle["model_b"],
+                "winner": battle["winner"],
+                "lang": battle["lang"],
+                "benchmark": battle["benchmark"],
+                "instruction": ann.instruction,
+                "completion_a": ann.completion_A,
+                "completion_b": ann.completion_B,
+                "judge_input": ann.judge_input,
+                "judge_completion": ann.judge_completion,
+                "estimated_input_tokens": estimate_token_count(judge_input),
+                "estimated_output_tokens": estimate_token_count(ann.judge_completion),
+                "cost_usd": cost_usd,
+                "cost_source": cost_source,
+            }
+        )
+    return add_parsed_columns(pd.DataFrame(rows), prompt_mode)
+
+
+def _judge_cache_name(args: CliMetaEvalArgs) -> str:
+    if args.prompt_mode == "standard":
+        return args.judge_model
+    return f"{args.judge_model}::{args.prompt_mode}"
+
+
+def _cache_keys(
+    df_batch: pd.DataFrame,
+    *,
+    judge: str,
+) -> list[AnnotationKey]:
+    return [
+        AnnotationKey(
+            benchmark=str(battle["benchmark"]),
+            instruction_id=str(battle["question_id"]),
+            model_a=str(battle["model_a"]),
+            model_b=str(battle["model_b"]),
+            judge=judge,
+        )
+        for _, battle in df_batch.iterrows()
+    ]
+
+
+def _annotation_from_entry(
+    entry: AnnotationEntry,
+    *,
+    instruction: str,
+    completion_a: str,
+    completion_b: str,
+) -> JudgeAnnotation:
+    return JudgeAnnotation(
+        instruction=instruction,
+        completion_A=completion_a,
+        completion_B=completion_b,
+        judge_completion=entry.judge_completion,
+        judge_input=entry.judge_input,
+    )
+
+
+def _run_cached_batch(
+    df_batch: pd.DataFrame,
+    args: CliMetaEvalArgs,
+    *,
+    judge_chat_model,
+    annotation_cache: AnnotationCache,
+    prompt_spec,
+    swapped: bool,
+) -> pd.DataFrame:
+    working = _swap_batch(df_batch) if swapped else df_batch
+    instructions, completions_a, completions_b = _battle_texts(working)
+    judge = _judge_cache_name(args)
+    keys = _cache_keys(working, judge=judge)
+    cached_entries = (
+        [None] * len(keys)
+        if args.ignore_cache
+        else annotation_cache.batch_get_annotations(keys)
+    )
+    missing_indices = [
+        index for index, entry in enumerate(cached_entries) if entry is None
+    ]
+
+    if missing_indices:
+        new_annotations = annotate_battles(
+            judge_chat_model=judge_chat_model,
+            instructions=[instructions[index] for index in missing_indices],
+            completions_A=[completions_a[index] for index in missing_indices],
+            completions_B=[completions_b[index] for index in missing_indices],
+            system_prompt=prompt_spec.system_prompt,
+            user_prompt_template=prompt_spec.user_prompt_template,
+            truncate_input_chars=args.truncate_judge_input_chars,
+            provide_explanation=args.provide_explanation,
+        )
+        new_entries = [
+            AnnotationEntry(
+                **key.__dict__,
+                judge_input=annotation.judge_input or "",
+                judge_completion=annotation.judge_completion,
+            )
+            for key, annotation in zip(
+                [keys[index] for index in missing_indices],
+                new_annotations,
+                strict=True,
+            )
+        ]
+        annotation_cache.batch_put(new_entries)
+        for index, entry in zip(missing_indices, new_entries, strict=True):
+            cached_entries[index] = entry
+
+    annotations = [
+        _annotation_from_entry(
+            entry,
+            instruction=instruction,
+            completion_a=completion_a,
+            completion_b=completion_b,
+        )
+        for entry, instruction, completion_a, completion_b in zip(
+            cached_entries,
+            instructions,
+            completions_a,
+            completions_b,
+            strict=True,
+        )
+        if entry is not None
+    ]
+    return _annotations_to_frame(
+        working,
+        annotations,
+        prompt_mode=args.prompt_mode,
+        judge_model=args.judge_model,
+    )
+
+
+def _normalize_pass_frame(
+    pass_frame: pd.DataFrame,
+    original_batch: pd.DataFrame,
+    *,
+    orientation: str,
+) -> pd.DataFrame:
+    normalized = pass_frame.copy()
+    normalized["orientation"] = orientation
+    normalized["presented_model_a"] = pass_frame["model_a"].tolist()
+    normalized["presented_model_b"] = pass_frame["model_b"].tolist()
+    normalized["presented_completion_a"] = pass_frame["completion_a"].tolist()
+    normalized["presented_completion_b"] = pass_frame["completion_b"].tolist()
+    normalized["model_a"] = original_batch["model_a"].tolist()
+    normalized["model_b"] = original_batch["model_b"].tolist()
+    normalized["winner"] = original_batch["winner"].tolist()
+    if orientation == "swapped":
+        normalized["completion_a"] = pass_frame["completion_b"].tolist()
+        normalized["completion_b"] = pass_frame["completion_a"].tolist()
+        normalized["winner_llm"] = [
+            invert_winner(winner) for winner in pass_frame["winner_llm"]
+        ]
+        normalized["pref_llm"] = 1.0 - pass_frame["pref_llm"]
+    return normalized
+
+
+def annotate_sample(
+    df_sample: pd.DataFrame,
+    args: CliMetaEvalArgs,
+    *,
+    judge_chat_model,
+    prompt_spec,
+    annotation_cache: AnnotationCache | None = None,
+) -> pd.DataFrame:
+    n_total = len(df_sample)
+    n_batches = (n_total + args.batch_size - 1) // args.batch_size
+    parts: list[pd.DataFrame] = []
+    owns_cache = annotation_cache is None
+    cache = annotation_cache or AnnotationCache()
+
+    try:
+        for batch_idx in range(n_batches):
+            start = batch_idx * args.batch_size
+            end = min(start + args.batch_size, n_total)
+            df_batch = df_sample.iloc[start:end].copy()
+            batch_df = _run_cached_batch(
+                df_batch,
+                args,
+                judge_chat_model=judge_chat_model,
+                annotation_cache=cache,
+                prompt_spec=prompt_spec,
+                swapped=False,
+            )
+            parts.append(
+                _normalize_pass_frame(
+                    batch_df,
+                    df_batch,
+                    orientation="forward",
+                )
+            )
+
+            if args.swap_mode == "both":
+                swapped_df = _run_cached_batch(
+                    df_batch,
+                    args,
+                    judge_chat_model=judge_chat_model,
+                    annotation_cache=cache,
+                    prompt_spec=prompt_spec,
+                    swapped=True,
+                )
+                parts.append(
+                    _normalize_pass_frame(
+                        swapped_df,
+                        df_batch,
+                        orientation="swapped",
+                    )
+                )
+    finally:
+        if owns_cache:
+            cache.close()
+
+    return pd.concat(parts, ignore_index=True)

--- a/judgearena/meta_eval/cache.py
+++ b/judgearena/meta_eval/cache.py
@@ -1,0 +1,165 @@
+"""SQLite-backed cache for meta-evaluation judge annotations."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import astuple, dataclass, field, fields
+from datetime import UTC, datetime
+from itertools import groupby
+from pathlib import Path
+
+from judgearena.utils import data_root
+
+DEFAULT_DB_DIR = data_root / "cache" / "db"
+
+
+@dataclass(frozen=True)
+class AnnotationEntry:
+    benchmark: str
+    instruction_id: str
+    model_a: str
+    model_b: str
+    judge: str
+    judge_input: str
+    judge_completion: str
+    reasoning_content: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_tokens: int = 0
+    date: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    @classmethod
+    def field_names(cls) -> tuple[str, ...]:
+        return tuple(field_info.name for field_info in fields(cls))
+
+    @classmethod
+    def key_fields(cls) -> tuple[str, ...]:
+        return ("benchmark", "instruction_id", "model_a", "model_b", "judge")
+
+
+@dataclass(frozen=True)
+class AnnotationKey:
+    benchmark: str
+    instruction_id: str
+    model_a: str
+    model_b: str
+    judge: str
+
+    @classmethod
+    def field_names(cls) -> tuple[str, ...]:
+        return tuple(field_info.name for field_info in fields(cls))
+
+
+def _db_path(db_dir: Path, benchmark: str, judge: str) -> Path:
+    return db_dir / benchmark / f"{judge.replace('/', '_')}.db"
+
+
+class AnnotationCache:
+    """Persistent per-battle cache matching the original meta-eval pipeline."""
+
+    def __init__(self, db_dir: Path | str = DEFAULT_DB_DIR) -> None:
+        self._db_dir = Path(db_dir)
+        self._connections: dict[tuple[str, str], sqlite3.Connection] = {}
+
+    def batch_get_annotations(
+        self, keys: list[AnnotationKey]
+    ) -> list[AnnotationEntry | None]:
+        column_names = ", ".join(AnnotationEntry.field_names())
+        results = []
+        for key in keys:
+            row = (
+                self._connection(key.benchmark, key.judge)
+                .execute(
+                    f"SELECT {column_names} FROM annotations "
+                    f"WHERE {self._where_clause()}",
+                    astuple(key),
+                )
+                .fetchone()
+            )
+            results.append(AnnotationEntry(*row) if row else None)
+        return results
+
+    def batch_put(self, entries: list[AnnotationEntry]) -> None:
+        if not entries:
+            return
+        column_names = ", ".join(AnnotationEntry.field_names())
+        placeholders = ", ".join("?" for _ in AnnotationEntry.field_names())
+        sql = (
+            f"INSERT OR REPLACE INTO annotations ({column_names}) "
+            f"VALUES ({placeholders})"
+        )
+
+        def cache_partition(entry: AnnotationEntry) -> tuple[str, str]:
+            return entry.benchmark, entry.judge
+
+        for (benchmark, judge), group in groupby(
+            sorted(entries, key=cache_partition),
+            key=cache_partition,
+        ):
+            connection = self._connection(benchmark, judge)
+            connection.executemany(sql, [astuple(entry) for entry in group])
+            connection.commit()
+
+    def close(self) -> None:
+        for connection in self._connections.values():
+            connection.close()
+        self._connections.clear()
+
+    def _connection(self, benchmark: str, judge: str) -> sqlite3.Connection:
+        key = (benchmark, judge)
+        if key not in self._connections:
+            path = _db_path(self._db_dir, benchmark, judge)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            connection = sqlite3.connect(
+                str(path),
+                check_same_thread=False,
+                timeout=30,
+            )
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._connections[key] = connection
+            self._create_table(connection)
+        return self._connections[key]
+
+    @staticmethod
+    def _create_table(connection: sqlite3.Connection) -> None:
+        integer_fields = {"input_tokens", "output_tokens", "reasoning_tokens"}
+        default_text_fields = {"reasoning_content", "date"}
+        column_definitions = ", ".join(
+            (
+                f"{name} INTEGER NOT NULL DEFAULT 0"
+                if name in integer_fields
+                else (
+                    f"{name} TEXT NOT NULL DEFAULT ''"
+                    if name in default_text_fields
+                    else f"{name} TEXT NOT NULL"
+                )
+            )
+            for name in AnnotationEntry.field_names()
+        )
+        key_columns = ", ".join(AnnotationEntry.key_fields())
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS annotations "
+            f"({column_definitions}, UNIQUE ({key_columns}))"
+        )
+        connection.execute(
+            "CREATE INDEX IF NOT EXISTS idx_annotation_key "
+            f"ON annotations ({key_columns})"
+        )
+        migrations = [
+            "ALTER TABLE annotations ADD COLUMN "
+            "reasoning_content TEXT NOT NULL DEFAULT ''",
+            "ALTER TABLE annotations ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE annotations ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE annotations ADD COLUMN "
+            "reasoning_tokens INTEGER NOT NULL DEFAULT 0",
+        ]
+        for migration in migrations:
+            try:
+                connection.execute(migration)
+            except sqlite3.OperationalError:
+                pass
+        connection.commit()
+
+    @staticmethod
+    def _where_clause() -> str:
+        return " AND ".join(f"{column} = ?" for column in AnnotationKey.field_names())

--- a/judgearena/meta_eval/cli_args.py
+++ b/judgearena/meta_eval/cli_args.py
@@ -1,0 +1,94 @@
+"""Runtime arguments for meta-evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from judgearena.config import RunConfig
+from judgearena.models import build_default_judge_model_kwargs
+
+PROMPT_MODES = (
+    "standard",
+    "arena-hard",
+    "alpaca-eval",
+    "alpaca-eval-pair-score",
+)
+
+
+@dataclass
+class CliMetaEvalArgs:
+    """Resolved arguments consumed by the meta-evaluation pipeline."""
+
+    judge_model: str
+    reference_arena: str = "LMArena-140k"
+    prompt_mode: str = "standard"
+    top_models: int = 20
+    battles_per_model: int = 50
+    batch_size: int = 50
+    languages: list[str] | None = None
+    n_bootstraps: int = 20
+    seed: int = 0
+    elo_gap_battles: list[int] = field(default_factory=lambda: [10, 20, 30, 40, 50])
+    elo_gap_seeds: int = 10
+    exclude_human_ties: bool = True
+    provide_explanation: bool = False
+    swap_mode: str = "fixed"
+    ignore_cache: bool = False
+    truncate_judge_input_chars: int | None = None
+    max_out_tokens_judge: int = 32768
+    max_model_len: int | None = None
+    chat_template: str | None = None
+    result_folder: str = "results"
+    engine_kwargs: dict[str, object] = field(default_factory=dict)
+    no_log_file: bool = False
+
+    def __post_init__(self) -> None:
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero.")
+        if self.swap_mode not in {"fixed", "both"}:
+            raise ValueError(f"Unsupported swap_mode {self.swap_mode!r}.")
+        if self.prompt_mode not in PROMPT_MODES:
+            raise ValueError(
+                f"Unsupported prompt_mode {self.prompt_mode!r}; "
+                f"expected one of {PROMPT_MODES}."
+            )
+
+
+def meta_eval_args_from_config(cfg: RunConfig) -> CliMetaEvalArgs:
+    """Map the shared hierarchical run config to meta-eval runtime arguments."""
+    if cfg.meta_eval is None:
+        raise ValueError("meta_eval config is required for the meta-eval task.")
+
+    judge_kwargs = build_default_judge_model_kwargs(
+        cfg.judge.model,
+        {},
+        judge_engine_kwargs_override=cfg.judge.model_kwargs(),
+    )
+    max_out_tokens_judge = int(judge_kwargs.pop("max_tokens"))
+    max_model_len = judge_kwargs.pop("max_model_len", None)
+    chat_template = judge_kwargs.pop("chat_template", None)
+
+    return CliMetaEvalArgs(
+        judge_model=cfg.judge.model,
+        reference_arena=cfg.meta_eval.reference_arena,
+        prompt_mode=cfg.meta_eval.prompt_mode,
+        top_models=cfg.meta_eval.top_models,
+        battles_per_model=cfg.meta_eval.battles_per_model,
+        batch_size=cfg.meta_eval.batch_size,
+        languages=cfg.meta_eval.languages,
+        n_bootstraps=cfg.meta_eval.n_bootstraps,
+        seed=cfg.run.seed,
+        elo_gap_battles=list(cfg.meta_eval.elo_gap_battles),
+        elo_gap_seeds=cfg.meta_eval.elo_gap_seeds,
+        exclude_human_ties=not cfg.meta_eval.include_human_ties,
+        provide_explanation=cfg.judge.provide_explanation,
+        swap_mode=cfg.judge.swap_mode,
+        ignore_cache=cfg.run.ignore_cache,
+        truncate_judge_input_chars=cfg.generation.truncate_judge_input_chars,
+        max_out_tokens_judge=max_out_tokens_judge,
+        max_model_len=max_model_len,
+        chat_template=chat_template,
+        result_folder=cfg.run.result_folder,
+        engine_kwargs=judge_kwargs,
+        no_log_file=cfg.run.no_log_file,
+    )

--- a/judgearena/meta_eval/cost.py
+++ b/judgearena/meta_eval/cost.py
@@ -1,0 +1,57 @@
+"""Cost estimation helpers for meta-evaluation annotations."""
+
+from __future__ import annotations
+
+import json
+
+from judgearena.utils import data_root
+
+_PRICING_CACHE_FILE = data_root / "cache" / "openrouter_pricing.json"
+_openrouter_pricing_cache: dict[str, tuple[float, float]] = {}
+
+
+def _openrouter_model_key(model_name: str) -> str:
+    if model_name.count("/") >= 2:
+        return "/".join(model_name.split("/")[-2:])
+    return model_name
+
+
+def load_openrouter_pricing() -> dict[str, tuple[float, float]]:
+    if _openrouter_pricing_cache:
+        return _openrouter_pricing_cache
+    if not _PRICING_CACHE_FILE.exists():
+        return {}
+    with _PRICING_CACHE_FILE.open(encoding="utf-8") as handle:
+        raw = json.load(handle)
+    for model_id, prices in raw.items():
+        prompt, completion = prices
+        _openrouter_pricing_cache[model_id] = (float(prompt), float(completion))
+    return _openrouter_pricing_cache
+
+
+def lookup_openrouter_pricing(model_name: str) -> tuple[float, float] | None:
+    pricing = load_openrouter_pricing()
+    key = _openrouter_model_key(model_name)
+    return pricing.get(key)
+
+
+def estimate_token_count(text: str) -> int:
+    return len(text) // 4 if isinstance(text, str) else 0
+
+
+def estimate_annotation_cost_usd(
+    *,
+    judge_input: str,
+    judge_completion: str,
+    judge_model: str,
+) -> tuple[float | None, str]:
+    """Estimate cost from text length and cached OpenRouter reference pricing."""
+    pricing = lookup_openrouter_pricing(judge_model)
+    if pricing is None:
+        return None, "unavailable"
+
+    input_price, output_price = pricing
+    prompt_tokens = estimate_token_count(judge_input)
+    completion_tokens = estimate_token_count(judge_completion)
+    cost = (prompt_tokens * input_price + completion_tokens * output_price) / 1e6
+    return float(cost), "estimated"

--- a/judgearena/meta_eval/metrics.py
+++ b/judgearena/meta_eval/metrics.py
@@ -1,0 +1,420 @@
+"""Metrics for judge meta-evaluation against human labels."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+from scipy.stats import spearmanr
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import cohen_kappa_score
+
+from judgearena.estimate_elo_ratings import compute_bradley_terry
+
+WINNER_LABELS = ["model_a", "model_b", "tie"]
+
+
+def _cohen_kappa(y_true: list[str], y_pred: list[str]) -> float:
+    if len(set(y_true) | set(y_pred)) < 2:
+        return float("nan")
+    return float(cohen_kappa_score(y_true, y_pred, labels=WINNER_LABELS))
+
+
+def _finite_std(values: list[float]) -> float:
+    finite = np.asarray([value for value in values if math.isfinite(value)])
+    return float(np.std(finite)) if len(finite) else float("nan")
+
+
+def bootstrap_std(
+    y_true: list[str],
+    y_pred: list[str],
+    *,
+    n_bootstraps: int,
+    seed: int,
+) -> tuple[float, float]:
+    if not y_true:
+        return float("nan"), float("nan")
+    rng = np.random.default_rng(seed)
+    y_true_arr = np.array(y_true)
+    y_pred_arr = np.array(y_pred)
+    acc_samples: list[float] = []
+    kappa_samples: list[float] = []
+    for _ in range(n_bootstraps):
+        idx = rng.choice(len(y_true_arr), size=len(y_true_arr), replace=True)
+        acc_samples.append(float(np.mean(y_true_arr[idx] == y_pred_arr[idx])))
+        kappa_samples.append(
+            _cohen_kappa(
+                y_true_arr[idx].tolist(),
+                y_pred_arr[idx].tolist(),
+            )
+        )
+    return float(np.std(acc_samples)), _finite_std(kappa_samples)
+
+
+def compute_agreement_metrics(
+    winner_human: list[str],
+    winner_llm: list[str],
+    *,
+    n_bootstraps: int,
+    seed: int,
+) -> dict[str, float | int]:
+    n_all = len(winner_human)
+    if n_all == 0:
+        nan = float("nan")
+        return {
+            "n": 0,
+            "accuracy": nan,
+            "acc_se": nan,
+            "kappa": nan,
+            "kappa_se": nan,
+            "n_nt": 0,
+            "accuracy_nt": nan,
+            "acc_se_nt": nan,
+            "kappa_nt": nan,
+            "kappa_se_nt": nan,
+        }
+
+    acc_all = (
+        sum(h == pred for h, pred in zip(winner_human, winner_llm, strict=True)) / n_all
+    )
+    kappa_all = _cohen_kappa(winner_human, winner_llm)
+    acc_se, kappa_se = bootstrap_std(
+        winner_human,
+        winner_llm,
+        n_bootstraps=n_bootstraps,
+        seed=seed,
+    )
+
+    no_tie = [
+        (h, pred)
+        for h, pred in zip(winner_human, winner_llm, strict=True)
+        if h != "tie"
+    ]
+    wh_nt, wl_nt = zip(*no_tie, strict=False) if no_tie else ([], [])
+    n_nt = len(wh_nt)
+    if n_nt:
+        acc_nt = sum(h == pred for h, pred in zip(wh_nt, wl_nt, strict=True)) / n_nt
+        kappa_nt = _cohen_kappa(list(wh_nt), list(wl_nt))
+        acc_se_nt, kappa_se_nt = bootstrap_std(
+            list(wh_nt),
+            list(wl_nt),
+            n_bootstraps=n_bootstraps,
+            seed=seed + 1,
+        )
+    else:
+        acc_nt = float("nan")
+        kappa_nt = float("nan")
+        acc_se_nt = float("nan")
+        kappa_se_nt = float("nan")
+
+    return {
+        "n": n_all,
+        "accuracy": acc_all,
+        "acc_se": acc_se,
+        "kappa": kappa_all,
+        "kappa_se": kappa_se,
+        "n_nt": n_nt,
+        "accuracy_nt": acc_nt,
+        "acc_se_nt": acc_se_nt,
+        "kappa_nt": kappa_nt,
+        "kappa_se_nt": kappa_se_nt,
+    }
+
+
+def compute_soft_bradley_terry(
+    df: pd.DataFrame,
+    pref_col: str = "pref_llm",
+    scale: float = 400,
+    base: float = 10,
+    init_rating: float = 1000,
+) -> dict[str, float]:
+    df = df.dropna(subset=[pref_col]).copy()
+    if df.empty:
+        return {}
+
+    all_models = sorted(set(df["model_a"].unique()) | set(df["model_b"].unique()))
+    models = pd.Series(np.arange(len(all_models)), index=all_models)
+    p = len(models)
+    n_battles = len(df)
+    x = np.zeros([2 * n_battles, p])
+    y = np.zeros(2 * n_battles)
+    sample_weights = np.zeros(2 * n_battles)
+
+    for idx, (_, row) in enumerate(df.iterrows()):
+        m_a = row["model_a"]
+        m_b = row["model_b"]
+        pref = row[pref_col]
+        x[2 * idx, models[m_a]] = +np.log(base)
+        x[2 * idx, models[m_b]] = -np.log(base)
+        y[2 * idx] = 1.0
+        sample_weights[2 * idx] = 1.0 - pref
+        x[2 * idx + 1, models[m_a]] = +np.log(base)
+        x[2 * idx + 1, models[m_b]] = -np.log(base)
+        y[2 * idx + 1] = 0.0
+        sample_weights[2 * idx + 1] = pref
+
+    nonzero = sample_weights > 0
+    x = x[nonzero]
+    y = y[nonzero]
+    sample_weights = sample_weights[nonzero]
+    if len(x) == 0:
+        return {}
+
+    try:
+        lr = LogisticRegression(fit_intercept=False, C=1e10, tol=1e-6, max_iter=1000)
+        lr.fit(x, y, sample_weight=sample_weights)
+    except ValueError:
+        return {}
+    elo_scores = scale * lr.coef_[0] + init_rating
+    return dict(pd.Series(elo_scores, index=models.index))
+
+
+def format_metric(value: float | None, se: float | None, *, digits: int = 2) -> str:
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    if se is None or not math.isfinite(se):
+        return f"{value:.{digits}f}"
+    return f"{value:.{digits}f} ± {se:.{digits}f}"
+
+
+def _bt_ratings(df_sub: pd.DataFrame) -> tuple[dict[str, float], dict[str, float]]:
+    try:
+        human = compute_bradley_terry(
+            df_sub[["model_a", "model_b", "winner"]],
+            "winner",
+        )
+        llm = compute_bradley_terry(
+            df_sub[["model_a", "model_b", "winner_llm"]].rename(
+                columns={"winner_llm": "winner"}
+            ),
+            "winner",
+        )
+    except ValueError:
+        return {}, {}
+    return human, llm
+
+
+def _bt_ratings_soft(df_sub: pd.DataFrame) -> tuple[dict[str, float], dict[str, float]]:
+    human = compute_bradley_terry(df_sub[["model_a", "model_b", "winner"]], "winner")
+    llm = compute_soft_bradley_terry(df_sub[["model_a", "model_b", "pref_llm"]])
+    return human, llm
+
+
+def _rating_vectors(
+    df_sub: pd.DataFrame,
+    *,
+    soft: bool,
+) -> tuple[np.ndarray, np.ndarray]:
+    ratings_fn = _bt_ratings_soft if soft else _bt_ratings
+    human, llm = ratings_fn(df_sub)
+    common = sorted(set(human) & set(llm))
+    return (
+        np.array([human[model] for model in common]),
+        np.array([llm[model] for model in common]),
+    )
+
+
+def _bootstrap_rank_metric(
+    hv: np.ndarray,
+    lv: np.ndarray,
+    *,
+    metric: str,
+    n_bootstraps: int,
+    seed: int,
+) -> tuple[float, float]:
+    if len(hv) == 0:
+        return float("nan"), float("nan")
+    rng = np.random.default_rng(seed)
+    samples: list[float] = []
+    for _ in range(n_bootstraps):
+        idx = rng.choice(len(hv), size=len(hv), replace=True)
+        if metric == "spearman":
+            if len(np.unique(hv[idx])) < 2 or len(np.unique(lv[idx])) < 2:
+                continue
+            value = float(spearmanr(hv[idx], lv[idx])[0])
+        else:
+            value = float(np.mean(np.abs(hv[idx] - lv[idx])))
+        if math.isfinite(value):
+            samples.append(value)
+    if not samples:
+        return float("nan"), float("nan")
+    return float(np.mean(samples)), float(np.std(samples))
+
+
+def spearman_with_se(
+    df_sub: pd.DataFrame,
+    *,
+    n_bootstraps: int,
+    seed: int,
+    soft: bool = False,
+) -> str:
+    human, llm = _rating_vectors(df_sub, soft=soft)
+    if len(human) == 0:
+        return "n/a"
+    if len(np.unique(human)) < 2 or len(np.unique(llm)) < 2:
+        return "n/a"
+    rho, _ = spearmanr(human, llm)
+    if rho is None or not math.isfinite(float(rho)):
+        return "n/a"
+    _, se = _bootstrap_rank_metric(
+        human,
+        llm,
+        metric="spearman",
+        n_bootstraps=n_bootstraps,
+        seed=seed,
+    )
+    return format_metric(float(rho), se)
+
+
+def mae_elo_with_se(
+    df_sub: pd.DataFrame,
+    *,
+    n_bootstraps: int,
+    seed: int,
+    soft: bool = False,
+) -> str:
+    human, llm = _rating_vectors(df_sub, soft=soft)
+    if len(human) == 0:
+        return "n/a"
+    mae = float(np.mean(np.abs(human - llm)))
+    _, se = _bootstrap_rank_metric(
+        human,
+        llm,
+        metric="mae",
+        n_bootstraps=n_bootstraps,
+        seed=seed,
+    )
+    return format_metric(mae, se, digits=1)
+
+
+def summarize_language_splits(
+    df_ann: pd.DataFrame,
+    *,
+    exclude_human_ties: bool,
+    n_bootstraps: int,
+    seed: int,
+) -> dict[str, dict[str, str | int]]:
+    rows: dict[str, dict[str, str | int]] = {}
+    for label, mask in [
+        ("English", df_ann["lang"] == "en"),
+        ("Multilingual", df_ann["lang"] != "en"),
+    ]:
+        df_sub = df_ann[mask]
+        if exclude_human_ties:
+            df_sub = df_sub[df_sub["winner"] != "tie"]
+        metrics = compute_agreement_metrics(
+            df_sub["winner"].tolist(),
+            df_sub["winner_llm"].tolist(),
+            n_bootstraps=n_bootstraps,
+            seed=seed,
+        )
+        entry: dict[str, str | int] = {"n": metrics["n"]}
+        if metrics["n"] == 0:
+            entry.update(
+                {
+                    "kappa": "n/a",
+                    "spearman": "n/a",
+                    "spearman_soft": "n/a",
+                    "mae_elo": "n/a",
+                    "mae_soft_elo": "n/a",
+                }
+            )
+        else:
+            entry["kappa"] = format_metric(
+                float(metrics["kappa"]),
+                float(metrics["kappa_se"]),
+            )
+            entry["spearman"] = spearman_with_se(
+                df_sub,
+                n_bootstraps=n_bootstraps,
+                seed=seed + 2,
+                soft=False,
+            )
+            entry["spearman_soft"] = spearman_with_se(
+                df_sub,
+                n_bootstraps=n_bootstraps,
+                seed=seed + 3,
+                soft=True,
+            )
+            entry["mae_elo"] = mae_elo_with_se(
+                df_sub,
+                n_bootstraps=n_bootstraps,
+                seed=seed + 4,
+                soft=False,
+            )
+            entry["mae_soft_elo"] = mae_elo_with_se(
+                df_sub,
+                n_bootstraps=n_bootstraps,
+                seed=seed + 5,
+                soft=True,
+            )
+        rows[label] = entry
+    return rows
+
+
+def compute_elo_gap_summary(
+    df_top: pd.DataFrame,
+    df_ann: pd.DataFrame,
+    top_models: list[str],
+    *,
+    n_battles_list: list[int],
+    n_seeds: int,
+    seed: int,
+    exclude_ties: bool,
+) -> pd.DataFrame:
+    df_battles = df_top[["model_a", "model_b", "winner"]].copy()
+    human_ratings = compute_bradley_terry(df_battles, "winner")
+    rows: list[dict[str, float | int | str]] = []
+
+    for num_battles in n_battles_list:
+        for offset in range(n_seeds):
+            rng = np.random.default_rng(seed + offset)
+            gaps: list[float] = []
+            for model in top_models:
+                model_mask_ann = (df_ann["model_a"] == model) | (
+                    df_ann["model_b"] == model
+                )
+                if model_mask_ann.sum() < num_battles:
+                    continue
+                model_mask_top = (df_battles["model_a"] == model) | (
+                    df_battles["model_b"] == model
+                )
+                other_human = df_battles[~model_mask_top].copy()
+                sample = df_ann[model_mask_ann].sample(
+                    n=num_battles,
+                    replace=False,
+                    random_state=int(rng.integers(0, 2**32 - 1)),
+                )
+                if exclude_ties:
+                    sample = sample[sample["winner_llm"] != "tie"]
+                if sample.empty:
+                    continue
+                model_llm = sample[["model_a", "model_b", "winner_llm"]].rename(
+                    columns={"winner_llm": "winner"}
+                )
+                hybrid = pd.concat([other_human, model_llm], ignore_index=True)
+                hybrid_ratings = compute_bradley_terry(hybrid, "winner")
+                if model in hybrid_ratings and model in human_ratings:
+                    gaps.append(
+                        abs(hybrid_ratings[model] - human_ratings[model]),
+                    )
+            if gaps:
+                rows.append(
+                    {
+                        "num_battles": num_battles,
+                        "seed": offset,
+                        "mean_gap": float(np.mean(gaps)),
+                        "exclude_ties": exclude_ties,
+                    }
+                )
+
+    if not rows:
+        return pd.DataFrame(columns=["num_battles", "mean", "se", "exclude_ties"])
+
+    df_rows = pd.DataFrame(rows)
+    return (
+        df_rows.groupby(["num_battles", "exclude_ties"])["mean_gap"]
+        .agg(mean="mean", se=lambda values: values.std() / np.sqrt(len(values)))
+        .reset_index()
+    )

--- a/judgearena/meta_eval/metrics.py
+++ b/judgearena/meta_eval/metrics.py
@@ -7,7 +7,6 @@ import math
 import numpy as np
 import pandas as pd
 from scipy.stats import spearmanr
-from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import cohen_kappa_score
 
 from judgearena.estimate_elo_ratings import fit_bradley_terry
@@ -122,54 +121,6 @@ def compute_agreement_metrics(
     }
 
 
-def compute_soft_bradley_terry(
-    df: pd.DataFrame,
-    pref_col: str = "pref_llm",
-    scale: float = 400,
-    base: float = 10,
-    init_rating: float = 1000,
-) -> dict[str, float]:
-    df = df.dropna(subset=[pref_col]).copy()
-    if df.empty:
-        return {}
-
-    all_models = sorted(set(df["model_a"].unique()) | set(df["model_b"].unique()))
-    models = pd.Series(np.arange(len(all_models)), index=all_models)
-    p = len(models)
-    n_battles = len(df)
-    x = np.zeros([2 * n_battles, p])
-    y = np.zeros(2 * n_battles)
-    sample_weights = np.zeros(2 * n_battles)
-
-    for idx, (_, row) in enumerate(df.iterrows()):
-        m_a = row["model_a"]
-        m_b = row["model_b"]
-        pref = row[pref_col]
-        x[2 * idx, models[m_a]] = +np.log(base)
-        x[2 * idx, models[m_b]] = -np.log(base)
-        y[2 * idx] = 1.0
-        sample_weights[2 * idx] = 1.0 - pref
-        x[2 * idx + 1, models[m_a]] = +np.log(base)
-        x[2 * idx + 1, models[m_b]] = -np.log(base)
-        y[2 * idx + 1] = 0.0
-        sample_weights[2 * idx + 1] = pref
-
-    nonzero = sample_weights > 0
-    x = x[nonzero]
-    y = y[nonzero]
-    sample_weights = sample_weights[nonzero]
-    if len(x) == 0:
-        return {}
-
-    try:
-        lr = LogisticRegression(fit_intercept=False, C=1e10, tol=1e-6, max_iter=1000)
-        lr.fit(x, y, sample_weight=sample_weights)
-    except ValueError:
-        return {}
-    elo_scores = scale * lr.coef_[0] + init_rating
-    return dict(pd.Series(elo_scores, index=models.index))
-
-
 def format_metric(value: float | None, se: float | None, *, digits: int = 2) -> str:
     if value is None or not math.isfinite(value):
         return "n/a"
@@ -216,7 +167,10 @@ def _bt_ratings_soft(df_sub: pd.DataFrame) -> tuple[dict[str, float], dict[str, 
         df_sub[["model_a", "model_b", "winner"]],
         "winner",
     )
-    llm = compute_soft_bradley_terry(df_sub[["model_a", "model_b", "pref_llm"]])
+    llm = fit_bradley_terry(
+        df_sub[["model_a", "model_b", "pref_llm"]],
+        pref_col="pref_llm",
+    )
     return human, llm
 
 
@@ -382,6 +336,11 @@ def compute_elo_gap_summary(
     seed: int,
     exclude_ties: bool,
 ) -> pd.DataFrame:
+    """Measure ELO error by annotation budget.
+
+    Tie predictions are excluded after sampling so ``num_battles`` remains the
+    number of judge annotations purchased, matching the reference experiment.
+    """
     df_battles = df_top[["model_a", "model_b", "winner"]].copy()
     human_ratings = _hard_bradley_terry(df_battles, "winner")
     rows: list[dict[str, float | int | str]] = []

--- a/judgearena/meta_eval/metrics.py
+++ b/judgearena/meta_eval/metrics.py
@@ -10,7 +10,7 @@ from scipy.stats import spearmanr
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import cohen_kappa_score
 
-from judgearena.estimate_elo_ratings import compute_bradley_terry
+from judgearena.estimate_elo_ratings import fit_bradley_terry
 
 WINNER_LABELS = ["model_a", "model_b", "tie"]
 
@@ -178,13 +178,29 @@ def format_metric(value: float | None, se: float | None, *, digits: int = 2) -> 
     return f"{value:.{digits}f} ± {se:.{digits}f}"
 
 
+def _hard_bradley_terry(
+    df: pd.DataFrame,
+    winner_col: str,
+) -> dict[str, float]:
+    battles = df[["model_a", "model_b", winner_col]].copy()
+    battles["pref"] = battles[winner_col].map(
+        {
+            "model_a": 0.0,
+            "model_b": 1.0,
+            "tie": 0.5,
+            "tie (bothbad)": 0.5,
+        }
+    )
+    return fit_bradley_terry(battles, pref_col="pref")
+
+
 def _bt_ratings(df_sub: pd.DataFrame) -> tuple[dict[str, float], dict[str, float]]:
     try:
-        human = compute_bradley_terry(
+        human = _hard_bradley_terry(
             df_sub[["model_a", "model_b", "winner"]],
             "winner",
         )
-        llm = compute_bradley_terry(
+        llm = _hard_bradley_terry(
             df_sub[["model_a", "model_b", "winner_llm"]].rename(
                 columns={"winner_llm": "winner"}
             ),
@@ -196,7 +212,10 @@ def _bt_ratings(df_sub: pd.DataFrame) -> tuple[dict[str, float], dict[str, float
 
 
 def _bt_ratings_soft(df_sub: pd.DataFrame) -> tuple[dict[str, float], dict[str, float]]:
-    human = compute_bradley_terry(df_sub[["model_a", "model_b", "winner"]], "winner")
+    human = _hard_bradley_terry(
+        df_sub[["model_a", "model_b", "winner"]],
+        "winner",
+    )
     llm = compute_soft_bradley_terry(df_sub[["model_a", "model_b", "pref_llm"]])
     return human, llm
 
@@ -364,7 +383,7 @@ def compute_elo_gap_summary(
     exclude_ties: bool,
 ) -> pd.DataFrame:
     df_battles = df_top[["model_a", "model_b", "winner"]].copy()
-    human_ratings = compute_bradley_terry(df_battles, "winner")
+    human_ratings = _hard_bradley_terry(df_battles, "winner")
     rows: list[dict[str, float | int | str]] = []
 
     for num_battles in n_battles_list:
@@ -394,7 +413,7 @@ def compute_elo_gap_summary(
                     columns={"winner_llm": "winner"}
                 )
                 hybrid = pd.concat([other_human, model_llm], ignore_index=True)
-                hybrid_ratings = compute_bradley_terry(hybrid, "winner")
+                hybrid_ratings = _hard_bradley_terry(hybrid, "winner")
                 if model in hybrid_ratings and model in human_ratings:
                     gaps.append(
                         abs(hybrid_ratings[model] - human_ratings[model]),

--- a/judgearena/meta_eval/parsers.py
+++ b/judgearena/meta_eval/parsers.py
@@ -1,0 +1,147 @@
+"""Winner and preference parsers for meta-evaluation prompt modes."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import numpy as np
+import pandas as pd
+
+from judgearena.evaluate import PairScore
+
+TIE_EPSILON = 0.01
+META_EVAL_PAIRSCORE_TEMPERATURE = 0.5
+
+_ARENA_HARD_PATTERNS = [
+    re.compile(r"\[\[([AB<>=]+)\]\]"),
+    re.compile(r"\[([AB<>=]+)\]"),
+]
+_ARENA_HARD_LIKERT_TO_WINNER = {
+    "A>>B": "model_a",
+    "A>B": "model_a",
+    "A=B": "tie",
+    "B>A": "model_b",
+    "B>>A": "model_b",
+    "B<<A": "model_a",
+    "B<A": "model_a",
+}
+
+
+def pair_score_parser(
+    temperature: float = META_EVAL_PAIRSCORE_TEMPERATURE,
+) -> PairScore:
+    parser = PairScore()
+    parser.temperature = temperature
+    return parser
+
+
+def parse_pairscore_pref(judge_completion: str, *, temperature: float) -> float:
+    score = pair_score_parser(temperature).parse_model_raw(judge_completion)
+    if score is None or np.isnan(score):
+        return 0.5
+    return float(score)
+
+
+def parse_pairscore_winner(
+    judge_completion: str,
+    *,
+    temperature: float,
+    eps: float = TIE_EPSILON,
+) -> str:
+    score = parse_pairscore_pref(judge_completion, temperature=temperature)
+    if abs(score - 0.5) < eps:
+        return "tie"
+    if score > 0.5 + eps:
+        return "model_b"
+    if score < 0.5 - eps:
+        return "model_a"
+    return "tie"
+
+
+def parse_arena_hard_winner(judge_completion: str) -> str:
+    if not isinstance(judge_completion, str):
+        return "tie"
+    for pattern in _ARENA_HARD_PATTERNS:
+        matches = pattern.findall(judge_completion.upper())
+        matches = [match for match in matches if match]
+        if matches:
+            return _ARENA_HARD_LIKERT_TO_WINNER.get(matches[-1].strip(), "tie")
+    return "tie"
+
+
+def parse_alpaca_eval_winner(judge_completion: str) -> str:
+    if not isinstance(judge_completion, str):
+        return "tie"
+
+    text = judge_completion
+    fenced = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        obj_match = re.search(
+            r'\{[^{}]*"ordered_models"[^{}]*\[[^\[\]]*\][^{}]*\}',
+            text,
+            re.DOTALL,
+        )
+        if obj_match:
+            text = obj_match.group(0)
+
+    try:
+        data = json.loads(text)
+        ordered = data.get("ordered_models", [])
+        m_entry = next((entry for entry in ordered if entry.get("model") == "m"), None)
+        if m_entry is None:
+            return "tie"
+        rank_m = m_entry["rank"]
+        if rank_m == 1:
+            return "model_a"
+        if rank_m == 2:
+            return "model_b"
+    except (json.JSONDecodeError, KeyError, TypeError):
+        pass
+    return "tie"
+
+
+def winner_to_pref(winner: str) -> float:
+    return {"model_a": 0.0, "model_b": 1.0}.get(winner, 0.5)
+
+
+def parse_winner(judge_completion: str, prompt_mode: str) -> str:
+    if prompt_mode == "arena-hard":
+        return parse_arena_hard_winner(judge_completion)
+    if prompt_mode == "alpaca-eval":
+        return parse_alpaca_eval_winner(judge_completion)
+    return parse_pairscore_winner(
+        judge_completion,
+        temperature=META_EVAL_PAIRSCORE_TEMPERATURE,
+    )
+
+
+def parse_pref(judge_completion: str, prompt_mode: str) -> float:
+    if prompt_mode in ("arena-hard", "alpaca-eval"):
+        return winner_to_pref(parse_winner(judge_completion, prompt_mode))
+    return parse_pairscore_pref(
+        judge_completion,
+        temperature=META_EVAL_PAIRSCORE_TEMPERATURE,
+    )
+
+
+def add_parsed_columns(df: pd.DataFrame, prompt_mode: str) -> pd.DataFrame:
+    out = df.copy()
+    completions = out["judge_completion"].tolist()
+    out["winner_llm"] = [
+        parse_winner(completion, prompt_mode) for completion in completions
+    ]
+    out["pref_llm"] = [
+        parse_pref(completion, prompt_mode) for completion in completions
+    ]
+    return out
+
+
+def invert_winner(winner: str) -> str:
+    if winner == "model_a":
+        return "model_b"
+    if winner == "model_b":
+        return "model_a"
+    return winner

--- a/judgearena/meta_eval/prompts.py
+++ b/judgearena/meta_eval/prompts.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib.resources import files
 
-from judgearena.evaluate import load_judge_system_and_user_prompt
 from judgearena.meta_eval.cli_args import PROMPT_MODES
+from judgearena.prompts.registry import resolve_judge_prompt
 
 
 @dataclass(frozen=True)
@@ -33,13 +33,13 @@ def resolve_prompt_mode(
         raise ValueError(f"Unknown prompt mode {prompt_mode!r}.")
 
     if prompt_mode == "standard":
-        system_prompt, user_prompt_template = load_judge_system_and_user_prompt(
+        resolved = resolve_judge_prompt(
             provide_explanation=provide_explanation,
         )
         return PromptModeSpec(
             name=prompt_mode,
-            system_prompt=system_prompt,
-            user_prompt_template=user_prompt_template,
+            system_prompt=resolved.system_prompt,
+            user_prompt_template=resolved.user_prompt_template,
         )
 
     if prompt_mode == "arena-hard":

--- a/judgearena/meta_eval/prompts.py
+++ b/judgearena/meta_eval/prompts.py
@@ -1,0 +1,63 @@
+"""Named prompt templates and mode registry for meta-evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.resources import files
+
+from judgearena.evaluate import load_judge_system_and_user_prompt
+from judgearena.meta_eval.cli_args import PROMPT_MODES
+
+
+@dataclass(frozen=True)
+class PromptModeSpec:
+    name: str
+    system_prompt: str | None = None
+    user_prompt_template: str | None = None
+
+
+def _read_prompt(filename: str) -> str:
+    return (
+        files("judgearena.meta_eval")
+        .joinpath("prompts", filename)
+        .read_text(encoding="utf-8")
+    )
+
+
+def resolve_prompt_mode(
+    prompt_mode: str,
+    *,
+    provide_explanation: bool = False,
+) -> PromptModeSpec:
+    if prompt_mode not in PROMPT_MODES:
+        raise ValueError(f"Unknown prompt mode {prompt_mode!r}.")
+
+    if prompt_mode == "standard":
+        system_prompt, user_prompt_template = load_judge_system_and_user_prompt(
+            provide_explanation=provide_explanation,
+        )
+        return PromptModeSpec(
+            name=prompt_mode,
+            system_prompt=system_prompt,
+            user_prompt_template=user_prompt_template,
+        )
+
+    if prompt_mode == "arena-hard":
+        return PromptModeSpec(
+            name=prompt_mode,
+            system_prompt=_read_prompt("arena_hard_system.txt"),
+            user_prompt_template=_read_prompt("arena_hard_user.txt"),
+        )
+
+    if prompt_mode == "alpaca-eval":
+        return PromptModeSpec(
+            name=prompt_mode,
+            system_prompt=_read_prompt("alpaca_eval_system.txt"),
+            user_prompt_template=_read_prompt("alpaca_eval_user.txt"),
+        )
+
+    return PromptModeSpec(
+        name=prompt_mode,
+        system_prompt=_read_prompt("alpaca_eval_system.txt"),
+        user_prompt_template=_read_prompt("alpaca_eval_pair_score_user.txt"),
+    )

--- a/judgearena/meta_eval/prompts/alpaca_eval_pair_score_user.txt
+++ b/judgearena/meta_eval/prompts/alpaca_eval_pair_score_user.txt
@@ -1,0 +1,32 @@
+I require a leaderboard for various large language models. I'll provide you with prompts given to these models and their corresponding responses. Your task is to assess these responses, ranking the models in order of preference from a human perspective.
+
+## Prompt
+
+{{
+    "instruction": "{user_prompt}",
+}}
+
+## Model Outputs
+
+Here are the unordered outputs from the models. Each output is associated with a specific model, identified by a unique model identifier.
+
+{{
+    {{
+        "model": "model A",
+        "output": "{completion_A}"
+    }},
+    {{
+        "model": "model B",
+        "output": "{completion_B}"
+    }}
+}}
+
+## Task
+
+Evaluate and rank the models based on the quality and relevance of their outputs. The ranking should be such that the model with the highest quality output is ranked first.
+
+## Your output, do not repeat the input above
+```
+score_A: <a number between 0 and 10 to indicate the quality of model A's answer>
+score_B: <a number between 0 and 10 to indicate the quality of model B's answer>
+```

--- a/judgearena/meta_eval/prompts/alpaca_eval_system.txt
+++ b/judgearena/meta_eval/prompts/alpaca_eval_system.txt
@@ -1,0 +1,1 @@
+You are a highly efficient assistant, who evaluates and ranks large language models (LLMs) based on the quality of their responses to given prompts. This process will create a leaderboard reflecting the most accurate and human-preferred answers.

--- a/judgearena/meta_eval/prompts/alpaca_eval_user.txt
+++ b/judgearena/meta_eval/prompts/alpaca_eval_user.txt
@@ -1,0 +1,30 @@
+I require a leaderboard for various large language models. I'll provide you with prompts given to these models and their corresponding responses. Your task is to assess these responses, ranking the models in order of preference from a human perspective.
+
+## Prompt
+
+{{
+    "instruction": "{user_prompt}",
+}}
+
+## Model Outputs
+
+Here are the unordered outputs from the models. Each output is associated with a specific model, identified by a unique model identifier.
+
+{{
+    {{
+        "model": "m",
+        "output": "{completion_A}"
+    }},
+    {{
+        "model": "M",
+        "output": "{completion_B}"
+    }}
+}}
+
+## Task
+
+Evaluate and rank the models based on the quality and relevance of their outputs. The ranking should be such that the model with the highest quality output is ranked first.
+
+Output ONLY a JSON object in this exact format (no other text):
+{{"ordered_models": [{{"model": "m", "rank": 1}}, {{"model": "M", "rank": 2}}]}}
+where rank 1 = best. Replace ranks according to your evaluation.

--- a/judgearena/meta_eval/prompts/arena_hard_system.txt
+++ b/judgearena/meta_eval/prompts/arena_hard_system.txt
@@ -1,0 +1,19 @@
+Please act as an impartial judge and evaluate the quality of the responses provided by two AI assistants to the user prompt displayed below. You will be given assistant A's answer and assistant B's answer. Your job is to evaluate which assistant's answer is better.
+
+Begin your evaluation by generating your own answer to the prompt. You must provide your answers before judging any answers.
+
+When evaluating the assistants' answers, compare both assistants' answers with your answer. You must identify and correct any mistakes or inaccurate information.
+
+Then consider if the assistant's answers are helpful, relevant, and concise. Helpful means the answer correctly responds to the prompt or follows the instructions. Note when user prompt has any ambiguity or more than one interpretation, it is more helpful and appropriate to ask for clarifications or more information from the user than providing an answer based on assumptions. Relevant means all parts of the response closely connect or are appropriate to what is being asked. Concise means the response is clear and not verbose or excessive.
+
+Then consider the creativity and novelty of the assistant's answers when needed. Finally, identify any missing important information in the assistants' answers that would be beneficial to include when responding to the user prompt.
+
+After providing your explanation, you must output only one of the following choices as your final verdict with a label:
+
+1. Assistant A is significantly better: [[A>>B]]
+2. Assistant A is slightly better: [[A>B]]
+3. Tie, relatively the same: [[A=B]]
+4. Assistant B is slightly better: [[B>A]]
+5. Assistant B is significantly better: [[B>>A]]
+
+Example output: "My final verdict is tie: [[A=B]]".

--- a/judgearena/meta_eval/prompts/arena_hard_user.txt
+++ b/judgearena/meta_eval/prompts/arena_hard_user.txt
@@ -1,0 +1,10 @@
+<|User Prompt|>
+{user_prompt}
+
+<|The Start of Assistant A's Answer|>
+{completion_A}
+<|The End of Assistant A's Answer|>
+
+<|The Start of Assistant B's Answer|>
+{completion_B}
+<|The End of Assistant B's Answer|>

--- a/judgearena/meta_eval/runner.py
+++ b/judgearena/meta_eval/runner.py
@@ -1,0 +1,259 @@
+"""Main entrypoint for judge meta-evaluation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pandas as pd
+
+from judgearena.log import attach_file_handler, get_logger, make_run_log_path
+from judgearena.meta_eval.annotate import annotate_sample
+from judgearena.meta_eval.cli_args import CliMetaEvalArgs
+from judgearena.meta_eval.metrics import (
+    compute_agreement_metrics,
+    compute_elo_gap_summary,
+    format_metric,
+    summarize_language_splits,
+)
+from judgearena.meta_eval.prompts import resolve_prompt_mode
+from judgearena.meta_eval.sampling import (
+    MetaEvalSamplingError,
+    load_reference_arena_battles,
+    sample_battles_per_model,
+    select_top_models,
+)
+from judgearena.models import make_model
+from judgearena.repro import _to_jsonable, write_run_metadata
+
+logger = get_logger(__name__)
+
+
+def _result_folder_name(args: CliMetaEvalArgs, started_at: datetime) -> str:
+    name = (
+        f"meta-eval-{args.reference_arena}-{args.prompt_mode}-"
+        f"{args.judge_model}-{args.swap_mode}"
+    )
+    return name.replace("/", "_") + f"-{started_at.strftime('%Y%m%d_%H%M%S')}"
+
+
+def _build_summary_csv(
+    language_summary: dict[str, dict[str, str | int]],
+) -> pd.DataFrame:
+    rows = []
+    for split, metrics in language_summary.items():
+        rows.append({"split": split, **metrics})
+    return pd.DataFrame(rows)
+
+
+def _agreement_view(
+    metrics: dict[str, float | int],
+    *,
+    exclude_human_ties: bool,
+) -> dict[str, float | int | str]:
+    suffix = "_nt" if exclude_human_ties else ""
+    n_key = "n_nt" if exclude_human_ties else "n"
+    accuracy = float(metrics[f"accuracy{suffix}"])
+    accuracy_se = float(metrics[f"acc_se{suffix}"])
+    kappa = float(metrics[f"kappa{suffix}"])
+    kappa_se = float(metrics[f"kappa_se{suffix}"])
+    return {
+        "n": int(metrics[n_key]),
+        "accuracy": accuracy,
+        "accuracy_se": accuracy_se,
+        "kappa": kappa,
+        "kappa_se": kappa_se,
+        "accuracy_formatted": format_metric(accuracy, accuracy_se, digits=3),
+        "kappa_formatted": format_metric(kappa, kappa_se, digits=3),
+    }
+
+
+def _annotation_telemetry(
+    df_ann: pd.DataFrame,
+    *,
+    swap_mode: str,
+) -> dict[str, object]:
+    costs = pd.to_numeric(df_ann["cost_usd"], errors="coerce").dropna()
+    sources = df_ann["cost_source"].dropna()
+    total_cost = float(costs.sum()) if not costs.empty else None
+    cost_per_1k = float(costs.mean() * 1000) if not costs.empty else None
+    if costs.empty:
+        logger.warning(
+            "OpenRouter reference pricing is unavailable; cost fields will be null."
+        )
+
+    return {
+        "judge_passes_per_battle": 2 if swap_mode == "both" else 1,
+        "judgement_count": len(df_ann),
+        "estimated_input_tokens": int(
+            pd.to_numeric(df_ann["estimated_input_tokens"], errors="coerce")
+            .fillna(0)
+            .sum()
+        ),
+        "estimated_output_tokens": int(
+            pd.to_numeric(df_ann["estimated_output_tokens"], errors="coerce")
+            .fillna(0)
+            .sum()
+        ),
+        "token_count_source": "estimated_chars_div_4",
+        "total_cost_usd": total_cost,
+        "cost_per_1k_judgements_usd": cost_per_1k,
+        "cost_source_counts": {
+            str(source): int(count) for source, count in sources.value_counts().items()
+        },
+    }
+
+
+def _compute_results(
+    *,
+    args: CliMetaEvalArgs,
+    top_models: list[str],
+    df_top: pd.DataFrame,
+    df_sample: pd.DataFrame,
+    df_ann: pd.DataFrame,
+) -> dict:
+    agreement_metrics = compute_agreement_metrics(
+        df_ann["winner"].tolist(),
+        df_ann["winner_llm"].tolist(),
+        n_bootstraps=args.n_bootstraps,
+        seed=args.seed,
+    )
+    primary_view = "no_human_ties" if args.exclude_human_ties else "all"
+    agreement = {
+        "primary_view": primary_view,
+        "all": _agreement_view(
+            agreement_metrics,
+            exclude_human_ties=False,
+        ),
+        "no_human_ties": _agreement_view(
+            agreement_metrics,
+            exclude_human_ties=True,
+        ),
+    }
+    ranking_annotations = df_ann[df_ann["orientation"] == "forward"].copy()
+    language_summary = summarize_language_splits(
+        ranking_annotations,
+        exclude_human_ties=args.exclude_human_ties,
+        n_bootstraps=args.n_bootstraps,
+        seed=args.seed,
+    )
+    elo_gap_all = compute_elo_gap_summary(
+        df_top,
+        ranking_annotations,
+        top_models,
+        n_battles_list=args.elo_gap_battles or [],
+        n_seeds=args.elo_gap_seeds,
+        seed=args.seed,
+        exclude_ties=False,
+    )
+    elo_gap_no_tie = compute_elo_gap_summary(
+        df_top,
+        ranking_annotations,
+        top_models,
+        n_battles_list=args.elo_gap_battles or [],
+        n_seeds=args.elo_gap_seeds,
+        seed=args.seed + 1000,
+        exclude_ties=True,
+    )
+    return {
+        "task": "meta-eval",
+        "reference_arena": args.reference_arena,
+        "prompt_mode": args.prompt_mode,
+        "judge_model": args.judge_model,
+        "top_models": top_models,
+        "sample_size": len(df_sample),
+        "ranking_annotation_count": len(ranking_annotations),
+        "agreement": agreement,
+        "language_summary": language_summary,
+        "elo_gap_all": elo_gap_all.to_dict(orient="records"),
+        "elo_gap_exclude_ties": elo_gap_no_tie.to_dict(orient="records"),
+        **_annotation_telemetry(df_ann, swap_mode=args.swap_mode),
+    }
+
+
+def main(args: CliMetaEvalArgs) -> dict:
+    started_at = datetime.now(UTC)
+    res_folder = Path(args.result_folder) / _result_folder_name(args, started_at)
+    res_folder.mkdir(parents=True, exist_ok=True)
+
+    if not args.no_log_file:
+        attach_file_handler(make_run_log_path(res_folder))
+
+    with open(res_folder / "args.json", "w", encoding="utf-8") as handle:
+        json.dump(asdict(args), handle, indent=2)
+
+    prompt_spec = resolve_prompt_mode(
+        args.prompt_mode,
+        provide_explanation=args.provide_explanation,
+    )
+    judge_chat_model = make_model(
+        model=args.judge_model,
+        max_tokens=args.max_out_tokens_judge,
+        max_model_len=args.max_model_len,
+        chat_template=args.chat_template,
+        **args.engine_kwargs,
+    )
+
+    logger.info("Loading reference arena %s", args.reference_arena)
+    df = load_reference_arena_battles(
+        args.reference_arena,
+        languages=args.languages,
+    )
+    top_models, df_top = select_top_models(df, top_models=args.top_models)
+    df_sample = sample_battles_per_model(
+        df_top,
+        top_models,
+        battles_per_model=args.battles_per_model,
+        seed=args.seed,
+    )
+
+    logger.info(
+        "Meta-eval sample: %d battles among top %d models",
+        len(df_sample),
+        len(top_models),
+    )
+
+    df_ann = annotate_sample(
+        df_sample,
+        args,
+        judge_chat_model=judge_chat_model,
+        prompt_spec=prompt_spec,
+    )
+    df_ann.to_parquet(res_folder / "annotations.parquet", index=False)
+
+    results = _compute_results(
+        args=args,
+        top_models=top_models,
+        df_top=df_top,
+        df_sample=df_sample,
+        df_ann=df_ann,
+    )
+
+    with open(res_folder / "results.json", "w", encoding="utf-8") as handle:
+        json.dump(_to_jsonable(results), handle, indent=2, allow_nan=False)
+
+    summary_csv = _build_summary_csv(results["language_summary"])
+    summary_csv.to_csv(res_folder / "summary.csv", index=False)
+
+    write_run_metadata(
+        output_dir=res_folder,
+        entrypoint="judgearena.meta_eval.runner",
+        run=asdict(args),
+        results=results,
+        input_payloads={"question_id": df_sample["question_id"].astype(str).tolist()},
+        judge_system_prompt=prompt_spec.system_prompt,
+        judge_user_prompt_template=prompt_spec.user_prompt_template,
+        started_at_utc=started_at,
+    )
+
+    logger.info("Meta-eval results saved to %s", res_folder)
+    return results
+
+
+def run_or_exit(args: CliMetaEvalArgs) -> dict:
+    try:
+        return main(args)
+    except MetaEvalSamplingError as exc:
+        raise SystemExit(str(exc)) from exc

--- a/judgearena/meta_eval/sampling.py
+++ b/judgearena/meta_eval/sampling.py
@@ -1,0 +1,112 @@
+"""Deterministic arena battle sampling for meta-evaluation."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from judgearena.arenas_utils import KNOWN_ARENAS, load_arena_dataframe
+from judgearena.log import get_logger
+
+logger = get_logger(__name__)
+
+
+class MetaEvalSamplingError(ValueError):
+    """Raised when filtering or sampling yields an unusable subset."""
+
+
+def normalize_human_winner(winner: object) -> str:
+    text = str(winner)
+    if "tie" in text:
+        return "tie"
+    return text
+
+
+def count_battles_per_model(df: pd.DataFrame) -> dict[str, int]:
+    return (
+        pd.concat([df["model_a"], df["model_b"]], ignore_index=True)
+        .value_counts()
+        .to_dict()
+    )
+
+
+def load_reference_arena_battles(
+    reference_arena: str,
+    *,
+    languages: list[str] | None = None,
+) -> pd.DataFrame:
+    if reference_arena not in KNOWN_ARENAS:
+        raise MetaEvalSamplingError(
+            f"Unsupported reference arena {reference_arena!r}; "
+            f"expected one of {KNOWN_ARENAS}."
+        )
+
+    df = load_arena_dataframe(arena=reference_arena).copy()
+    df["winner"] = df["winner"].map(normalize_human_winner)
+
+    if languages:
+        df = df[df["lang"].isin(languages)].copy()
+        if df.empty:
+            langs = ", ".join(languages)
+            raise MetaEvalSamplingError(
+                f"No battles remain after filtering to languages: {langs}."
+            )
+
+    if df.empty:
+        raise MetaEvalSamplingError(
+            f"No battles found for reference arena {reference_arena!r}."
+        )
+    return df
+
+
+def select_top_models(
+    df: pd.DataFrame,
+    *,
+    top_models: int,
+) -> tuple[list[str], pd.DataFrame]:
+    battle_counts = count_battles_per_model(df)
+    if not battle_counts:
+        raise MetaEvalSamplingError("Cannot select top models from an empty dataframe.")
+
+    top = sorted(battle_counts, key=battle_counts.__getitem__, reverse=True)[
+        :top_models
+    ]
+    top_set = set(top)
+    df_top = df[df["model_a"].isin(top_set) & df["model_b"].isin(top_set)].copy()
+    if df_top.empty:
+        raise MetaEvalSamplingError(
+            f"No battles remain among the top {top_models} models."
+        )
+    return top, df_top
+
+
+def sample_battles_per_model(
+    df_top: pd.DataFrame,
+    top_models: list[str],
+    *,
+    battles_per_model: int,
+    seed: int,
+) -> pd.DataFrame:
+    per_model_samples: list[pd.DataFrame] = []
+    for model_index, model in enumerate(top_models):
+        model_mask = (df_top["model_a"] == model) | (df_top["model_b"] == model)
+        df_model = df_top[model_mask]
+        if df_model.empty:
+            logger.warning("Model %s has no battles among top models; skipping.", model)
+            continue
+        sample_size = min(battles_per_model, len(df_model))
+        sampled = df_model.sample(
+            n=sample_size,
+            replace=False,
+            random_state=seed + model_index,
+        )
+        per_model_samples.append(sampled)
+
+    if not per_model_samples:
+        raise MetaEvalSamplingError(
+            "Sampling produced no battles; reduce top_models or battles_per_model."
+        )
+
+    df_sample = pd.concat(per_model_samples, ignore_index=True)
+    if df_sample.empty:
+        raise MetaEvalSamplingError("Sampled battle set is empty.")
+    return df_sample

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "pandas>=2.3.2",
     "pyyaml>=6.0.2",
     "scikit-learn>=1.8.0",
+    "scipy>=1.16.0",
     "tqdm>=4.67.1",
     "pydantic-settings>=2.0",
     "pydantic>=2.13.4",
@@ -54,6 +55,7 @@ exclude = ["slurmpilot_scripts*"]
 [tool.setuptools.package-data]
 "judgearena.criteria" = ["data/*.yaml"]
 "judgearena.prompts" = ["*.txt", "*/*.txt"]
+"judgearena.meta_eval" = ["prompts/*.txt"]
 
 [dependency-groups]
 dev = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,13 @@ def _base_elo() -> dict:
     }
 
 
+def _base_meta_eval() -> dict:
+    return {
+        "task": "meta-eval",
+        "judge": {"model": "Dummy/j"},
+    }
+
+
 def test_generate_config_constructs():
     cfg = RunConfig(**_base_generate())
     assert cfg.task == "alpaca-eval"
@@ -33,6 +40,20 @@ def test_elo_config_derives_arena():
     cfg = RunConfig(**_base_elo())
     assert cfg.elo is not None
     assert cfg.elo.arena == "ComparIA"
+
+
+def test_meta_eval_config_constructs():
+    cfg = RunConfig(**_base_meta_eval())
+    assert cfg.meta_eval is not None
+    assert cfg.meta_eval.reference_arena == "LMArena-140k"
+    assert cfg.model.name is None
+
+
+def test_meta_eval_rejects_model_config():
+    data = _base_meta_eval()
+    data["model"] = {"name": "Dummy/a"}
+    with pytest.raises(ValidationError, match="model config is not used"):
+        RunConfig(**data)
 
 
 def test_elo_requires_model_path():

--- a/tests/test_meta_eval.py
+++ b/tests/test_meta_eval.py
@@ -14,7 +14,7 @@ import judgearena.meta_eval.runner as meta_eval_runner
 import judgearena.meta_eval.sampling as meta_sampling
 from judgearena import cli as cli_module
 from judgearena.arenas_utils import extract_turn_text
-from judgearena.evaluate import JudgeAnnotation, PairScore
+from judgearena.evaluate import JudgeAnnotation, PairScore, annotate_battles
 from judgearena.meta_eval.cache import AnnotationCache, AnnotationEntry, AnnotationKey
 from judgearena.meta_eval.cli_args import CliMetaEvalArgs
 from judgearena.meta_eval.metrics import (
@@ -216,6 +216,23 @@ def test_extract_text_structured_content():
         )
         == "part one"
     )
+
+
+def test_annotate_battles_serializes_judge_input():
+    class FakeJudge:
+        @staticmethod
+        def batch(*, inputs, **_kwargs):
+            return ["score_A: 9\nscore_B: 1"] * len(inputs)
+
+    annotation = annotate_battles(
+        judge_chat_model=FakeJudge(),
+        instructions=["Question"],
+        completions_A=["Answer A"],
+        completions_B=["Answer B"],
+    )[0]
+
+    assert isinstance(annotation.judge_input, str)
+    assert "Question" in annotation.judge_input
 
 
 def test_language_filter_empty_raises(monkeypatch, synthetic_arena_df):

--- a/tests/test_meta_eval.py
+++ b/tests/test_meta_eval.py
@@ -155,18 +155,17 @@ def test_cli_meta_eval_dispatch(monkeypatch):
         [
             "--task",
             "meta-eval",
-            "--judge",
+            "--judge.model",
             "Dummy/J",
-            "--reference_arena",
+            "--meta_eval.reference_arena",
             "LMArena-140k",
-            "--prompt_mode",
+            "--meta_eval.prompt_mode",
             "arena-hard",
-            "--languages",
-            "en",
-            "es",
-            "--top_models",
+            "--meta_eval.languages",
+            '["en", "es"]',
+            "--meta_eval.top_models",
             "5",
-            "--battles_per_model",
+            "--meta_eval.battles_per_model",
             "10",
         ]
     )
@@ -202,12 +201,16 @@ def test_meta_eval_rejects_nonpositive_batch_size():
 @pytest.mark.parametrize(
     ("flag", "value", "message"),
     [
-        ("--model_A", "Dummy/A", "--model_A/--model_B are not used"),
-        ("--n_instructions", "10", "--n_instructions is not used"),
+        ("--model.name", "Dummy/A", "model config is not used"),
         (
-            "--max_out_tokens_models",
+            "--generation.n_instructions",
+            "10",
+            "generation.n_instructions is not used",
+        ),
+        (
+            "--model.max_out_tokens",
             "1024",
-            "--max_out_tokens_models is not used",
+            "model.max_out_tokens is not used",
         ),
     ],
 )
@@ -223,7 +226,7 @@ def test_cli_meta_eval_rejects_irrelevant_flags(
             [
                 "--task",
                 "meta-eval",
-                "--judge",
+                "--judge.model",
                 "Dummy/J",
                 flag,
                 value,

--- a/tests/test_meta_eval.py
+++ b/tests/test_meta_eval.py
@@ -14,9 +14,10 @@ import judgearena.meta_eval.runner as meta_eval_runner
 import judgearena.meta_eval.sampling as meta_sampling
 from judgearena import cli as cli_module
 from judgearena.arenas_utils import extract_turn_text
+from judgearena.config import RunConfig
 from judgearena.evaluate import JudgeAnnotation, PairScore, annotate_battles
 from judgearena.meta_eval.cache import AnnotationCache, AnnotationEntry, AnnotationKey
-from judgearena.meta_eval.cli_args import CliMetaEvalArgs
+from judgearena.meta_eval.cli_args import CliMetaEvalArgs, meta_eval_args_from_config
 from judgearena.meta_eval.metrics import (
     compute_agreement_metrics,
     compute_elo_gap_summary,
@@ -37,6 +38,7 @@ from judgearena.meta_eval.sampling import (
     sample_battles_per_model,
     select_top_models,
 )
+from judgearena.models import DEFAULT_VLLM_JUDGE_THINKING_TOKEN_BUDGET
 from judgearena.repro import METADATA_FILENAME
 
 
@@ -173,6 +175,28 @@ def test_cli_meta_eval_dispatch(monkeypatch):
     assert args.prompt_mode == "arena-hard"
     assert args.languages == ["en", "es"]
     assert args.top_models == 5
+
+
+def test_meta_eval_applies_default_judge_model_kwargs():
+    cfg = RunConfig(
+        task="meta-eval",
+        judge={"model": "VLLM/Qwen/Qwen3-8B"},
+    )
+
+    args = meta_eval_args_from_config(cfg)
+
+    assert (
+        args.engine_kwargs["thinking_token_budget"]
+        == DEFAULT_VLLM_JUDGE_THINKING_TOKEN_BUDGET
+    )
+
+
+def test_meta_eval_rejects_nonpositive_batch_size():
+    with pytest.raises(ValueError, match="batch_size must be greater than zero"):
+        CliMetaEvalArgs(
+            judge_model="Dummy/judge",
+            batch_size=0,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_meta_eval.py
+++ b/tests/test_meta_eval.py
@@ -1,0 +1,649 @@
+"""Tests for judge meta-evaluation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import judgearena.meta_eval.annotate as meta_annotate
+import judgearena.meta_eval.cost as meta_cost
+import judgearena.meta_eval.runner as meta_eval_runner
+import judgearena.meta_eval.sampling as meta_sampling
+from judgearena import cli as cli_module
+from judgearena.arenas_utils import extract_turn_text
+from judgearena.evaluate import JudgeAnnotation, PairScore
+from judgearena.meta_eval.cache import AnnotationCache, AnnotationEntry, AnnotationKey
+from judgearena.meta_eval.cli_args import CliMetaEvalArgs
+from judgearena.meta_eval.metrics import (
+    compute_agreement_metrics,
+    compute_elo_gap_summary,
+)
+from judgearena.meta_eval.parsers import (
+    META_EVAL_PAIRSCORE_TEMPERATURE,
+    invert_winner,
+    parse_alpaca_eval_winner,
+    parse_arena_hard_winner,
+    parse_pairscore_winner,
+    parse_pref,
+    parse_winner,
+)
+from judgearena.meta_eval.prompts import PromptModeSpec, resolve_prompt_mode
+from judgearena.meta_eval.sampling import (
+    MetaEvalSamplingError,
+    load_reference_arena_battles,
+    sample_battles_per_model,
+    select_top_models,
+)
+from judgearena.repro import METADATA_FILENAME
+
+
+def _conversation(
+    instruction: str,
+    answer_a: str,
+    answer_b: str,
+    *,
+    structured: bool = False,
+) -> tuple[list[dict], list[dict]]:
+    if structured:
+        user_content = [{"type": "text", "text": instruction, "image": None}]
+        assistant_content = [{"type": "text", "text": answer_a}]
+        assistant_b_content = [{"type": "text", "text": answer_b}]
+    else:
+        user_content = instruction
+        assistant_content = answer_a
+        assistant_b_content = answer_b
+    conv_a = [
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": assistant_content},
+    ]
+    conv_b = [
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": assistant_b_content},
+    ]
+    return conv_a, conv_b
+
+
+@pytest.fixture
+def synthetic_arena_df() -> pd.DataFrame:
+    rows = []
+    models = [f"model-{idx}" for idx in range(5)]
+    for idx in range(120):
+        model_a = models[idx % len(models)]
+        model_b = models[(idx + 1) % len(models)]
+        winner = ["model_a", "model_b", "tie"][idx % 3]
+        lang = "en" if idx % 2 == 0 else "es"
+        conv_a, conv_b = _conversation(
+            f"Question {idx}",
+            f"Answer A {idx}",
+            f"Answer B {idx}",
+            structured=idx % 4 == 0,
+        )
+        rows.append(
+            {
+                "question_id": f"q-{idx}",
+                "tstamp": 1_700_000_000 + idx,
+                "model_a": model_a,
+                "model_b": model_b,
+                "winner": winner,
+                "conversation_a": conv_a,
+                "conversation_b": conv_b,
+                "benchmark": "LMArena-140k",
+                "lang": lang,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def meta_args(tmp_path: Path) -> CliMetaEvalArgs:
+    return CliMetaEvalArgs(
+        reference_arena="LMArena-140k",
+        prompt_mode="standard",
+        top_models=3,
+        battles_per_model=4,
+        batch_size=8,
+        languages=["en", "es"],
+        n_bootstraps=20,
+        seed=7,
+        judge_model="Dummy/judge",
+        result_folder=str(tmp_path / "results"),
+        no_log_file=True,
+    )
+
+
+def _judge_annotations(*, instructions, completions_A, completions_B, **_kwargs):
+    return [
+        JudgeAnnotation(
+            instruction=instruction,
+            completion_A=completion_a,
+            completion_B=completion_b,
+            judge_completion="score_A: 9\nscore_B: 1",
+            judge_input="judge prompt",
+        )
+        for instruction, completion_a, completion_b in zip(
+            instructions,
+            completions_A,
+            completions_B,
+            strict=True,
+        )
+    ]
+
+
+@pytest.fixture
+def stub_meta_eval_runner(monkeypatch, synthetic_arena_df):
+    monkeypatch.setattr(
+        meta_eval_runner,
+        "load_reference_arena_battles",
+        lambda reference_arena, languages=None: synthetic_arena_df,
+    )
+    monkeypatch.setattr(meta_eval_runner, "make_model", lambda **_kwargs: object())
+
+
+def test_cli_meta_eval_dispatch(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_main(args: CliMetaEvalArgs) -> None:
+        captured["args"] = args
+
+    monkeypatch.setattr(cli_module, "main_meta_eval", fake_main)
+    cli_module.cli(
+        [
+            "--task",
+            "meta-eval",
+            "--judge",
+            "Dummy/J",
+            "--reference_arena",
+            "LMArena-140k",
+            "--prompt_mode",
+            "arena-hard",
+            "--languages",
+            "en",
+            "es",
+            "--top_models",
+            "5",
+            "--battles_per_model",
+            "10",
+        ]
+    )
+    args: CliMetaEvalArgs = captured["args"]
+    assert args.reference_arena == "LMArena-140k"
+    assert args.prompt_mode == "arena-hard"
+    assert args.languages == ["en", "es"]
+    assert args.top_models == 5
+
+
+@pytest.mark.parametrize(
+    ("flag", "value", "message"),
+    [
+        ("--model_A", "Dummy/A", "--model_A/--model_B are not used"),
+        ("--n_instructions", "10", "--n_instructions is not used"),
+        (
+            "--max_out_tokens_models",
+            "1024",
+            "--max_out_tokens_models is not used",
+        ),
+    ],
+)
+def test_cli_meta_eval_rejects_irrelevant_flags(
+    monkeypatch,
+    flag,
+    value,
+    message,
+):
+    monkeypatch.setattr(cli_module, "main_meta_eval", lambda _args: None)
+    with pytest.raises(SystemExit, match=message):
+        cli_module.cli(
+            [
+                "--task",
+                "meta-eval",
+                "--judge",
+                "Dummy/J",
+                flag,
+                value,
+            ]
+        )
+
+
+def test_extract_text_structured_content():
+    conv_a, _ = _conversation("hello", "A", "B", structured=True)
+    assert extract_turn_text(conv_a[0]) == "hello"
+    assert (
+        extract_turn_text(
+            {"content": [{"type": "text", "text": "part one"}]},
+        )
+        == "part one"
+    )
+
+
+def test_language_filter_empty_raises(monkeypatch, synthetic_arena_df):
+    monkeypatch.setattr(
+        meta_sampling,
+        "load_arena_dataframe",
+        lambda arena: synthetic_arena_df,
+    )
+    with pytest.raises(MetaEvalSamplingError, match="languages"):
+        load_reference_arena_battles("LMArena-140k", languages=["zz"])
+
+
+def test_sampling_is_deterministic(synthetic_arena_df):
+    df = synthetic_arena_df.copy()
+    top_models, df_top = select_top_models(df, top_models=3)
+    first = sample_battles_per_model(
+        df_top,
+        top_models,
+        battles_per_model=3,
+        seed=11,
+    )
+    second = sample_battles_per_model(
+        df_top,
+        top_models,
+        battles_per_model=3,
+        seed=11,
+    )
+    assert first["question_id"].tolist() == second["question_id"].tolist()
+    assert len(first) == 9
+
+
+@pytest.mark.parametrize(
+    ("completion", "expected"),
+    [
+        ("My verdict is [[A>>B]]", "model_a"),
+        ("Final: [[B>A]]", "model_b"),
+        ("No signal", "tie"),
+    ],
+)
+def test_parse_arena_hard_winner(completion, expected):
+    assert parse_arena_hard_winner(completion) == expected
+
+
+def test_parse_alpaca_eval_winner():
+    completion = (
+        '```json\n{"ordered_models": [{"model": "m", "rank": 2}, '
+        '{"model": "M", "rank": 1}]}\n```'
+    )
+    assert parse_alpaca_eval_winner(completion) == "model_b"
+
+
+def test_pairscore_temperature_and_tie():
+    completion = "score_A: 5\nscore_B: 5"
+    benchmark = PairScore()
+    benchmark.temperature = 0.3
+    meta = PairScore()
+    meta.temperature = META_EVAL_PAIRSCORE_TEMPERATURE
+    assert benchmark.parse_model_raw(completion) == 0.5
+    assert meta.parse_model_raw(completion) == 0.5
+    assert parse_pairscore_winner(completion, temperature=0.5) == "tie"
+    assert (
+        parse_pairscore_winner(
+            "score_A: 10\nscore_B: 0",
+            temperature=0.5,
+        )
+        == "model_a"
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "completion", "expected"),
+    [
+        ("standard", "score_A: 9\nscore_B: 1", "model_a"),
+        ("arena-hard", "[[A=B]]", "tie"),
+        (
+            "alpaca-eval",
+            '{"ordered_models": [{"model": "m", "rank": 1}]}',
+            "model_a",
+        ),
+        ("alpaca-eval-pair-score", "score_A: 9\nscore_B: 1", "model_a"),
+    ],
+)
+def test_parse_winner_modes(mode, completion, expected):
+    assert parse_winner(completion, mode) == expected
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["arena-hard", "alpaca-eval", "alpaca-eval-pair-score"],
+)
+def test_file_backed_prompt_modes_load_packaged_resources(mode):
+    prompt = resolve_prompt_mode(mode)
+    assert prompt.system_prompt
+    assert prompt.user_prompt_template
+
+
+def test_parse_pref_continuous_semantics():
+    assert parse_pref("score_A: 10\nscore_B: 0", "standard") < 0.5
+    assert parse_pref("score_A: 0\nscore_B: 10", "standard") > 0.5
+    assert parse_pref("[[A=B]]", "arena-hard") == 0.5
+
+
+def test_swap_inversion():
+    assert invert_winner("model_a") == "model_b"
+    assert invert_winner("tie") == "tie"
+
+
+def test_agreement_metrics_on_fixture():
+    human = ["model_a", "model_b", "tie", "model_a"]
+    llm = ["model_a", "model_a", "tie", "model_b"]
+    metrics = compute_agreement_metrics(
+        human,
+        llm,
+        n_bootstraps=10,
+        seed=0,
+    )
+    assert metrics["n"] == 4
+    assert metrics["accuracy"] == 0.5
+    assert metrics["n_nt"] == 3
+
+
+def _cache_key(**overrides) -> AnnotationKey:
+    values = {
+        "benchmark": "LMArena-140k",
+        "instruction_id": "q-1",
+        "model_a": "model-a",
+        "model_b": "model-b",
+        "judge": "Dummy/judge",
+    }
+    values.update(overrides)
+    return AnnotationKey(**values)
+
+
+def _cache_entry(completion: str = "score_A: 9\nscore_B: 1", **overrides):
+    key = _cache_key(**overrides)
+    return AnnotationEntry(
+        **key.__dict__,
+        judge_input="judge prompt",
+        judge_completion=completion,
+    )
+
+
+def test_annotation_cache_persists_and_preserves_batch_order(tmp_path):
+    db_dir = tmp_path / "db"
+    first = AnnotationCache(db_dir)
+    first.batch_put(
+        [
+            _cache_entry(instruction_id="q-2", completion="second"),
+            _cache_entry(instruction_id="q-1", completion="first"),
+        ]
+    )
+    first.close()
+
+    second = AnnotationCache(db_dir)
+    entries = second.batch_get_annotations(
+        [
+            _cache_key(instruction_id="q-1"),
+            _cache_key(instruction_id="q-2"),
+            _cache_key(instruction_id="missing"),
+        ]
+    )
+    assert [entry.judge_completion if entry else None for entry in entries] == [
+        "first",
+        "second",
+        None,
+    ]
+    second.close()
+
+
+def test_annotation_cache_distinguishes_prompt_mode_and_model_order(tmp_path):
+    cache = AnnotationCache(tmp_path / "db")
+    cache.batch_put(
+        [
+            _cache_entry(judge="Dummy/judge::arena-hard"),
+            _cache_entry(model_a="model-b", model_b="model-a"),
+        ]
+    )
+    entries = cache.batch_get_annotations(
+        [
+            _cache_key(judge="Dummy/judge"),
+            _cache_key(judge="Dummy/judge::arena-hard"),
+            _cache_key(model_a="model-b", model_b="model-a"),
+        ]
+    )
+    assert entries[0] is None
+    assert all(entry is not None for entry in entries[1:])
+    cache.close()
+
+
+def test_annotate_sample_uses_cache_and_inverts_swapped_pass(
+    monkeypatch,
+    synthetic_arena_df,
+    meta_args,
+    tmp_path,
+):
+    calls = {"count": 0}
+
+    def fake_annotate_battles(**kwargs):
+        calls["count"] += 1
+        return _judge_annotations(**kwargs)
+
+    monkeypatch.setattr(meta_annotate, "annotate_battles", fake_annotate_battles)
+    meta_args.swap_mode = "both"
+    sample = synthetic_arena_df.iloc[:1]
+    cache = AnnotationCache(tmp_path / "db")
+    prompt_spec = PromptModeSpec(
+        name="standard",
+        system_prompt="system",
+        user_prompt_template="user",
+    )
+
+    annotations = meta_annotate.annotate_sample(
+        sample,
+        meta_args,
+        judge_chat_model=object(),
+        prompt_spec=prompt_spec,
+        annotation_cache=cache,
+    )
+    assert len(annotations) == 2
+    assert annotations["orientation"].tolist() == ["forward", "swapped"]
+    assert annotations["winner"].tolist() == [sample.iloc[0]["winner"]] * 2
+    assert annotations["winner_llm"].tolist() == ["model_a", "model_b"]
+    assert annotations["model_a"].tolist() == [sample.iloc[0]["model_a"]] * 2
+    assert annotations["presented_model_a"].tolist() == [
+        sample.iloc[0]["model_a"],
+        sample.iloc[0]["model_b"],
+    ]
+    assert annotations["completion_a"].nunique() == 1
+    assert (
+        annotations.iloc[1]["presented_completion_a"]
+        == annotations.iloc[0]["completion_b"]
+    )
+    assert calls["count"] == 2
+
+    meta_annotate.annotate_sample(
+        sample,
+        meta_args,
+        judge_chat_model=object(),
+        prompt_spec=prompt_spec,
+        annotation_cache=cache,
+    )
+    assert calls["count"] == 2
+
+    meta_args.ignore_cache = True
+    meta_annotate.annotate_sample(
+        sample,
+        meta_args,
+        judge_chat_model=object(),
+        prompt_spec=prompt_spec,
+        annotation_cache=cache,
+    )
+    assert calls["count"] == 4
+    cache.close()
+
+
+def test_cost_uses_offline_reference_pricing(monkeypatch, tmp_path):
+    pricing_file = tmp_path / "openrouter_pricing.json"
+    pricing_file.write_text(
+        json.dumps({"provider/model": [1.0, 2.0]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(meta_cost, "_PRICING_CACHE_FILE", pricing_file)
+    meta_cost._openrouter_pricing_cache.clear()
+
+    cost, source = meta_cost.estimate_annotation_cost_usd(
+        judge_input="a" * 40,
+        judge_completion="b" * 20,
+        judge_model="OpenRouter/provider/model",
+    )
+    assert cost == pytest.approx((10 * 1.0 + 5 * 2.0) / 1e6)
+    assert source == "estimated"
+    meta_cost._openrouter_pricing_cache.clear()
+
+
+def test_swapped_pass_telemetry_counts_both_judgements():
+    annotations = pd.DataFrame(
+        {
+            "cost_usd": [0.1, 0.2],
+            "cost_source": ["estimated", "estimated"],
+            "estimated_input_tokens": [10, 11],
+            "estimated_output_tokens": [5, 6],
+        }
+    )
+    telemetry = meta_eval_runner._annotation_telemetry(
+        annotations,
+        swap_mode="both",
+    )
+    assert telemetry["judgement_count"] == 2
+    assert telemetry["total_cost_usd"] == pytest.approx(0.3)
+    assert telemetry["estimated_input_tokens"] == 21
+    assert telemetry["estimated_output_tokens"] == 11
+
+
+def test_degenerate_agreement_metrics_do_not_warn(recwarn):
+    metrics = compute_agreement_metrics(
+        ["model_a"] * 4,
+        ["model_a"] * 4,
+        n_bootstraps=10,
+        seed=0,
+    )
+    assert metrics["accuracy"] == 1.0
+    assert pd.isna(metrics["kappa"])
+    assert not recwarn.list
+
+
+def test_integration_meta_eval_artifacts(
+    monkeypatch,
+    meta_args: CliMetaEvalArgs,
+    stub_meta_eval_runner,
+):
+    def fake_annotate(df_sample, args, **kwargs):
+        frame = df_sample[
+            ["question_id", "model_a", "model_b", "winner", "lang", "benchmark"]
+        ].copy()
+        winners = frame["winner"].where(frame["winner"] == "model_a", "model_b")
+        return frame.assign(
+            orientation="forward",
+            instruction="instr",
+            completion_a="A",
+            completion_b="B",
+            judge_input="prompt",
+            judge_completion="score_A: 9\nscore_B: 1",
+            estimated_input_tokens=2,
+            estimated_output_tokens=5,
+            cost_usd=0.001,
+            cost_source="estimated",
+            winner_llm=winners,
+            pref_llm=winners.map({"model_a": 0.0, "model_b": 1.0}),
+        )
+
+    monkeypatch.setattr(meta_eval_runner, "annotate_sample", fake_annotate)
+
+    results = meta_eval_runner.main(meta_args)
+    output_dirs = list(Path(meta_args.result_folder).glob("meta-eval-*"))
+    assert len(output_dirs) == 1
+    out = output_dirs[0]
+    assert (out / "args.json").exists()
+    assert (out / "annotations.parquet").exists()
+    assert (out / "results.json").exists()
+    assert (out / "summary.csv").exists()
+    assert (out / METADATA_FILENAME).exists()
+    metadata = json.loads((out / METADATA_FILENAME).read_text(encoding="utf-8"))
+    assert metadata["entrypoint"] == "judgearena.meta_eval.runner"
+    assert results["agreement"]["primary_view"] == "no_human_ties"
+    assert results["agreement"]["all"]["n"] > results["agreement"]["no_human_ties"]["n"]
+    assert results["judgement_count"] == results["sample_size"]
+    assert results["total_cost_usd"] == pytest.approx(results["sample_size"] * 0.001)
+    assert "English" in results["language_summary"]
+
+
+def test_swap_mode_both_artifact_reproduces_overall_agreement(
+    monkeypatch,
+    meta_args,
+    stub_meta_eval_runner,
+    tmp_path,
+):
+    cache_class = AnnotationCache
+    monkeypatch.setattr(
+        meta_annotate,
+        "AnnotationCache",
+        lambda: cache_class(tmp_path / "cache"),
+    )
+    monkeypatch.setattr(meta_annotate, "annotate_battles", _judge_annotations)
+    meta_args.swap_mode = "both"
+    meta_args.battles_per_model = 2
+    meta_args.elo_gap_battles = [1]
+    meta_args.elo_gap_seeds = 1
+
+    results = meta_eval_runner.main(meta_args)
+    output_dir = next(Path(meta_args.result_folder).glob("meta-eval-*"))
+    annotations = pd.read_parquet(output_dir / "annotations.parquet")
+    forward = annotations[annotations["orientation"] == "forward"]
+    swapped = annotations[annotations["orientation"] == "swapped"]
+
+    assert len(annotations) == 2 * results["sample_size"]
+    assert len(forward) == len(swapped) == results["sample_size"]
+    assert results["judgement_count"] == len(annotations)
+    assert results["ranking_annotation_count"] == len(forward)
+    assert (swapped["model_a"].to_numpy() == swapped["presented_model_b"]).all()
+    assert (swapped["model_b"].to_numpy() == swapped["presented_model_a"]).all()
+    assert (swapped["completion_a"].to_numpy() == forward["completion_a"]).all()
+    assert (swapped["completion_b"].to_numpy() == forward["completion_b"]).all()
+
+    recomputed = compute_agreement_metrics(
+        annotations["winner"].tolist(),
+        annotations["winner_llm"].tolist(),
+        n_bootstraps=meta_args.n_bootstraps,
+        seed=meta_args.seed,
+    )
+    assert results["agreement"]["all"]["accuracy"] == recomputed["accuracy"]
+    assert results["agreement"]["all"]["kappa"] == recomputed["kappa"]
+
+
+def test_elo_gap_summary_runs(synthetic_arena_df):
+    top_models, df_top = select_top_models(synthetic_arena_df, top_models=3)
+    df_sample = sample_battles_per_model(
+        df_top,
+        top_models,
+        battles_per_model=3,
+        seed=1,
+    )
+    df_ann = df_sample.copy()
+    df_ann["winner_llm"] = df_ann["winner"]
+    df_ann["pref_llm"] = 0.5
+    summary = compute_elo_gap_summary(
+        df_top,
+        df_ann,
+        top_models,
+        n_battles_list=[2],
+        n_seeds=2,
+        seed=0,
+        exclude_ties=False,
+    )
+    assert not summary.empty
+
+
+def test_empty_language_subset_reports_na(
+    monkeypatch,
+    synthetic_arena_df,
+    meta_args: CliMetaEvalArgs,
+):
+    meta_args.languages = ["en"]
+
+    def _raise_empty(_reference_arena, languages=None):
+        raise MetaEvalSamplingError(
+            "No battles remain after filtering to languages: en."
+        )
+
+    monkeypatch.setattr(meta_eval_runner, "load_reference_arena_battles", _raise_empty)
+    with pytest.raises(SystemExit):
+        meta_eval_runner.run_or_exit(meta_args)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -10,6 +10,14 @@ from importlib.resources import files
 
 from judgearena.criteria.defaults import CRITERIA_BY_NAME
 
+META_EVAL_PROMPT_RESOURCES = (
+    "arena_hard_system.txt",
+    "arena_hard_user.txt",
+    "alpaca_eval_system.txt",
+    "alpaca_eval_user.txt",
+    "alpaca_eval_pair_score_user.txt",
+)
+
 
 def _assert_non_empty_text_resource(package: str, relative_path: str) -> None:
     content = files(package).joinpath(relative_path).read_text()
@@ -30,6 +38,11 @@ def main() -> None:
     _assert_non_empty_text_resource("judgearena.prompts", "prompt.txt")
     _assert_non_empty_text_resource("judgearena.prompts", "system-prompt.txt")
     _assert_non_empty_text_resource("judgearena.criteria", "data/default.yaml")
+    for filename in META_EVAL_PROMPT_RESOURCES:
+        _assert_non_empty_text_resource(
+            "judgearena.meta_eval",
+            f"prompts/{filename}",
+        )
 
     print("✅ All integrity checks passed: Imports, Criteria, and Resources are valid.")
 


### PR DESCRIPTION
## Summary

- Add `--task meta-eval` for evaluating judge models against human-labeled arena battles.
- Support deterministic sampling, language filtering, four named prompt modes, and optional swapped-order judging.
- Report agreement, ranking, ELO, bootstrap uncertainty, ELO-gap, token, and cost metrics.
- Save auditable per-pass annotations, summaries, results, and run metadata.
- Package prompt resources and integrate meta-eval with the hierarchical `RunConfig` CLI.

## Usage

```bash
judgearena \
  --task meta-eval \
  --judge.model OpenRouter/deepseek/deepseek-v3.2 \
  --meta_eval.reference_arena LMArena-140k \
  --meta_eval.prompt_mode standard \
  --meta_eval.languages '["en", "es"]' \
  --meta_eval.top_models 20 \
  --meta_eval.battles_per_model 50 \
  --meta_eval.n_bootstraps 1000 \
  --run.seed 0
```

## Outputs

Runs produce:

- `annotations.parquet`
- `results.json`
- `summary.csv`
- `args.json`
- `run-metadata.v1.json`

With `--judge.swap_mode both`, annotations contain one row per judge pass with normalized model ordering and an `orientation` column.

## Cache note

Meta-eval temporarily retains the existing per-battle SQLite WAL cache. It should be used from a single host and not concurrently across NFS-mounted compute nodes. Cache unification remains deferred to the dedicated caching work.
