### PR TITLE
Make run metadata compact, explicit, and more reusable

### DIFF
--- a/judgearena/dataset_revisions.py
+++ b/judgearena/dataset_revisions.py
@@ -54,11 +54,51 @@ def hf_revision(repo_id: str) -> str | None:
 def all_dataset_revisions() -> dict[str, str | None]:
     """Return a copy of every pin recorded in this module.
 
-    Used by :func:`judgearena.repro.write_run_metadata` to record the
-    pin table alongside each run so future readers know which version of
-    the data was visible at the time of the run.
+    Run metadata uses :func:`revisions_for_task` or
+    :func:`revisions_for_arena` so it records only sources relevant to that
+    experiment rather than copying the complete global pin table.
     """
     return {
         **HF_DATASET_REVISIONS,
         **{f"raw:{k}": v for k, v in RAW_URL_REVISIONS.items()},
+    }
+
+
+def revisions_for_task(task: str) -> dict[str, str | None]:
+    """Return only the pinned sources used by one instruction benchmark."""
+    repo_ids: list[str] = []
+    if task == "alpaca-eval":
+        repo_ids = ["judge-arena/judge-arena-dataset"]
+    elif task.startswith("arena-hard-"):
+        repo_ids = ["lmarena-ai/arena-hard-auto"]
+    elif task.startswith("m-arena-hard-v0.1"):
+        repo_ids = ["CohereLabs/m-ArenaHard"]
+    elif task.startswith("m-arena-hard-v2.0"):
+        repo_ids = ["CohereLabs/m-ArenaHard-v2.0"]
+    elif task == "mt-bench":
+        repo_ids = ["lmsys/mt-bench"]
+    elif task.startswith("fluency-"):
+        repo_ids = ["geoalgo/multilingual-contexts-to-be-completed"]
+
+    revisions = {repo_id: hf_revision(repo_id) for repo_id in repo_ids}
+    if task == "mt-bench":
+        revisions["raw:lm-sys/FastChat"] = RAW_URL_REVISIONS.get("lm-sys/FastChat")
+    return revisions
+
+
+def revisions_for_arena(arena: str) -> dict[str, str | None]:
+    """Return the pinned source revision(s) used by one ELO arena."""
+    arena_repositories = {
+        "LMArena-100k": ["lmarena-ai/arena-human-preference-100k"],
+        "LMArena-55k": ["lmarena-ai/arena-human-preference-55k"],
+        "LMArena-140k": ["lmarena-ai/arena-human-preference-140k"],
+        "LMArena": [
+            "lmarena-ai/arena-human-preference-100k",
+            "lmarena-ai/arena-human-preference-55k",
+            "lmarena-ai/arena-human-preference-140k",
+        ],
+        "ComparIA": ["ministere-culture/comparia-votes"],
+    }
+    return {
+        repo_id: hf_revision(repo_id) for repo_id in arena_repositories.get(arena, [])
     }

--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -12,6 +12,7 @@ from sklearn.linear_model import LogisticRegression
 
 from judgearena.arenas_utils import _extract_instruction_text, load_arena_dataframe
 from judgearena.battles import Leaderboard, summarize_bootstrap, write_battles
+from judgearena.dataset_revisions import revisions_for_arena
 from judgearena.evaluate import (
     PairScore,
     calibrate_temperature,
@@ -23,7 +24,7 @@ from judgearena.generate import generate_instructions
 from judgearena.generate_and_evaluate import _build_generation_kwargs
 from judgearena.log import get_logger
 from judgearena.models import build_default_judge_model_kwargs, make_model
-from judgearena.repro import write_run_metadata
+from judgearena.repro import InputMetadata, RunContext, write_run_metadata
 from judgearena.utils import cache_function_dataframe, compute_pref_summary
 from judgearena.utils.eval import PrefSummary, Report
 
@@ -619,6 +620,8 @@ def main(cfg: "RunConfig") -> dict:
     # Run the judge on a random subset of human arena battles that already
     # have ground-truth winner labels so we can fit T* via MLE.
     calibrated_temperature: float | None = None
+    calibration_example_count: int | None = None
+    calibration_judgment_count: int | None = None
     if cfg.elo.calibrate_temperature:
         if not cfg.elo.soft_elo:
             logger.warning(
@@ -639,6 +642,7 @@ def main(cfg: "RunConfig") -> dict:
             cal_battles = df_arena.sample(
                 n=_cal_n, random_state=int(rng.integers(0, 2**31))
             )
+            calibration_example_count = len(cal_battles)
 
             cal_instructions = [
                 _extract_instruction_text(df_arena_all.loc[i, "conversation_a"][0])
@@ -655,17 +659,29 @@ def main(cfg: "RunConfig") -> dict:
 
             judge_chat_model_cal = make_model(
                 model=cfg.judge.model,
-                max_tokens=cfg.judge.max_out_tokens,
                 **judge_extra_kwargs,
             )
-            cal_annotations, _, cal_prefs = judge_and_parse_prefs(
-                judge_chat_model=judge_chat_model_cal,
-                instructions=cal_instructions,
-                completions_A=cal_completions_a,
-                completions_B=cal_completions_b,
-                swap_mode=cfg.judge.swap_mode,
-                provide_explanation=cfg.judge.provide_explanation,
-                truncate_input_chars=cfg.generation.truncate_judge_input_chars,
+            cal_annotations, cal_annotations_reversed, cal_prefs = (
+                judge_and_parse_prefs(
+                    judge_chat_model=judge_chat_model_cal,
+                    instructions=cal_instructions,
+                    completions_A=cal_completions_a,
+                    completions_B=cal_completions_b,
+                    swap_mode=cfg.judge.swap_mode,
+                    provide_explanation=cfg.judge.provide_explanation,
+                    strip_thinking_before_judging=cfg.judge.strip_thinking_before_judging,
+                    system_prompt=resolved_prompt.system_prompt,
+                    user_prompt_template=resolved_prompt.user_prompt_template,
+                    prompt_preset=resolved_prompt.preset_name,
+                    parser_mode=resolved_prompt.parser_mode,
+                    truncate_input_chars=cfg.generation.truncate_judge_input_chars,
+                    use_tqdm=use_tqdm,
+                )
+            )
+            calibration_judgment_count = len(cal_annotations) + (
+                len(cal_annotations_reversed)
+                if cal_annotations_reversed is not None
+                else 0
             )
 
             # Build (delta_s, y) pairs from calibration battles.
@@ -824,6 +840,11 @@ def main(cfg: "RunConfig") -> dict:
     # instruction-index join key back to the arena initial table / completion
     # cache. battles.parquet keeps pref_hard so both hard and soft ELO recompute.
     res_dir = result_path.parent
+    from judgearena.config import dump_config
+
+    config_path = res_dir / "config.yaml"
+    dump_config(cfg, config_path)
+
     battle_cols = [
         "model_a",
         "model_b",
@@ -834,14 +855,21 @@ def main(cfg: "RunConfig") -> dict:
         "judge_model",
         "question_id",
     ]
+    battles_path = res_dir / "battles.parquet"
     write_battles(
-        res_dir / "battles.parquet",
+        battles_path,
         df_llm_judge[[c for c in battle_cols if c in df_llm_judge.columns]],
     )
+    artifacts: dict[str, Path] = {
+        "battles": battles_path,
+        "results": result_path,
+    }
     if bootstrap_ratings:
+        bootstrap_path = res_dir / "bootstrap_ratings.csv"
         pd.DataFrame(bootstrap_ratings).to_csv(
-            res_dir / "bootstrap_ratings.csv", index=False
+            bootstrap_path, index=False
         )
+        ratings_path = res_dir / "elo_ratings.json"
         Leaderboard(
             arena=cfg.elo.arena,
             model=model_name,
@@ -849,7 +877,13 @@ def main(cfg: "RunConfig") -> dict:
             n_bootstraps=n_bootstraps,
             seed=cfg.run.seed,
             ratings=entries,
-        ).write(res_dir / "elo_ratings.json")
+        ).write(ratings_path)
+        artifacts.update(
+            {
+                "bootstrap_ratings": bootstrap_path,
+                "elo_ratings": ratings_path,
+            }
+        )
 
     # Reproducibility manifest (git hash, dependency versions, timings) — parity
     # with the other entrypoints, all of which write run-metadata. Best-effort:
@@ -858,15 +892,33 @@ def main(cfg: "RunConfig") -> dict:
         write_run_metadata(
             output_dir=res_dir,
             entrypoint="judgearena.estimate_elo_ratings.main",
-            run=cfg.model_dump(),
-            results=results,
-            input_payloads=(
-                {"question_id": df_battles["question_id"].tolist()}
-                if "question_id" in df_battles.columns
-                else None
+            context=RunContext.from_config(
+                cfg,
+                workflow="elo",
+                configuration_path=config_path,
             ),
-            judge_system_prompt=resolved_prompt.system_prompt,
-            judge_user_prompt_template=resolved_prompt.user_prompt_template,
+            inputs=InputMetadata.capture(
+                dataset_revisions=revisions_for_arena(cfg.elo.arena),
+                example_ids=(
+                    df_battles["question_id"].tolist()
+                    if "question_id" in df_battles.columns
+                    else None
+                ),
+                content=df_judge[
+                    [
+                        "instruction",
+                        "completion_A",
+                        "completion_B",
+                        "opponent_model",
+                    ]
+                ].to_dict(orient="records"),
+                example_count=len(df_battles),
+                judgment_count=n_llm,
+                calibration_example_count=calibration_example_count,
+                calibration_judgment_count=calibration_judgment_count,
+            ),
+            judge_prompt=resolved_prompt,
+            artifacts=artifacts,
             started_at_utc=run_started_at,
         )
     except OSError as e:

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -1,20 +1,11 @@
-import json
 import re
 from dataclasses import dataclass
-from datetime import UTC, datetime
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from langchain_core.language_models.llms import LLM
 from langchain_core.prompts import ChatPromptTemplate
 from scipy.optimize import minimize_scalar
 
-from judgearena.instruction_dataset import load_instructions
-from judgearena.instruction_dataset.arena_hard import (
-    download_arena_hard,
-    is_arena_hard_dataset,
-)
 from judgearena.log import get_logger
 from judgearena.models import do_inference
 from judgearena.prompts.registry import (
@@ -25,15 +16,7 @@ from judgearena.prompts.registry import (
 from judgearena.prompts.registry import (
     resolve_run_judge_prompt as _resolve_run_judge_prompt,
 )
-from judgearena.repro import _to_jsonable, write_run_metadata
-from judgearena.utils import (
-    compute_pref_summary,
-    data_root,
-    download_hf,
-    read_df,
-    strip_thinking_tags,
-    truncate,
-)
+from judgearena.utils import strip_thinking_tags, truncate
 
 logger = get_logger(__name__)
 
@@ -130,18 +113,6 @@ def calibrate_temperature(
     return float(result.x)
 
 
-def load_judge_system_and_user_prompt(
-    provide_explanation: bool = True,
-    multi_turn: bool = False,
-) -> tuple[str, str]:
-    resolved = resolve_judge_prompt(
-        preset=DEFAULT_JUDGE_PROMPT_PRESET,
-        provide_explanation=provide_explanation,
-        multi_turn=multi_turn,
-    )
-    return resolved.system_prompt or "", resolved.user_prompt_template
-
-
 def resolve_judge_prompts(
     *,
     provide_explanation: bool = False,
@@ -191,159 +162,6 @@ def resolve_run_judge_prompt(
     return _resolve_run_judge_prompt(task, cli_args, multi_turn=multi_turn)
 
 
-def evaluate_completions(
-    dataset: str = "alpaca-eval",
-    judge_chat_model: LLM = None,
-    method_A: str = "gpt4_1106_preview",
-    method_B: str = "llama-2-70b-chat-hf",
-    num_annotations: int | None = 50,
-    use_tqdm: bool = False,
-    truncate_input_chars: int | None = 8192,
-    provide_explanation: bool = False,
-    prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
-    strip_thinking_before_judging: bool = False,
-):
-    """
-    :param dataset:
-    :param judge_chat_model:
-    :param method_A: one method to evaluate, can be a method existing in `dataset` or a local path to the completion
-    of a local method. The path should be a dataframe ending with ".csv.zip" or ".parquet", have columns
-    "instruction_index" and "output" and should contains all the instruction of `dataset`.
-    :param method_B: another method to evaluate against `method_A`
-    :param num_annotations: if specified will do at most `num_annotations` annotations
-    :param use_tqdm:
-    :param truncate_input_chars: if specified, truncates the length of completion, useful to save cost and avoid
-    exceeding context limit
-    :return:
-    """
-    run_started_at = datetime.now(UTC)
-    local_path_tables = data_root / "tables"
-    if is_arena_hard_dataset(dataset):
-        download_arena_hard(dataset=dataset, local_tables_path=local_path_tables)
-    else:
-        download_hf(name=dataset, local_path=local_path_tables)
-
-    instructions = load_instructions(
-        dataset=dataset,
-    ).loc[:, "instruction"]
-
-    # A bit ugly, only loads if local path exist as we do not have a local path of completion for cases such as
-    # m-arena-hard.
-    dataset_output_path = local_path_tables / "model_outputs" / f"{dataset}.csv.zip"
-    if dataset_output_path.exists():
-        df_outputs = read_df(dataset_output_path)
-        # empty strings are encoded as Nan in csv
-        df_outputs.loc[:, "output"] = df_outputs.loc[:, "output"].fillna("")
-        df_outputs = df_outputs.pivot_table(
-            index="instruction_index", columns="model", values="output", aggfunc="last"
-        ).sort_index()
-        df_outputs = df_outputs.loc[instructions.index]
-    else:
-        df_outputs = None
-
-    def get_output(df_outputs: pd.DataFrame, dataset: str, method: str):
-        if Path(method).exists():
-            logger.info("Path %s exists, loading local model completions.", method)
-            df = read_df(Path(method)).set_index("instruction_index").sort_index()
-            logger.info("Loaded %d completions.", len(df))
-            df.loc[:, "output"] = df.loc[:, "output"].fillna("")
-            return df.loc[:, "output"]
-        else:
-            logger.info("Loading %s from %s dataset.", method, dataset)
-            assert method in df_outputs.columns, (
-                f"Method {method} not present, pick among {df_outputs.columns.tolist()}"
-            )
-            return df_outputs.loc[:, method].sort_index()
-
-    completions_A = get_output(df_outputs=df_outputs, dataset=dataset, method=method_A)
-    completions_B = get_output(df_outputs=df_outputs, dataset=dataset, method=method_B)
-    if num_annotations is not None:
-        instructions = instructions.head(num_annotations)
-        completions_A = completions_A.head(num_annotations)
-        completions_B = completions_B.head(num_annotations)
-    assert completions_A.index.tolist() == completions_B.index.tolist(), (
-        f"Index mismatch between methods {method_A} and {method_B}."
-    )
-
-    if judge_chat_model is None:
-        from langchain_together.llms import Together
-
-        judge_chat_model = Together(model="meta-llama/Llama-3.3-70B-Instruct-Turbo")
-
-    unique_string = dataset + "-" + datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_folder = data_root / "judge-evals" / unique_string
-    logger.info("Saving results in %s", output_folder)
-    output_folder.mkdir(parents=True, exist_ok=True)
-    resolved_prompt = resolve_judge_prompts(
-        provide_explanation=provide_explanation,
-        prompt_preset=prompt_preset,
-    )
-
-    annotations = annotate_battles(
-        judge_chat_model=judge_chat_model,
-        instructions=instructions.tolist(),
-        completions_A=completions_A.loc[instructions.index].tolist(),
-        completions_B=completions_B.loc[instructions.index].tolist(),
-        system_prompt=resolved_prompt.system_prompt,
-        user_prompt_template=resolved_prompt.user_prompt_template,
-        prompt_preset=resolved_prompt.preset_name,
-        use_tqdm=use_tqdm,
-        truncate_input_chars=truncate_input_chars,
-        provide_explanation=provide_explanation,
-        strip_thinking_before_judging=strip_thinking_before_judging,
-    )
-
-    # Pairwise judge results
-    score_parser = PairScore(parser_mode=resolved_prompt.parser_mode)
-    prefs = pd.Series(
-        [
-            score_parser.parse_model_raw(annotation.judge_completion)
-            for annotation in annotations
-        ]
-    )
-    results = {
-        **compute_pref_summary(prefs).to_dict(),
-        **resolved_prompt.metadata(),
-    }
-    pd.DataFrame(annotations).to_csv(output_folder / "annotations.csv", index=False)
-
-    logger.info("%s against %s:\n%s", method_A, method_B, results)
-    with open(output_folder / "results.json", "w") as f:
-        json.dump(_to_jsonable(results), f, allow_nan=False)
-
-    run_metadata = {
-        "dataset": dataset,
-        "method_A": method_A,
-        "method_B": method_B,
-        "num_annotations": num_annotations,
-        "n_annotations": len(instructions),
-        "use_tqdm": use_tqdm,
-        "truncate_input_chars": truncate_input_chars,
-        "provide_explanation": provide_explanation,
-        **resolved_prompt.metadata(),
-        "strip_thinking_before_judging": strip_thinking_before_judging,
-    }
-
-    try:
-        write_run_metadata(
-            output_dir=output_folder,
-            entrypoint="judgearena.evaluate.evaluate_completions",
-            run=run_metadata,
-            results=results,
-            input_payloads={
-                "instruction_index": instructions.index.tolist(),
-                "instructions": instructions.tolist(),
-                "completions_A": completions_A.loc[instructions.index].tolist(),
-                "completions_B": completions_B.loc[instructions.index].tolist(),
-            },
-            judge_system_prompt=resolved_prompt.system_prompt,
-            judge_user_prompt_template=resolved_prompt.user_prompt_template,
-            started_at_utc=run_started_at,
-        )
-    except OSError as e:
-        logger.warning("Failed to write run metadata: %s", e)
-
-
 @dataclass
 class JudgeAnnotation:
     instruction: str  # instruction from the user
@@ -369,8 +187,7 @@ def annotate_battles(
 ) -> list[JudgeAnnotation]:
     """
     Directly evaluate from list of instructions and completions
-    Can also pass custom LLM judge prompts, if not passed uses defaults
-    `system_prompt, user_prompt_template = load_judge_system_and_user_prompt()`
+    Can also pass custom LLM judge prompts; if omitted, the configured preset is used.
     Example usage:
     ```python
     annotations = annotate_battles(

--- a/judgearena/generate_and_evaluate.py
+++ b/judgearena/generate_and_evaluate.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
+from judgearena.dataset_revisions import revisions_for_task
 from judgearena.evaluate import judge_and_parse_prefs, resolve_run_judge_prompt
 from judgearena.generate import generate_base, generate_instructions
 from judgearena.instruction_dataset import load_instructions
@@ -35,7 +36,7 @@ from judgearena.models import (
     make_model,
 )
 from judgearena.mt_bench.mt_bench_utils import run_mt_bench
-from judgearena.repro import write_run_metadata
+from judgearena.repro import InputMetadata, RunContext, write_run_metadata
 from judgearena.utils import (
     cache_function_dataframe,
     compute_pref_summary,
@@ -249,13 +250,16 @@ def main(cfg: "RunConfig"):
         run_ts = run_started_at.strftime("%Y%m%d_%H%M%S")
         res_folder = Path(cfg.run.result_folder) / f"{name}-{run_ts}"
         res_folder.mkdir(parents=True, exist_ok=True)
+        run_log_path = None
         if not cfg.run.no_log_file:
-            attach_file_handler(make_run_log_path(res_folder))
+            run_log_path = make_run_log_path(res_folder)
+            attach_file_handler(run_log_path)
         return run_mt_bench(
             cfg,
             ignore_cache,
             res_folder=res_folder,
             result_name=name,
+            run_log_path=run_log_path,
         )
 
     # Currrently, we run context evaluation
@@ -292,8 +296,10 @@ def main(cfg: "RunConfig"):
     run_ts = run_started_at.strftime("%Y%m%d_%H%M%S")
     res_folder = Path(cfg.run.result_folder) / f"{name}-{run_ts}"
     res_folder.mkdir(parents=True, exist_ok=True)
+    run_log_path = None
     if not cfg.run.no_log_file:
-        attach_file_handler(make_run_log_path(res_folder))
+        run_log_path = make_run_log_path(res_folder)
+        attach_file_handler(run_log_path)
 
     logger.info(
         "Using task %s and evaluating %s against baseline %s.",
@@ -390,7 +396,8 @@ def main(cfg: "RunConfig"):
     # save the resolved config for results analysis (round-trippable via --config_path)
     from judgearena.config import dump_config
 
-    dump_config(cfg, res_folder / "config.yaml")
+    config_path = res_folder / "config.yaml"
+    dump_config(cfg, config_path)
 
     logger.info("Saving results to %s", res_folder)
     resolved_prompt = resolve_run_judge_prompt(cfg.task, cfg.judge)
@@ -427,7 +434,8 @@ def main(cfg: "RunConfig"):
         df_reversed["judge"] = cfg.judge.model
         df = pd.concat([df, df_reversed])
 
-    df.to_csv(res_folder / f"{name}-annotations.csv", index=False)
+    annotations_path = res_folder / f"{name}-annotations.csv"
+    df.to_csv(annotations_path, index=False)
 
     # compute and report statistics
     summary = compute_pref_summary(prefs)
@@ -444,12 +452,8 @@ def main(cfg: "RunConfig"):
         metadata={
             "baseline_assignment": "per-row" if not baseline_plan.is_flat else "flat",
             "baseline_models": baseline_plan.unique_models,
-            **resolved_prompt.metadata(),
-            "strip_thinking_before_judging": cfg.judge.strip_thinking_before_judging,
-            "battle_thinking_token_budget": cfg.judge.battle_thinking_token_budget,
         },
     )
-    results = report.to_dict()
     logger.info(
         "%s vs %s judged by %s",
         cfg.model.name,
@@ -457,27 +461,37 @@ def main(cfg: "RunConfig"):
         cfg.judge.model,
     )
     report.render()
-    report.save(res_folder / f"results-{name}.json")
-
-    eval_instructions = instructions.head(n_instructions).tolist()
-    eval_completions_A = completions_A.head(n_instructions).tolist()
-    eval_completions_B = completions_B.head(n_instructions).tolist()
+    result_path = report.save(res_folder / f"results-{name}.json")
 
     try:
         write_run_metadata(
             output_dir=res_folder,
             entrypoint="judgearena.generate_and_evaluate.main",
-            run=cfg.model_dump(),
-            results=results,
-            input_payloads={
-                "instruction_index": eval_instruction_index,
-                "instructions": eval_instructions,
-                "completions_A": eval_completions_A,
-                "completions_B": eval_completions_B,
-                "baseline_model_B": baseline_per_eval.tolist(),
+            context=RunContext.from_config(
+                cfg,
+                workflow="pairwise",
+                configuration_path=config_path,
+            ),
+            inputs=InputMetadata.capture(
+                dataset_revisions=revisions_for_task(cfg.task),
+                example_ids=eval_instruction_index,
+                content={
+                    "instructions": instructions.loc[eval_instruction_index].tolist(),
+                    "completions_a": completions_A.loc[eval_instruction_index].tolist(),
+                    "completions_b": completions_B.loc[eval_instruction_index].tolist(),
+                    "baseline_models": baseline_per_eval.tolist(),
+                },
+                judgment_count=len(annotations)
+                + (
+                    len(annotations_reversed) if annotations_reversed is not None else 0
+                ),
+            ),
+            judge_prompt=resolved_prompt,
+            artifacts={
+                "annotations": annotations_path,
+                "results": result_path,
+                **({"log": run_log_path} if run_log_path is not None else {}),
             },
-            judge_system_prompt=resolved_prompt.system_prompt,
-            judge_user_prompt_template=resolved_prompt.user_prompt_template,
             started_at_utc=run_started_at,
         )
     except OSError as e:

--- a/judgearena/mt_bench/fastchat_compat.py
+++ b/judgearena/mt_bench/fastchat_compat.py
@@ -14,7 +14,9 @@ from judgearena.mt_bench.common import (
 )
 from judgearena.mt_bench.pairwise_judging import (
     MTBenchJudgeItem,
+    MTBenchJudgingResult,
     build_mt_bench_pairwise_judge_items,
+    collect_prompt_variants,
     infer_pairwise_judgments_by_prompt_groups,
     swap_pairwise_answer_kwargs,
 )
@@ -291,6 +293,7 @@ def _resolve_fastchat_item_result(
         "judge": judge_model,
         "prompt_name": prompt.name,
         "system_prompt": prompt.system_prompt,
+        "user_prompt_template": prompt.user_prompt_template,
         "g1_user_prompt": g1_user_prompt,
         "g1_judgment": g1_raw,
         "g1_verdict": g1_verdict,
@@ -347,7 +350,7 @@ def judge_mt_bench_pairwise_fastchat(
     use_tqdm: bool,
     prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
     strip_thinking_before_judging: bool = False,
-) -> tuple[pd.Series, list[dict[str, Any]], list[dict[str, object]], int]:
+) -> MTBenchJudgingResult:
     """Run FastChat-style MT-Bench pairwise judging with bracketed verdict outputs."""
     assert swap_mode in ("fixed", "both")
     eval_single, eval_multi = resolve_mt_bench_turn_flags(turns_mode)
@@ -362,6 +365,7 @@ def judge_mt_bench_pairwise_fastchat(
         prompt_preset=prompt_preset,
         strip_thinking_before_judging=strip_thinking_before_judging,
     )
+    prompt_variants = collect_prompt_variants(items)
 
     g1_judgments, _ = infer_pairwise_judgments_by_prompt_groups(
         judge_chat_model=judge_chat_model,
@@ -402,4 +406,11 @@ def judge_mt_bench_pairwise_fastchat(
         metadata.append(item_metadata)
         prefs.append(preference)
 
-    return pd.Series(prefs, dtype=float), annotations, metadata, num_inconsistent
+    return MTBenchJudgingResult(
+        preferences=pd.Series(prefs, dtype=float),
+        annotations=annotations,
+        item_metadata=metadata,
+        prompt_variants=prompt_variants,
+        judgment_count=len(items) * (2 if swap_mode == "both" else 1),
+        num_inconsistent=num_inconsistent,
+    )

--- a/judgearena/mt_bench/mt_bench_utils.py
+++ b/judgearena/mt_bench/mt_bench_utils.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
+from judgearena.dataset_revisions import revisions_for_task
 from judgearena.generate import generate_multiturn
 from judgearena.instruction_dataset import load_instructions
 from judgearena.instruction_dataset.mt_bench import (
@@ -25,13 +26,17 @@ from judgearena.mt_bench.fastchat_compat import (
     FASTCHAT_TEMPERATURE_CONFIG,
     judge_mt_bench_pairwise_fastchat,
 )
+from judgearena.mt_bench.pairwise_judging import (
+    MTBenchJudgingResult,
+    MTBenchPromptVariant,
+)
 from judgearena.mt_bench.preset_judging import judge_mt_bench_with_preset
 from judgearena.prompts.registry import (
     DEFAULT_JUDGE_PROMPT_PRESET,
     ResolvedJudgePrompt,
     resolve_run_judge_prompt,
 )
-from judgearena.repro import write_run_metadata
+from judgearena.repro import InputMetadata, RunContext, write_run_metadata
 from judgearena.utils import (
     cache_function_dataframe,
     compute_pref_summary,
@@ -151,6 +156,7 @@ def _build_mt_bench_input_payloads(
     completions_a: pd.DataFrame,
     completions_b: pd.DataFrame,
 ) -> dict[str, object]:
+    """Build the exact MT-Bench inputs used by the metadata fingerprint."""
     return {
         "instruction_index": questions_df.index.tolist(),
         "turn_1": questions_df["turn_1"].tolist(),
@@ -167,30 +173,47 @@ def _save_mt_bench_results(
     cfg: RunConfig,
     res_folder: Path,
     result_name: str,
-    results: dict[str, object],
+    result_path: Path,
     annotations_df: pd.DataFrame,
     started_at_utc: datetime,
     input_payloads: dict[str, object],
-    judge_system_prompt: str | None = None,
-    judge_user_prompt_template: str | None = None,
+    judgment_count: int,
+    judge_prompt: ResolvedJudgePrompt,
+    prompt_variants: list[MTBenchPromptVariant],
+    run_log_path: Path | None = None,
 ) -> None:
     """Persist MT-Bench arguments, annotations, aggregate results, and metadata."""
     res_folder.mkdir(parents=True, exist_ok=True)
 
     from judgearena.config import dump_config
 
-    dump_config(cfg, res_folder / "config.yaml")
+    config_path = res_folder / "config.yaml"
+    dump_config(cfg, config_path)
 
-    annotations_df.to_csv(res_folder / f"{result_name}-annotations.csv", index=False)
+    annotations_path = res_folder / f"{result_name}-annotations.csv"
+    annotations_df.to_csv(annotations_path, index=False)
 
     write_run_metadata(
         output_dir=res_folder,
         entrypoint="judgearena.mt_bench.mt_bench_utils.run_mt_bench",
-        run=cfg.model_dump(),
-        results=results,
-        input_payloads=input_payloads,
-        judge_system_prompt=judge_system_prompt,
-        judge_user_prompt_template=judge_user_prompt_template,
+        context=RunContext.from_config(
+            cfg,
+            workflow="mt_bench",
+            configuration_path=config_path,
+        ),
+        inputs=InputMetadata.capture(
+            dataset_revisions=revisions_for_task(cfg.task),
+            example_ids=input_payloads["instruction_index"],
+            content=input_payloads,
+            judgment_count=judgment_count,
+        ),
+        judge_prompt=judge_prompt,
+        prompt_variants=[variant.to_dict() for variant in prompt_variants],
+        artifacts={
+            "annotations": annotations_path,
+            "results": result_path,
+            **({"log": run_log_path} if run_log_path is not None else {}),
+        },
         started_at_utc=started_at_utc,
     )
 
@@ -200,16 +223,16 @@ def _finalize_mt_bench_run(
     cfg: RunConfig,
     res_folder: Path,
     result_name: str,
-    prefs: pd.Series,
-    annotations: list[dict[str, object]],
-    combined_metadata: list[dict[str, object]],
+    judging_result: MTBenchJudgingResult,
     resolved_prompt: ResolvedJudgePrompt,
     questions_df: pd.DataFrame,
     completions_a: pd.DataFrame,
     completions_b: pd.DataFrame,
     started_at_utc: datetime,
+    run_log_path: Path | None = None,
     extra_result_fields: dict[str, object] | None = None,
 ) -> pd.Series:
+    prefs = judging_result.preferences
     stats = compute_pref_summary(prefs)
     report = BattleReport(
         task=cfg.task,
@@ -217,35 +240,35 @@ def _finalize_mt_bench_run(
         model_b=cfg.model.baseline,
         judge_model=cfg.judge.model,
         summary=stats,
-        per_category=_compute_grouped_stats(prefs, combined_metadata, "category"),
-        per_turn=_compute_grouped_stats(prefs, combined_metadata, "turn"),
+        per_category=_compute_grouped_stats(
+            prefs, judging_result.item_metadata, "category"
+        ),
+        per_turn=_compute_grouped_stats(prefs, judging_result.item_metadata, "turn"),
         preferences=prefs.tolist(),
         metadata={
-            **resolved_prompt.metadata(),
-            "battle_thinking_token_budget": cfg.judge.battle_thinking_token_budget,
-            "strip_thinking_before_judging": cfg.judge.strip_thinking_before_judging,
             **(extra_result_fields or {}),
             "date": datetime.now(UTC).isoformat(),
             "user": os.getenv("USER", ""),
         },
     )
-    results = report.to_dict()
     report.render()
-    report.save(res_folder / f"results-{result_name}.json")
+    result_path = report.save(res_folder / f"results-{result_name}.json")
     _save_mt_bench_results(
         cfg=cfg,
         res_folder=res_folder,
         result_name=result_name,
-        results=results,
-        annotations_df=pd.DataFrame(annotations),
+        result_path=result_path,
+        annotations_df=pd.DataFrame(judging_result.annotations),
         started_at_utc=started_at_utc,
         input_payloads=_build_mt_bench_input_payloads(
             questions_df=questions_df,
             completions_a=completions_a,
             completions_b=completions_b,
         ),
-        judge_system_prompt=resolved_prompt.system_prompt,
-        judge_user_prompt_template=resolved_prompt.user_prompt_template,
+        judgment_count=judging_result.judgment_count,
+        judge_prompt=resolved_prompt,
+        prompt_variants=judging_result.prompt_variants,
+        run_log_path=run_log_path,
     )
     return prefs
 
@@ -262,37 +285,35 @@ def _run_mt_bench_fastchat(
     resolved_prompt: ResolvedJudgePrompt,
     fastchat_prompt_preset: str,
     started_at_utc: datetime,
+    run_log_path: Path | None = None,
 ) -> pd.Series:
-    prefs, annotations, combined_metadata, num_inconsistent = (
-        judge_mt_bench_pairwise_fastchat(
-            judge_chat_model=judge_chat_model,
-            judge_model=cfg.judge.model,
-            questions=questions_df,
-            completions_a=completions_a,
-            completions_b=completions_b,
-            model_a=cfg.model.name,
-            model_b=cfg.model.baseline,
-            turns_mode="both",
-            swap_mode=cfg.judge.swap_mode,
-            truncate_input_chars=cfg.generation.truncate_judge_input_chars,
-            use_tqdm=cfg.run.use_tqdm,
-            prompt_preset=fastchat_prompt_preset,
-            strip_thinking_before_judging=cfg.judge.strip_thinking_before_judging,
-        )
+    judging_result = judge_mt_bench_pairwise_fastchat(
+        judge_chat_model=judge_chat_model,
+        judge_model=cfg.judge.model,
+        questions=questions_df,
+        completions_a=completions_a,
+        completions_b=completions_b,
+        model_a=cfg.model.name,
+        model_b=cfg.model.baseline,
+        turns_mode="both",
+        swap_mode=cfg.judge.swap_mode,
+        truncate_input_chars=cfg.generation.truncate_judge_input_chars,
+        use_tqdm=cfg.run.use_tqdm,
+        prompt_preset=fastchat_prompt_preset,
+        strip_thinking_before_judging=cfg.judge.strip_thinking_before_judging,
     )
     return _finalize_mt_bench_run(
         cfg=cfg,
         res_folder=res_folder,
         result_name=result_name,
-        prefs=prefs,
-        annotations=annotations,
-        combined_metadata=combined_metadata,
+        judging_result=judging_result,
         resolved_prompt=resolved_prompt,
         questions_df=questions_df,
         completions_a=completions_a,
         completions_b=completions_b,
         started_at_utc=started_at_utc,
-        extra_result_fields={"num_inconsistent": num_inconsistent},
+        run_log_path=run_log_path,
+        extra_result_fields={"num_inconsistent": judging_result.num_inconsistent},
     )
 
 
@@ -307,8 +328,9 @@ def _run_mt_bench_preset(
     judge_chat_model,
     resolved_prompt: ResolvedJudgePrompt,
     started_at_utc: datetime,
+    run_log_path: Path | None = None,
 ) -> pd.Series:
-    prefs, annotations, combined_metadata = judge_mt_bench_with_preset(
+    judging_result = judge_mt_bench_with_preset(
         judge_chat_model=judge_chat_model,
         judge_model=cfg.judge.model,
         questions=questions_df,
@@ -330,14 +352,13 @@ def _run_mt_bench_preset(
         cfg=cfg,
         res_folder=res_folder,
         result_name=result_name,
-        prefs=prefs,
-        annotations=annotations,
-        combined_metadata=combined_metadata,
+        judging_result=judging_result,
         resolved_prompt=resolved_prompt,
         questions_df=questions_df,
         completions_a=completions_a,
         completions_b=completions_b,
         started_at_utc=started_at_utc,
+        run_log_path=run_log_path,
     )
 
 
@@ -347,6 +368,7 @@ def run_mt_bench(
     *,
     res_folder: Path,
     result_name: str,
+    run_log_path: Path | None = None,
 ):
     """MT-Bench pipeline with preset or FastChat-original pairwise judging."""
     run_started_at = datetime.now(UTC)
@@ -395,6 +417,7 @@ def run_mt_bench(
             resolved_prompt=resolved_prompt,
             fastchat_prompt_preset=DEFAULT_JUDGE_PROMPT_PRESET,
             started_at_utc=run_started_at,
+            run_log_path=run_log_path,
         )
     return _run_mt_bench_preset(
         cfg=cfg,
@@ -406,4 +429,5 @@ def run_mt_bench(
         judge_chat_model=judge_chat_model,
         resolved_prompt=resolved_prompt,
         started_at_utc=run_started_at,
+        run_log_path=run_log_path,
     )

--- a/judgearena/mt_bench/pairwise_judging.py
+++ b/judgearena/mt_bench/pairwise_judging.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 import pandas as pd
 from langchain_core.prompts import ChatPromptTemplate
@@ -31,6 +31,49 @@ class MTBenchJudgeItem:
     @property
     def prompt_name(self) -> str:
         return self.prompt.name
+
+
+@dataclass(frozen=True)
+class MTBenchPromptVariant:
+    name: str
+    system_prompt: str | None
+    user_prompt_template: str
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "name": self.name,
+            "system_prompt": self.system_prompt,
+            "user_prompt_template": self.user_prompt_template,
+        }
+
+
+@dataclass
+class MTBenchJudgingResult:
+    preferences: pd.Series
+    annotations: list[dict[str, Any]]
+    item_metadata: list[dict[str, object]]
+    prompt_variants: list[MTBenchPromptVariant]
+    judgment_count: int
+    num_inconsistent: int = 0
+
+
+def collect_prompt_variants(
+    items: list[MTBenchJudgeItem],
+) -> list[MTBenchPromptVariant]:
+    """Collect the exact named prompts selected for this judging run."""
+    variants_by_name: dict[str, MTBenchPromptVariant] = {}
+    for item in items:
+        variant = MTBenchPromptVariant(
+            name=item.prompt.name,
+            system_prompt=item.prompt.system_prompt,
+            user_prompt_template=item.prompt.user_prompt_template,
+        )
+        existing = variants_by_name.setdefault(variant.name, variant)
+        if existing != variant:
+            raise ValueError(
+                f"MT-Bench prompt name {variant.name!r} resolved to multiple templates."
+            )
+    return [variants_by_name[name] for name in sorted(variants_by_name)]
 
 
 def group_indices_by_prompt_key(items: list[MTBenchJudgeItem]) -> dict[str, list[int]]:

--- a/judgearena/mt_bench/preset_judging.py
+++ b/judgearena/mt_bench/preset_judging.py
@@ -13,7 +13,9 @@ from judgearena.mt_bench.common import (
 )
 from judgearena.mt_bench.pairwise_judging import (
     MTBenchJudgeItem,
+    MTBenchJudgingResult,
     build_mt_bench_pairwise_judge_items,
+    collect_prompt_variants,
     infer_pairwise_judgments_by_prompt_groups,
 )
 from judgearena.mt_bench.prompt_templates import build_mt_bench_user_prompt_template
@@ -154,7 +156,7 @@ def judge_mt_bench_with_preset(
     system_file: str | None = None,
     user_file: str | None = None,
     strip_thinking_before_judging: bool = False,
-) -> tuple[pd.Series, list[dict[str, Any]], list[dict[str, object]]]:
+) -> MTBenchJudgingResult:
     assert swap_mode in ("fixed", "both")
     eval_single, eval_multi = resolve_mt_bench_turn_flags(turns_mode)
 
@@ -171,6 +173,7 @@ def judge_mt_bench_with_preset(
         user_file=user_file,
         strip_thinking_before_judging=strip_thinking_before_judging,
     )
+    prompt_variants = collect_prompt_variants(items)
     judgments, prompt_kwargs_used = infer_pairwise_judgments_by_prompt_groups(
         judge_chat_model=judge_chat_model,
         items=items,
@@ -242,4 +245,10 @@ def judge_mt_bench_with_preset(
         )
         _append_results(swapped_judgments, swapped_prompt_kwargs, swapped=True)
 
-    return pd.Series(preferences, dtype=float), annotations, metadata
+    return MTBenchJudgingResult(
+        preferences=pd.Series(preferences, dtype=float),
+        annotations=annotations,
+        item_metadata=metadata,
+        prompt_variants=prompt_variants,
+        judgment_count=len(annotations),
+    )

--- a/judgearena/repro.py
+++ b/judgearena/repro.py
@@ -1,9 +1,4 @@
-"""Reproducibility metadata helpers.
-
-Writes a compact, versioned run metadata file that captures the essential run
-configuration, result summary, dependency versions, optional git state, and
-produced artifacts list.
-"""
+"""Compact reproducibility manifests for JudgeArena runs."""
 
 from __future__ import annotations
 
@@ -14,14 +9,241 @@ import platform
 import re
 import subprocess
 import tomllib
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-METADATA_FILENAME = "run-metadata.v1.json"
-METADATA_SCHEMA_VERSION = "judgearena-run-metadata/v1"
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from judgearena.config import RunConfig
+    from judgearena.prompts.registry import ResolvedJudgePrompt
+
+METADATA_FILENAME = "run-metadata.v2.json"
+METADATA_SCHEMA_VERSION = "judgearena-run-metadata/v2"
 _REQUIREMENT_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)")
+
+
+class _MetadataModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ModelIdentity(_MetadataModel):
+    """Configured model fields, named exactly as they are in ``RunConfig``."""
+
+    name: str
+    baseline: str | None = None
+
+
+class JudgeIdentity(_MetadataModel):
+    model: str
+
+
+class EloIdentity(_MetadataModel):
+    arena: str
+    baseline_model: str | None = None
+
+
+class RunIdentity(_MetadataModel):
+    """Small, human-readable identity for one evaluation run."""
+
+    workflow: str
+    task: str | None = None
+    model: ModelIdentity | None = None
+    judge: JudgeIdentity | None = None
+    elo: EloIdentity | None = None
+
+    @classmethod
+    def from_config(cls, cfg: RunConfig, *, workflow: str) -> RunIdentity:
+        """Extract config-owned identity fields without renaming them."""
+        elo = None
+        if cfg.elo is not None and cfg.elo.arena is not None:
+            elo = EloIdentity(
+                arena=cfg.elo.arena,
+                baseline_model=cfg.elo.baseline_model,
+            )
+        return cls(
+            workflow=workflow,
+            task=cfg.task,
+            model=ModelIdentity(
+                name=cfg.model.name,
+                baseline=cfg.model.baseline,
+            ),
+            judge=JudgeIdentity(model=cfg.judge.model),
+            elo=elo,
+        )
+
+
+class ConfigurationMetadata(_MetadataModel):
+    path: str
+    sha256: str
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> ConfigurationMetadata:
+        config_path = Path(path)
+        return cls(path=config_path.name, sha256=_hash_file_sha256(config_path))
+
+
+class RunContext(_MetadataModel):
+    """Reusable metadata context for one run."""
+
+    identity: RunIdentity
+    configuration: ConfigurationMetadata | None = None
+
+    @classmethod
+    def from_config(
+        cls,
+        cfg: RunConfig,
+        *,
+        workflow: str,
+        configuration_path: str | Path,
+    ) -> RunContext:
+        return cls(
+            identity=RunIdentity.from_config(cfg, workflow=workflow),
+            configuration=ConfigurationMetadata.from_path(configuration_path),
+        )
+
+
+class ExecutionMetadata(_MetadataModel):
+    entrypoint: str
+    started_at_utc: str
+    finished_at_utc: str
+    duration_seconds: float = Field(ge=0)
+
+
+class InputMetadata(_MetadataModel):
+    dataset_revisions: dict[str, str | None] | None = None
+    example_count: int | None = Field(default=None, ge=0)
+    example_ids_sha256: str | None = None
+    content_sha256: str | None = None
+    judgment_count: int | None = Field(default=None, ge=0)
+    calibration_example_count: int | None = Field(default=None, ge=0)
+    calibration_judgment_count: int | None = Field(default=None, ge=0)
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        dataset_revisions: dict[str, str | None] | None = None,
+        example_ids: Sequence[Any] | None = None,
+        content: Any = None,
+        example_count: int | None = None,
+        judgment_count: int | None = None,
+        calibration_example_count: int | None = None,
+        calibration_judgment_count: int | None = None,
+    ) -> InputMetadata:
+        """Fingerprint inputs without embedding their full payload."""
+        normalized_ids = (
+            _to_jsonable(list(example_ids)) if example_ids is not None else None
+        )
+        if normalized_ids is not None and not isinstance(normalized_ids, list):
+            raise TypeError("example_ids must normalize to a list.")
+        if example_count is None and normalized_ids is not None:
+            example_count = len(normalized_ids)
+        elif normalized_ids is not None and example_count != len(normalized_ids):
+            raise ValueError(
+                "example_count must equal the number of supplied example_ids."
+            )
+        distinct_judgment_count = (
+            judgment_count if judgment_count != example_count else None
+        )
+        return cls(
+            dataset_revisions=dataset_revisions or None,
+            example_count=example_count,
+            example_ids_sha256=_hash_normalized_set_sha256(normalized_ids),
+            content_sha256=_hash_json_sha256(content),
+            judgment_count=distinct_judgment_count,
+            calibration_example_count=calibration_example_count,
+            calibration_judgment_count=calibration_judgment_count,
+        )
+
+
+class PromptVariantMetadata(_MetadataModel):
+    name: str
+    system_sha256: str | None = None
+    user_sha256: str
+
+    @classmethod
+    def from_content(
+        cls, variant: Mapping[str, str | None]
+    ) -> PromptVariantMetadata:
+        return cls(
+            name=variant["name"],
+            system_sha256=_hash_string_sha256(variant.get("system_prompt")),
+            user_sha256=_hash_string_sha256(variant.get("user_prompt_template")),
+        )
+
+
+class PromptMetadata(_MetadataModel):
+    preset: str
+    source: str
+    parser_mode: str
+    delegated: bool
+    system_path: str | None = None
+    user_path: str | None = None
+    system_sha256: str | None = None
+    user_sha256: str | None = None
+    variants: list[PromptVariantMetadata] | None = None
+
+    @classmethod
+    def from_resolved(
+        cls,
+        prompt: ResolvedJudgePrompt,
+        *,
+        variants: Sequence[Mapping[str, str | None]] | None = None,
+    ) -> PromptMetadata:
+        """Fingerprint the exact prompt used by the judge."""
+        variant_metadata = (
+            [
+                PromptVariantMetadata.from_content(variant)
+                for variant in sorted(variants, key=lambda item: str(item["name"]))
+            ]
+            if variants
+            else None
+        )
+        return cls(
+            preset=prompt.preset_name,
+            source=prompt.source,
+            parser_mode=prompt.parser_mode,
+            delegated=prompt.delegated,
+            system_path=prompt.system_path,
+            user_path=prompt.user_path,
+            system_sha256=None if variant_metadata else prompt.system_sha256,
+            user_sha256=None if variant_metadata else prompt.user_sha256,
+            variants=variant_metadata,
+        )
+
+
+class CodeMetadata(_MetadataModel):
+    git_commit: str | None = None
+    git_dirty: bool | None = None
+
+
+class EnvironmentMetadata(_MetadataModel):
+    python_version: str
+    platform: str
+    dependencies: dict[str, str | None]
+
+
+class ArtifactMetadata(_MetadataModel):
+    kind: str
+    path: str
+    size_bytes: int
+    sha256: str
+
+
+class RunMetadata(_MetadataModel):
+    schema_version: str
+    identity: RunIdentity
+    configuration: ConfigurationMetadata | None = None
+    inputs: InputMetadata
+    prompt: PromptMetadata | None = None
+    code: CodeMetadata
+    environment: EnvironmentMetadata
+    execution: ExecutionMetadata
+    artifacts: list[ArtifactMetadata]
 
 
 def _utc_now() -> datetime:
@@ -65,7 +287,14 @@ def _hash_string_sha256(value: str | None) -> str | None:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _hash_json_sha256(value: Any) -> str | None:
+    if value is None:
+        return None
+    return _hash_string_sha256(_stable_json_dumps(value))
+
+
 def _hash_normalized_set_sha256(values: list[Any] | None) -> str | None:
+    """Hash a collection independently of input order and duplicate values."""
     if values is None:
         return None
 
@@ -76,6 +305,14 @@ def _hash_normalized_set_sha256(values: list[Any] | None) -> str | None:
 
     normalized_values = [normalized_by_key[key] for key in sorted(normalized_by_key)]
     return _hash_string_sha256(_stable_json_dumps(normalized_values))
+
+
+def _hash_file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _extract_dist_name(requirement_spec: str) -> str | None:
@@ -175,61 +412,63 @@ def _get_git_hash(start_path: Path) -> str | None:
     return _run_git(["rev-parse", "HEAD"], cwd=root)
 
 
-def _collect_artifacts(
-    output_dir: Path, metadata_filename: str
+def _get_git_dirty(start_path: Path) -> bool | None:
+    repo_root = _run_git(["rev-parse", "--show-toplevel"], cwd=start_path)
+    if repo_root is None:
+        return None
+    status = _run_git(
+        ["status", "--porcelain", "--untracked-files=no"], cwd=Path(repo_root)
+    )
+    return bool(status) if status is not None else None
+
+
+def _describe_artifacts(
+    output_dir: Path,
+    artifacts: Mapping[str, str | Path] | None,
 ) -> list[dict[str, Any]]:
-    artifacts: list[dict[str, Any]] = []
-    for path in sorted(output_dir.rglob("*")):
-        if not path.is_file():
-            continue
-        if path.name == metadata_filename:
-            continue
-        rel = path.relative_to(output_dir)
-        artifacts.append(
+    """Describe only files explicitly registered by the producing workflow."""
+    described: list[dict[str, Any]] = []
+    output_root = output_dir.resolve()
+    for kind, raw_path in sorted((artifacts or {}).items()):
+        path = Path(raw_path)
+        candidates = [path.resolve()]
+        if not path.is_absolute():
+            candidates.append((output_dir / path).resolve())
+        resolved_path = None
+        rel = None
+        for candidate in candidates:
+            try:
+                rel = candidate.relative_to(output_root)
+                resolved_path = candidate
+                break
+            except ValueError:
+                continue
+        if resolved_path is None or rel is None:
+            raise ValueError(
+                f"Artifact '{kind}' must be inside output directory {output_dir}."
+            )
+        if not resolved_path.is_file():
+            raise FileNotFoundError(f"Artifact '{kind}' does not exist: {path}")
+        described.append(
             {
+                "kind": kind,
                 "path": str(rel),
-                "size_bytes": path.stat().st_size,
+                "size_bytes": resolved_path.stat().st_size,
+                "sha256": _hash_file_sha256(resolved_path),
             }
         )
-    return artifacts
-
-
-def _build_dataset_statistics(input_payloads: dict[str, Any] | None) -> dict[str, Any]:
-    if not input_payloads:
-        return {}
-    summary: dict[str, Any] = {}
-    for key, payload in input_payloads.items():
-        normalized = _to_jsonable(payload)
-        count = len(normalized) if hasattr(normalized, "__len__") else None
-        summary[f"{key}_count"] = count
-    return summary
-
-
-def _compact_results(results: dict[str, Any] | None) -> dict[str, Any]:
-    """Compact result payload for metadata storage.
-
-    Keep summary stats but avoid embedding large per-sample arrays.
-    """
-    payload = _to_jsonable(results or {})
-    if not isinstance(payload, dict):
-        return {"value": payload}
-
-    if "preferences" in payload:
-        prefs = payload.pop("preferences")
-        count = len(prefs) if hasattr(prefs, "__len__") else None
-        payload["preferences_count"] = count
-    return payload
+    return described
 
 
 def write_run_metadata(
     *,
     output_dir: str | Path,
     entrypoint: str,
-    run: dict[str, Any],
-    results: dict[str, Any] | None = None,
-    input_payloads: dict[str, Any] | None = None,
-    judge_system_prompt: str | None = None,
-    judge_user_prompt_template: str | None = None,
+    context: RunContext,
+    inputs: InputMetadata | None = None,
+    judge_prompt: ResolvedJudgePrompt | None = None,
+    prompt_variants: Sequence[Mapping[str, str | None]] | None = None,
+    artifacts: Mapping[str, str | Path] | None = None,
     started_at_utc: datetime | None = None,
     metadata_filename: str = METADATA_FILENAME,
 ) -> Path:
@@ -243,51 +482,44 @@ def write_run_metadata(
         started = started.replace(tzinfo=UTC)
     duration_sec = max(0.0, (finished - started).total_seconds())
 
-    metadata: dict[str, Any] = {
-        "schema_version": METADATA_SCHEMA_VERSION,
-        "timestamps": {
-            "started_at_utc": started.isoformat(),
-            "finished_at_utc": finished.isoformat(),
-            "duration_sec": duration_sec,
-        },
-        "entrypoint": entrypoint,
-        "run": _to_jsonable(run),
-        "results": _compact_results(results),
-        "dataset_statistics": _build_dataset_statistics(input_payloads),
-        "environment": {
-            "python_version": platform.python_version(),
-            "platform": platform.platform(),
-        },
-        "dependencies": _get_dependency_versions(
-            start_path=Path(__file__).resolve().parent
+    source_path = Path(__file__).resolve().parent
+    metadata = RunMetadata(
+        schema_version=METADATA_SCHEMA_VERSION,
+        identity=context.identity,
+        configuration=context.configuration,
+        inputs=inputs or InputMetadata(),
+        prompt=(
+            PromptMetadata.from_resolved(judge_prompt, variants=prompt_variants)
+            if judge_prompt is not None
+            else None
         ),
-    }
-    git_hash = _get_git_hash(start_path=Path(__file__).resolve().parent)
-    if git_hash:
-        metadata["git_hash"] = git_hash
-
-    instruction_indices = None
-    if input_payloads and "instruction_index" in input_payloads:
-        raw_indices = _to_jsonable(input_payloads["instruction_index"])
-        if isinstance(raw_indices, list):
-            instruction_indices = raw_indices
-    instruction_indices_hash = _hash_normalized_set_sha256(instruction_indices)
-    if instruction_indices_hash:
-        metadata["instruction_indices_sha256"] = instruction_indices_hash
-
-    judge_system_prompt_hash = _hash_string_sha256(judge_system_prompt)
-    if judge_system_prompt_hash:
-        metadata["judge_system_prompt_sha256"] = judge_system_prompt_hash
-
-    judge_user_prompt_template_hash = _hash_string_sha256(judge_user_prompt_template)
-    if judge_user_prompt_template_hash:
-        metadata["judge_user_prompt_template_sha256"] = judge_user_prompt_template_hash
-
-    metadata["artifacts"] = _collect_artifacts(
-        output_path, metadata_filename=metadata_filename
+        code=CodeMetadata(
+            git_commit=_get_git_hash(start_path=source_path),
+            git_dirty=_get_git_dirty(start_path=source_path),
+        ),
+        environment=EnvironmentMetadata(
+            python_version=platform.python_version(),
+            platform=platform.platform(),
+            dependencies=_get_dependency_versions(start_path=source_path),
+        ),
+        execution=ExecutionMetadata(
+            entrypoint=entrypoint,
+            started_at_utc=started.isoformat(),
+            finished_at_utc=finished.isoformat(),
+            duration_seconds=duration_sec,
+        ),
+        artifacts=[
+            ArtifactMetadata(**artifact)
+            for artifact in _describe_artifacts(output_path, artifacts)
+        ],
     )
 
     metadata_path = output_path / metadata_filename
     with open(metadata_path, "w", encoding="utf-8") as f:
-        json.dump(_to_jsonable(metadata), f, indent=2, allow_nan=False)
+        json.dump(
+            _to_jsonable(metadata.model_dump(exclude_none=True)),
+            f,
+            indent=2,
+            allow_nan=False,
+        )
     return metadata_path

--- a/tests/test_estimate_elo_ratings.py
+++ b/tests/test_estimate_elo_ratings.py
@@ -1,4 +1,6 @@
+import json
 import math
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -92,6 +94,8 @@ def _default_args(*, result_folder: str, **kwargs) -> RunConfig:
     swap_mode = kwargs.pop("swap_mode", "fixed")
     strip_thinking_before_judging = kwargs.pop("strip_thinking_before_judging", False)
     battle_thinking_token_budget = kwargs.pop("battle_thinking_token_budget", None)
+    calibrate_temperature = kwargs.pop("calibrate_temperature", False)
+    calibration_size = kwargs.pop("calibration_size", None)
     assert not kwargs, f"unexpected kwargs: {kwargs}"
     judge: dict[str, object] = {
         "model": judge_model,
@@ -105,7 +109,13 @@ def _default_args(*, result_folder: str, **kwargs) -> RunConfig:
         model={"name": model},
         judge=judge,
         generation={"n_instructions": n_instructions},
-        elo={"arena": arena, "n_bootstraps": n_bootstraps, "languages": languages},
+        elo={
+            "arena": arena,
+            "n_bootstraps": n_bootstraps,
+            "languages": languages,
+            "calibrate_temperature": calibrate_temperature,
+            "calibration_size": calibration_size,
+        },
         run={"result_folder": result_folder},
     )
 
@@ -181,6 +191,58 @@ def test_main_returns_summary(tmp_path):
 def test_main_winrate_in_valid_range(tmp_path):
     result = main(_default_args(result_folder=str(tmp_path)))
     assert 0.0 <= result["winrate"] <= 1.0
+
+
+def test_main_writes_compact_metadata_and_config(tmp_path):
+    result = main(_default_args(result_folder=str(tmp_path)))
+    result_dir = Path(result["result_path"]).parent
+
+    assert (result_dir / "config.yaml").exists()
+    metadata = json.loads((result_dir / "run-metadata.v2.json").read_text())
+    assert metadata["identity"]["workflow"] == "elo"
+    assert metadata["identity"]["elo"]["arena"] == "ComparIA"
+    assert metadata["identity"]["model"]["name"] == "Dummy/my model"
+    assert metadata["identity"]["judge"]["model"].startswith("Dummy/")
+    assert metadata["configuration"]["path"] == "config.yaml"
+    assert metadata["inputs"]["example_count"] == 10
+    assert "judgment_count" not in metadata["inputs"]
+    assert "content_sha256" in metadata["inputs"]
+
+
+def test_calibration_judgments_and_prompt_are_recorded(monkeypatch, tmp_path):
+    original = estimate_elo_ratings.judge_and_parse_prefs
+    calls = []
+
+    def keep_all_arena_battles(df):
+        anchors = df.loc[:, ["model_a", "model_b", "winner"]].copy()
+        anchors["pref"] = anchors["winner"].map(_winner_to_pref)
+        anchors["pref_hard"] = anchors["pref"]
+        anchors["source"] = "human"
+        return anchors
+
+    def spy_judge(*args, **kwargs):
+        calls.append(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        estimate_elo_ratings, "arena_anchor_battles", keep_all_arena_battles
+    )
+    monkeypatch.setattr(estimate_elo_ratings, "judge_and_parse_prefs", spy_judge)
+    result = main(
+        _default_args(
+            result_folder=str(tmp_path),
+            calibrate_temperature=True,
+            calibration_size=5,
+        )
+    )
+
+    metadata = json.loads(
+        (Path(result["result_path"]).parent / "run-metadata.v2.json").read_text()
+    )
+    assert metadata["inputs"]["calibration_example_count"] == 5
+    assert metadata["inputs"]["calibration_judgment_count"] == 5
+    assert calls[-1]["system_prompt"] is not None
+    assert calls[-1]["user_prompt_template"] is not None
 
 
 def test_main_winrate_depends_on_judge(tmp_path):

--- a/tests/test_generate_and_evaluate.py
+++ b/tests/test_generate_and_evaluate.py
@@ -1,3 +1,5 @@
+import json
+
 import pandas as pd
 import pytest
 
@@ -242,6 +244,15 @@ def test_generate_and_evaluate_correct_order_bias(tmp_path):
 
     avg_pref = sum(prefs) / len(prefs)
     assert avg_pref == 0.5
+
+    metadata_path = next(tmp_path.glob("*/run-metadata.v2.json"))
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["inputs"]["example_count"] == 5
+    assert metadata["inputs"]["judgment_count"] == 10
+    assert metadata["identity"]["workflow"] == "pairwise"
+    assert metadata["identity"]["model"]["name"] == "Dummy/no answer"
+    assert metadata["configuration"]["path"] == "config.yaml"
+    assert "content_sha256" in metadata["inputs"]
 
 
 def test_generate_and_evaluate_passes_judge_side_controls(monkeypatch, tmp_path):

--- a/tests/test_mt_bench_downloads.py
+++ b/tests/test_mt_bench_downloads.py
@@ -7,7 +7,14 @@ import judgearena.instruction_dataset.mt_bench as mt_bench
 import judgearena.mt_bench.mt_bench_utils as mt_bench_utils
 import judgearena.utils.io as utils_io
 from judgearena.config import RunConfig
-from judgearena.prompts.registry import FASTCHAT_PAIRWISE_PROMPT_PRESET
+from judgearena.mt_bench.pairwise_judging import (
+    MTBenchJudgingResult,
+    MTBenchPromptVariant,
+)
+from judgearena.prompts.registry import (
+    FASTCHAT_PAIRWISE_PROMPT_PRESET,
+    resolve_judge_prompt,
+)
 
 
 def test_download_mt_bench_skips_question_download_if_cached(tmp_path, monkeypatch):
@@ -208,7 +215,7 @@ def test_save_mt_bench_results_writes_run_metadata(monkeypatch, tmp_path):
 
     def fake_write_run_metadata(**kwargs):
         captured.update(kwargs)
-        return tmp_path / "run-metadata.v1.json"
+        return tmp_path / "run-metadata.v2.json"
 
     monkeypatch.setattr(
         mt_bench_utils,
@@ -221,17 +228,44 @@ def test_save_mt_bench_results_writes_run_metadata(monkeypatch, tmp_path):
         judge={"model": "judge"},
     )
     started_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC)
+    resolved_prompt = resolve_judge_prompt(preset="default")
+    result_path = tmp_path / "results-mt-bench-test.json"
+    result_path.write_text("{}")
 
     mt_bench_utils._save_mt_bench_results(
         cfg=cfg,
         res_folder=tmp_path,
         result_name="mt-bench-test",
-        results={"win_rate": 0.5, "preferences": [1.0]},
-        annotations_df=pd.DataFrame([{"preference": 1.0}]),
+        result_path=result_path,
+        annotations_df=pd.DataFrame(
+            [
+                {
+                    "preference": 1.0,
+                    "prompt_name": "annotation-only",
+                    "system_prompt": "not metadata input",
+                    "user_prompt_template": "not metadata input",
+                }
+            ]
+        ),
         started_at_utc=started_at,
-        input_payloads={"instruction_index": [1]},
-        judge_system_prompt="system",
-        judge_user_prompt_template="user",
+        input_payloads={
+            "instruction_index": [1],
+            "turn_1": ["Q"],
+            "turn_2": ["Q2"],
+            "completion_turn_1_A": ["A1"],
+            "completion_turn_2_A": ["A2"],
+            "completion_turn_1_B": ["B1"],
+            "completion_turn_2_B": ["B2"],
+        },
+        judgment_count=1,
+        judge_prompt=resolved_prompt,
+        prompt_variants=[
+            MTBenchPromptVariant(
+                name="single",
+                system_prompt="system",
+                user_prompt_template="user {answer}",
+            )
+        ],
     )
 
     assert (tmp_path / "config.yaml").exists()
@@ -239,10 +273,54 @@ def test_save_mt_bench_results_writes_run_metadata(monkeypatch, tmp_path):
     # The results JSON is now written by report.save() in _finalize_mt_bench_run,
     # not by _save_mt_bench_results (which writes config / annotations / run metadata).
     assert captured["entrypoint"] == "judgearena.mt_bench.mt_bench_utils.run_mt_bench"
-    assert captured["input_payloads"] == {"instruction_index": [1]}
-    assert captured["judge_system_prompt"] == "system"
-    assert captured["judge_user_prompt_template"] == "user"
+    assert captured["context"].identity.workflow == "mt_bench"
+    assert captured["context"].identity.model.name == "model-a"
+    assert captured["context"].identity.judge.model == "judge"
+    assert captured["inputs"].example_count == 1
+    assert captured["inputs"].judgment_count is None
+    assert captured["inputs"].content_sha256 is not None
+    assert captured["prompt_variants"] == [
+        {
+            "name": "single",
+            "system_prompt": "system",
+            "user_prompt_template": "user {answer}",
+        }
+    ]
+    assert captured["artifacts"] == {
+        "annotations": tmp_path / "mt-bench-test-annotations.csv",
+        "results": result_path,
+    }
+    assert captured["judge_prompt"] is resolved_prompt
     assert captured["started_at_utc"] == started_at
+
+
+def test_build_mt_bench_input_payloads_preserves_original_fields():
+    questions = pd.DataFrame(
+        {"turn_1": ["Q1"], "turn_2": ["Q2"], "unused": ["ignored"]},
+        index=[7],
+    )
+    completions_a = pd.DataFrame(
+        {"completion_turn_1": ["A1"], "completion_turn_2": ["A2"]},
+        index=[7],
+    )
+    completions_b = pd.DataFrame(
+        {"completion_turn_1": ["B1"], "completion_turn_2": ["B2"]},
+        index=[7],
+    )
+
+    assert mt_bench_utils._build_mt_bench_input_payloads(
+        questions_df=questions,
+        completions_a=completions_a,
+        completions_b=completions_b,
+    ) == {
+        "instruction_index": [7],
+        "turn_1": ["Q1"],
+        "turn_2": ["Q2"],
+        "completion_turn_1_A": ["A1"],
+        "completion_turn_2_A": ["A2"],
+        "completion_turn_1_B": ["B1"],
+        "completion_turn_2_B": ["B2"],
+    }
 
 
 def test_run_mt_bench_resolves_native_baseline_and_judge_controls(
@@ -548,12 +626,20 @@ def test_run_mt_bench_forwards_strip_thinking_to_fastchat_judge(monkeypatch, tmp
     )
     monkeypatch.setattr(mt_bench_utils, "make_model", lambda **kwargs: object())
     monkeypatch.setattr(
-        mt_bench_utils, "_finalize_mt_bench_run", lambda **kwargs: kwargs["prefs"]
+        mt_bench_utils,
+        "_finalize_mt_bench_run",
+        lambda **kwargs: kwargs["judging_result"].preferences,
     )
 
     def fake_judge(**kwargs):
         captured["judge"] = kwargs
-        return pd.Series([0.0], dtype=float), [], [], 0
+        return MTBenchJudgingResult(
+            preferences=pd.Series([0.0], dtype=float),
+            annotations=[],
+            item_metadata=[],
+            prompt_variants=[],
+            judgment_count=1,
+        )
 
     monkeypatch.setattr(mt_bench_utils, "judge_mt_bench_pairwise_fastchat", fake_judge)
 

--- a/tests/test_mt_bench_fastchat_compat.py
+++ b/tests/test_mt_bench_fastchat_compat.py
@@ -96,7 +96,7 @@ def test_select_prompt_variants(
 def test_judge_mt_bench_pairwise_fastchat_swap_mode_both_is_conservative():
     judge = SequenceJudge(["[[A]]", "[[B]]"])
 
-    prefs, annotations, metadata, num_inconsistent = judge_mt_bench_pairwise_fastchat(
+    result = judge_mt_bench_pairwise_fastchat(
         judge_chat_model=judge,
         judge_model="judge",
         questions=_questions_df(category="writing"),
@@ -110,11 +110,15 @@ def test_judge_mt_bench_pairwise_fastchat_swap_mode_both_is_conservative():
         use_tqdm=False,
     )
 
-    assert num_inconsistent == 0
+    assert result.num_inconsistent == 0
+    assert result.judgment_count == 2
     assert len(judge.calls) == 2
-    assert prefs.tolist() == [0.0]
-    assert annotations[0]["g1_winner"] == "model_A"
-    assert annotations[0]["g2_winner"] == "model_A"
-    assert annotations[0]["final_winner"] == "model_A"
-    assert "B1" in annotations[0]["g2_user_prompt"]
-    assert metadata == [{"question_id": 1, "category": "writing", "turn": 1}]
+    assert result.preferences.tolist() == [0.0]
+    assert result.annotations[0]["g1_winner"] == "model_A"
+    assert result.annotations[0]["g2_winner"] == "model_A"
+    assert result.annotations[0]["final_winner"] == "model_A"
+    assert "B1" in result.annotations[0]["g2_user_prompt"]
+    assert result.item_metadata == [
+        {"question_id": 1, "category": "writing", "turn": 1}
+    ]
+    assert [variant.name for variant in result.prompt_variants] == ["pair-v2"]

--- a/tests/test_mt_bench_preset_judging.py
+++ b/tests/test_mt_bench_preset_judging.py
@@ -124,7 +124,7 @@ def test_judge_mt_bench_with_preset_parses_and_inverts_swapped_scores():
         ]
     )
 
-    prefs, annotations, metadata = judge_mt_bench_with_preset(
+    result = judge_mt_bench_with_preset(
         judge_chat_model=judge,
         judge_model="judge",
         questions=_questions_df(category="writing"),
@@ -140,14 +140,16 @@ def test_judge_mt_bench_with_preset_parses_and_inverts_swapped_scores():
     )
 
     assert len(judge.calls) == 2
-    assert len(prefs) == 2
-    assert prefs.iloc[0] == pytest.approx(prefs.iloc[1])
-    assert prefs.iloc[0] < 0.5
-    assert annotations[0]["model_A"] == "model-a"
-    assert annotations[1]["model_A"] == "model-b"
-    assert annotations[1]["swapped"] is True
-    assert "B1" in annotations[1]["user_prompt"]
-    assert metadata == [
+    assert result.judgment_count == 2
+    assert len(result.preferences) == 2
+    assert result.preferences.iloc[0] == pytest.approx(result.preferences.iloc[1])
+    assert result.preferences.iloc[0] < 0.5
+    assert result.annotations[0]["model_A"] == "model-a"
+    assert result.annotations[1]["model_A"] == "model-b"
+    assert result.annotations[1]["swapped"] is True
+    assert "B1" in result.annotations[1]["user_prompt"]
+    assert result.item_metadata == [
         {"question_id": 1, "category": "writing", "turn": 1},
         {"question_id": 1, "category": "writing", "turn": 1},
     ]
+    assert [variant.name for variant in result.prompt_variants] == ["default-single"]

--- a/tests/test_repro.py
+++ b/tests/test_repro.py
@@ -1,79 +1,172 @@
 import json
 
+import pytest
+
 import judgearena.repro as repro
+from judgearena.config import RunConfig
+from judgearena.prompts.registry import resolve_judge_prompt
 
 
-def test_write_run_metadata_writes_expected_fields(tmp_path, monkeypatch):
+def _resolved_prompt():
+    return resolve_judge_prompt(preset="default")
+
+
+def test_write_run_metadata_writes_compact_v2_manifest(tmp_path, monkeypatch):
     monkeypatch.setattr(
         repro, "_get_dependency_versions", lambda *args, **kwargs: {"pytest": "test"}
     )
     monkeypatch.setattr(repro, "_get_git_hash", lambda *args, **kwargs: "a" * 40)
+    monkeypatch.setattr(repro, "_get_git_dirty", lambda *args, **kwargs: False)
 
     (tmp_path / "annotations.csv").write_text(
         "instruction_index,judge_completion\n0,a\n"
     )
     (tmp_path / "results.json").write_text("{}")
+    (tmp_path / "stale.txt").write_text("from an earlier run")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("task: alpaca-eval\n")
 
     metadata_path = repro.write_run_metadata(
         output_dir=tmp_path,
         entrypoint="judgearena.test.entrypoint",
-        run={"dataset": "alpaca-eval"},
-        results={
-            "num_battles": 3,
-            "preferences": [0.0, 0.5, 1.0],
-            "judge_score": float("nan"),
+        context=repro.RunContext(
+            identity=repro.RunIdentity(
+                workflow="pairwise",
+                task="alpaca-eval",
+                model=repro.ModelIdentity(name="candidate", baseline="baseline"),
+                judge=repro.JudgeIdentity(model="judge"),
+            ),
+            configuration=repro.ConfigurationMetadata.from_path(config_path),
+        ),
+        inputs=repro.InputMetadata.capture(
+            dataset_revisions={"repo/dataset": "revision"},
+            example_ids=[2, 1, 2],
+            content={"instructions": ["two", "one", "two"]},
+            judgment_count=6,
+        ),
+        judge_prompt=_resolved_prompt(),
+        prompt_variants=[
+            {
+                "name": "single",
+                "system_prompt": "system",
+                "user_prompt_template": "judge {answer}",
+            }
+        ],
+        artifacts={
+            "annotations": tmp_path / "annotations.csv",
+            "results": tmp_path / "results.json",
         },
-        input_payloads={
-            "instruction_index": [2, 1, 2],
-            "instructions": ["i0", "i1", "i2"],
-            "completions_A": ["a0", "a1", "a2"],
-            "completions_B": ["b0", "b1", "b2"],
-        },
-        judge_system_prompt="system prompt",
-        judge_user_prompt_template="user prompt",
     )
 
     metadata = json.loads(metadata_path.read_text())
+    assert metadata_path.name == "run-metadata.v2.json"
     assert metadata["schema_version"] == repro.METADATA_SCHEMA_VERSION
-    assert metadata["entrypoint"] == "judgearena.test.entrypoint"
-    assert metadata["results"]["num_battles"] == 3
-    assert metadata["results"]["preferences_count"] == 3
-    assert metadata["results"]["judge_score"] is None
-    assert metadata["dataset_statistics"]["instruction_index_count"] == 3
-    assert {artifact["path"] for artifact in metadata["artifacts"]} == {
-        "annotations.csv",
-        "results.json",
+    assert metadata["identity"] == {
+        "workflow": "pairwise",
+        "task": "alpaca-eval",
+        "model": {"name": "candidate", "baseline": "baseline"},
+        "judge": {"model": "judge"},
     }
-    assert "extras" not in metadata
-    assert metadata["git_hash"] == "a" * 40
-    assert "instruction_indices_sha256" in metadata
-    assert "judge_system_prompt_sha256" in metadata
-    assert "judge_user_prompt_template_sha256" in metadata
+    assert metadata["configuration"] == {
+        "path": "config.yaml",
+        "sha256": repro._hash_file_sha256(config_path),
+    }
+    assert metadata["execution"]["entrypoint"] == "judgearena.test.entrypoint"
+    assert metadata["inputs"]["dataset_revisions"] == {"repo/dataset": "revision"}
+    assert metadata["inputs"]["example_count"] == 3
+    assert metadata["inputs"]["judgment_count"] == 6
+    assert "example_ids_sha256" in metadata["inputs"]
+    assert "content_sha256" in metadata["inputs"]
+    assert "metrics" not in metadata
+    assert metadata["code"] == {"git_commit": "a" * 40, "git_dirty": False}
+    assert metadata["prompt"] == {
+        "preset": "default",
+        "source": "preset",
+        "parser_mode": "score",
+        "delegated": False,
+        "system_path": "system-prompt.txt",
+        "user_path": "prompt.txt",
+        "variants": [
+            {
+                "name": "single",
+                "system_sha256": repro._hash_string_sha256("system"),
+                "user_sha256": repro._hash_string_sha256("judge {answer}"),
+            }
+        ],
+    }
+    assert metadata["artifacts"] == [
+        {
+            "kind": "annotations",
+            "path": "annotations.csv",
+            "size_bytes": (tmp_path / "annotations.csv").stat().st_size,
+            "sha256": repro._hash_file_sha256(tmp_path / "annotations.csv"),
+        },
+        {
+            "kind": "results",
+            "path": "results.json",
+            "size_bytes": (tmp_path / "results.json").stat().st_size,
+            "sha256": repro._hash_file_sha256(tmp_path / "results.json"),
+        },
+    ]
+    assert "stale.txt" not in {
+        artifact["path"] for artifact in metadata["artifacts"]
+    }
+    assert "run" not in metadata
+    assert "results" not in metadata
+    assert "dataset_statistics" not in metadata
+    assert "judge_system_prompt_sha256" not in metadata
 
 
-def test_write_run_metadata_hashes_instruction_indices_as_set(tmp_path, monkeypatch):
-    monkeypatch.setattr(repro, "_get_dependency_versions", lambda *args, **kwargs: {})
-    monkeypatch.setattr(repro, "_get_git_hash", lambda *args, **kwargs: None)
+def test_input_metadata_hashes_example_ids_as_normalized_set():
+    inputs_a = repro.InputMetadata.capture(example_ids=[9, 1, 5])
+    inputs_b = repro.InputMetadata.capture(example_ids=[5, 9, 1, 5])
 
-    metadata_path_a = repro.write_run_metadata(
-        output_dir=tmp_path / "run_a",
-        entrypoint="judgearena.test.entrypoint",
-        run={"dataset": "alpaca-eval"},
-        input_payloads={"instruction_index": [9, 1, 5, 9]},
+    assert inputs_a.example_ids_sha256 == inputs_b.example_ids_sha256
+
+
+def test_input_metadata_content_hash_changes_with_content():
+    inputs_a = repro.InputMetadata.capture(content={"instructions": ["A"]})
+    inputs_b = repro.InputMetadata.capture(content={"instructions": ["B"]})
+
+    assert inputs_a.content_sha256 != inputs_b.content_sha256
+
+
+def test_configuration_hash_changes_with_config(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("task: one\n")
+    first = repro.ConfigurationMetadata.from_path(config_path)
+    config_path.write_text("task: two\n")
+    second = repro.ConfigurationMetadata.from_path(config_path)
+
+    assert first.sha256 != second.sha256
+
+
+def test_run_identity_uses_config_field_names():
+    cfg = RunConfig(
+        task="alpaca-eval",
+        model={"name": "model-a", "baseline": "model-b"},
+        judge={"model": "judge"},
     )
-    metadata_path_b = repro.write_run_metadata(
-        output_dir=tmp_path / "run_b",
-        entrypoint="judgearena.test.entrypoint",
-        run={"dataset": "alpaca-eval"},
-        input_payloads={"instruction_index": [5, 9, 1]},
+
+    identity = repro.RunIdentity.from_config(cfg, workflow="pairwise")
+
+    assert identity.model_dump(exclude_none=True) == {
+        "workflow": "pairwise",
+        "task": "alpaca-eval",
+        "model": {"name": "model-a", "baseline": "model-b"},
+        "judge": {"model": "judge"},
+    }
+
+
+def test_prompt_hash_changes_with_resolved_prompt():
+    default = repro.PromptMetadata.from_resolved(resolve_judge_prompt(preset="default"))
+    fluency = repro.PromptMetadata.from_resolved(resolve_judge_prompt(preset="fluency"))
+    with_explanation = repro.PromptMetadata.from_resolved(
+        resolve_judge_prompt(preset="default_with_explanation")
     )
 
-    metadata_a = json.loads(metadata_path_a.read_text())
-    metadata_b = json.loads(metadata_path_b.read_text())
-    assert (
-        metadata_a["instruction_indices_sha256"]
-        == metadata_b["instruction_indices_sha256"]
-    )
+    assert default.system_sha256 != fluency.system_sha256
+    assert default.user_sha256 != with_explanation.user_sha256
 
 
 def test_write_run_metadata_omits_optional_fields_when_inputs_missing(
@@ -81,17 +174,33 @@ def test_write_run_metadata_omits_optional_fields_when_inputs_missing(
 ):
     monkeypatch.setattr(repro, "_get_dependency_versions", lambda *args, **kwargs: {})
     monkeypatch.setattr(repro, "_get_git_hash", lambda *args, **kwargs: None)
+    monkeypatch.setattr(repro, "_get_git_dirty", lambda *args, **kwargs: None)
 
     metadata_path = repro.write_run_metadata(
         output_dir=tmp_path,
         entrypoint="judgearena.test.entrypoint",
-        run={"dataset": "alpaca-eval"},
+        context=repro.RunContext(identity=repro.RunIdentity(workflow="pairwise")),
     )
 
     metadata = json.loads(metadata_path.read_text())
-    assert metadata["dataset_statistics"] == {}
+    assert metadata["inputs"] == {}
     assert metadata["artifacts"] == []
-    assert "git_hash" not in metadata
-    assert "instruction_indices_sha256" not in metadata
-    assert "judge_system_prompt_sha256" not in metadata
-    assert "judge_user_prompt_template_sha256" not in metadata
+    assert "metrics" not in metadata
+    assert metadata["code"] == {}
+    assert "prompt" not in metadata
+    assert "configuration" not in metadata
+
+
+def test_input_metadata_omits_redundant_judgment_count():
+    inputs = repro.InputMetadata.capture(example_ids=[1, 2], judgment_count=2)
+
+    assert inputs.example_count == 2
+    assert inputs.judgment_count is None
+
+
+def test_input_metadata_rejects_inconsistent_example_count():
+    with pytest.raises(ValueError, match="must equal"):
+        repro.InputMetadata.capture(
+            example_ids=[1, 2],
+            example_count=3,
+        )


### PR DESCRIPTION
## Summary
Our first draft of metadata is a bit outdated:
- What we save is not checked properly. Quite complicated to put "what to save" 
- We repeat some fields like config, we also save `config.yaml` which makes the run already re-usable. Thus we should remove this duplication
- There were some bugs like metadata capturing what exist in the folder as artifact, however it should track _what it saves_

PR Priority 🟢: (not urgent)

This PR replaces the free-form `run-metadata.v1.json` manifest with a typed and versioned `run-metadata.v2.json` schema shared by the pairwise, ELO, and MT-Bench pipelines.

The saved `config.yaml` remains the source of truth for configuration. The metadata manifest provides a readable run identity, reproducibility fingerprints, execution information, and an explicit inventory of produced artifacts without copying full configuration or result payloads.

## Before and after

| Concern | v1 | v2 |
|---|---|---|
| Configuration | Complete configuration copied into `run` | `config.yaml` referenced by path and SHA-256 |
| Results | Summary copied into metadata | Kept in the result artifact |
| Inputs | Counts generated mechanically from payload keys | Relevant revisions, counts, and stable fingerprints |
| Prompts | Flat optional hash fields | Typed resolved prompt and named MT-Bench variants |
| Artifacts | Output directory scanned recursively | Produced files registered explicitly |
| Artifact integrity | Path and size only | Kind, relative path, size, and SHA-256 |
| Ownership | Free-form dictionaries in each entry point | Shared Pydantic models and writer |

Abbreviated v1 manifest:

```json
{
  "run": {"task": "alpaca-eval", "model": {"name": "..."}},
  "results": {"winrate": 0.5},
  "dataset_statistics": {
    "instructions_count": 100,
    "completions_A_count": 100,
    "completions_B_count": 100
  },
  "artifacts": [
    {"path": "results.json", "size_bytes": 123}
  ]
}
```

Abbreviated v2 manifest:

```json
{
  "schema_version": "judgearena-run-metadata/v2",
  "identity": {
    "workflow": "pairwise",
    "task": "alpaca-eval",
    "model": {"name": "...", "baseline": "..."},
    "judge": {"model": "..."}
  },
  "configuration": {
    "path": "config.yaml",
    "sha256": "..."
  },
  "inputs": {
    "example_count": 100,
    "example_ids_sha256": "...",
    "content_sha256": "..."
  },
  "prompt": {
    "preset": "default",
    "user_sha256": "..."
  },
  "artifacts": [
    {
      "kind": "results",
      "path": "results.json",
      "size_bytes": 123,
      "sha256": "..."
    }
  ]
}
```

## Implementation

- Adds typed metadata models in `judgearena/repro.py`. Unknown fields are rejected and unavailable optional fields are omitted.
- Keeps a minimal identity using the original `RunConfig` field names.
- Records only dataset revisions relevant to the selected task or arena.
- Fingerprints the normalized example-ID set and exact ordered judging inputs without embedding instructions or completions.
- Records judgment and calibration counts only when they add information.
- Fingerprints the exact resolved judge prompt. MT-Bench returns its dynamically selected prompt variants explicitly instead of metadata inferring them from annotation columns.
- Registers produced artifacts explicitly and records their kind, relative path, size, and checksum. Files left by previous runs are not included.
- Captures the Git commit and dirty state, Python and dependency versions, entry point, timestamps, and duration centrally.

All active workflows use the same API:

```python
write_run_metadata(
    output_dir=result_dir,
    entrypoint="judgearena.generate_and_evaluate.main",
    context=RunContext.from_config(
        cfg,
        workflow="pairwise",
        configuration_path=config_path,
    ),
    inputs=InputMetadata.capture(...),
    judge_prompt=resolved_prompt,
    artifacts={...},
    started_at_utc=run_started_at,
)
```

## Adding a field

1. Do not copy information already owned by `config.yaml`, result files, or annotation artifacts.
2. Add the field to its owning typed model, such as `RunIdentity`, `InputMetadata`, or `PromptMetadata`.
3. Prefer an optional field unless every workflow can provide it.
4. Populate it at the workflow boundary and add a focused test in `tests/test_repro.py`. Add entry-point tests only when new plumbing is required.

New output files normally require only another entry in the `artifacts` mapping, not a schema change.

## Compatibility

The filename and schema version intentionally change from v1 to v2. Consumers should branch on `schema_version`. Evaluation results, annotations, configuration files, and active CLI workflows are otherwise unchanged.

## Validation

```bash
uv run ruff check judgearena tests
uv run pytest
```

- Ruff passed.
- 234 tests passed.




