### PR TITLE
(1/n) Refactor benchmark execution behind a shared runner interface

### DIFF
--- a/judgearena/baselines.py
+++ b/judgearena/baselines.py
@@ -1,0 +1,34 @@
+"""Dataset-native baselines for pairwise generate-and-evaluate benchmarks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from judgearena.instruction_dataset.arena_hard import ARENA_HARD_BASELINES
+from judgearena.instruction_dataset.m_arenahard import (
+    M_ARENA_HARD_BASELINES,
+    split_m_arena_hard_dataset,
+)
+from judgearena.instruction_dataset.mt_bench import MT_BENCH_BASELINES
+
+ALPACA_EVAL_BASELINES: dict[str, str] = {
+    "alpaca-eval": "gpt4_1106_preview",
+}
+
+PAIRWISE_BASELINES: dict[str, str | Mapping[str, str]] = {
+    **ALPACA_EVAL_BASELINES,
+    **ARENA_HARD_BASELINES,
+    **M_ARENA_HARD_BASELINES,
+    **MT_BENCH_BASELINES,
+}
+
+
+def native_pairwise_baseline(task: str) -> str | Mapping[str, str] | None:
+    """Return the dataset-native pairwise baseline, if the task defines one."""
+    if task in PAIRWISE_BASELINES:
+        return PAIRWISE_BASELINES[task]
+    parsed_m_arena_hard = split_m_arena_hard_dataset(task)
+    if parsed_m_arena_hard is not None:
+        version_key, _lang_or_subset = parsed_m_arena_hard
+        return PAIRWISE_BASELINES[version_key]
+    return None

--- a/judgearena/benchmark.py
+++ b/judgearena/benchmark.py
@@ -1,0 +1,80 @@
+"""Shared contract and model setup for generate-and-evaluate benchmarks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Protocol
+
+from judgearena.models import (
+    build_default_judge_model_kwargs,
+    is_thinking_model,
+    make_model,
+)
+
+if TYPE_CHECKING:
+    from judgearena.config import RunConfig
+
+
+class BenchmarkRunner(Protocol):
+    """Callable implemented by a benchmark-specific evaluation module."""
+
+    def __call__(self, cfg: RunConfig, /) -> object: ...
+
+
+@dataclass(frozen=True)
+class BenchmarkAdapter:
+    """Route a set of task names to one benchmark runner.
+
+    ``tasks=None`` defines the fallback adapter and should therefore be last.
+    Adding a benchmark only requires its runner and one registry entry.
+    """
+
+    name: str
+    tasks: frozenset[str] | None
+    runner: BenchmarkRunner
+
+    def supports(self, task: str) -> bool:
+        return self.tasks is None or task in self.tasks
+
+
+def resolve_benchmark_adapter(
+    task: str, adapters: tuple[BenchmarkAdapter, ...]
+) -> BenchmarkAdapter:
+    """Return the first adapter supporting ``task``."""
+    for adapter in adapters:
+        if adapter.supports(task):
+            return adapter
+    raise ValueError(f"No generate-and-evaluate adapter supports task {task!r}.")
+
+
+def build_generation_kwargs(
+    cfg: RunConfig, model_spec: str, *, role: Literal["A", "B"]
+) -> dict[str, object]:
+    """Resolve generation kwargs for an evaluated or baseline model."""
+    if role == "A":
+        generation_kwargs = cfg.model.evaluated_generation_kwargs()
+    elif role == "B":
+        generation_kwargs = cfg.model.baseline_generation_kwargs()
+    else:  # guarded by the type; keeps untyped callers honest
+        raise ValueError(f"Unknown generation role: {role!r}")
+
+    provider, _, model_name = model_spec.partition("/")
+    budget = cfg.judge.battle_thinking_token_budget
+    if budget is not None and provider == "VLLM" and is_thinking_model(model_name):
+        max_tokens = int(generation_kwargs.get("max_tokens", cfg.model.max_out_tokens))
+        generation_kwargs["thinking_token_budget"] = min(int(budget), max_tokens)
+    return generation_kwargs
+
+
+def build_judge(cfg: RunConfig):
+    """Construct the configured judge consistently across benchmark adapters."""
+    return make_model(
+        model=cfg.judge.model,
+        **build_default_judge_model_kwargs(
+            cfg.judge.model,
+            cfg.model.engine_kwargs,
+            judge_engine_kwargs_override=cfg.judge.model_kwargs(
+                fallback_chat_template=cfg.model.chat_template,
+            ),
+        ),
+    )

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -16,8 +16,8 @@ from pydantic_settings import (
     YamlConfigSettingsSource,
 )
 
+from judgearena.baselines import native_pairwise_baseline
 from judgearena.constants import ELO_TASK_PREFIX, ELO_TASK_TO_ARENA
-from judgearena.generate_and_evaluate import native_pairwise_baseline
 
 # Set by build_run_config() for the duration of RunConfig() construction.
 _ACTIVE_CONFIG_PATH: str | None = None

--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -12,6 +12,7 @@ from sklearn.linear_model import LogisticRegression
 
 from judgearena.arenas_utils import _extract_instruction_text, load_arena_dataframe
 from judgearena.battles import Leaderboard, summarize_bootstrap, write_battles
+from judgearena.benchmark import build_generation_kwargs
 from judgearena.evaluate import (
     PairScore,
     calibrate_temperature,
@@ -20,7 +21,6 @@ from judgearena.evaluate import (
     resolve_run_judge_prompt,
 )
 from judgearena.generate import generate_instructions
-from judgearena.generate_and_evaluate import _build_generation_kwargs
 from judgearena.log import get_logger
 from judgearena.models import build_default_judge_model_kwargs, make_model
 from judgearena.repro import write_run_metadata
@@ -416,7 +416,7 @@ def main(cfg: "RunConfig") -> dict:
     # thinking-token sub-budget for thinking models (the Elo entrypoint
     # previously called evaluated_generation_kwargs() directly and silently
     # dropped battle_thinking_token_budget).
-    extra_kwargs = _build_generation_kwargs(cfg, cfg.model.name, role="A")
+    extra_kwargs = build_generation_kwargs(cfg, cfg.model.name, role="A")
     use_tqdm = False
     gen_fun = partial(
         generate_instructions,

--- a/judgearena/generate_and_evaluate.py
+++ b/judgearena/generate_and_evaluate.py
@@ -11,30 +11,26 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
+from judgearena.baselines import native_pairwise_baseline
+from judgearena.benchmark import (
+    BenchmarkAdapter,
+    build_generation_kwargs,
+    build_judge,
+    resolve_benchmark_adapter,
+)
 from judgearena.evaluate import judge_and_parse_prefs, resolve_run_judge_prompt
 from judgearena.generate import generate_base, generate_instructions
 from judgearena.instruction_dataset import load_instructions
 from judgearena.instruction_dataset.arena_hard import (
-    ARENA_HARD_BASELINES,
     download_arena_hard,
     is_arena_hard_dataset,
 )
 from judgearena.instruction_dataset.fluency import is_fluency_task as task_is_fluency
 from judgearena.instruction_dataset.fluency import load_fluency_contexts
-from judgearena.instruction_dataset.m_arenahard import (
-    M_ARENA_HARD_BASELINES,
-    split_m_arena_hard_dataset,
-)
-from judgearena.instruction_dataset.mt_bench import MT_BENCH_BASELINES
 from judgearena.log import (
     attach_file_handler,
     get_logger,
     make_run_log_path,
-)
-from judgearena.models import (
-    build_default_judge_model_kwargs,
-    is_thinking_model,
-    make_model,
 )
 from judgearena.mt_bench.mt_bench_utils import run_mt_bench
 from judgearena.repro import write_run_metadata
@@ -52,17 +48,6 @@ if TYPE_CHECKING:
     from judgearena.config import RunConfig
 
 logger = get_logger(__name__)
-
-ALPACA_EVAL_BASELINES: dict[str, str] = {
-    "alpaca-eval": "gpt4_1106_preview",
-}
-
-PAIRWISE_BASELINES: dict[str, str | Mapping[str, str]] = {
-    **ALPACA_EVAL_BASELINES,
-    **ARENA_HARD_BASELINES,
-    **M_ARENA_HARD_BASELINES,
-    **MT_BENCH_BASELINES,
-}
 
 
 def try_load_dataset_completions(
@@ -147,17 +132,6 @@ class BaselinePlan:
         return self.baseline_by_index.loc[index]
 
 
-def native_pairwise_baseline(task: str) -> str | Mapping[str, str] | None:
-    """Return the dataset-native pairwise baseline, if the task defines one."""
-    if task in PAIRWISE_BASELINES:
-        return PAIRWISE_BASELINES[task]
-    parsed_m_arena_hard = split_m_arena_hard_dataset(task)
-    if parsed_m_arena_hard is not None:
-        version_key, _lang_or_subset = parsed_m_arena_hard
-        return PAIRWISE_BASELINES[version_key]
-    return None
-
-
 def _resolve_baseline_plan(
     *, task: str, model_b: str | None, instructions_df: pd.DataFrame
 ) -> BaselinePlan:
@@ -193,31 +167,7 @@ def _resolve_baseline_plan(
     raise ValueError(f"Unsupported baseline shape for dataset '{task}'.")
 
 
-def _build_generation_kwargs(
-    cfg: "RunConfig", model_spec: str, *, role: str
-) -> dict[str, object]:
-    """Battle-model kwargs, adding a thinking-token sub-budget when requested."""
-    if role == "A":
-        generation_kwargs = cfg.model.evaluated_generation_kwargs()
-    elif role == "B":
-        generation_kwargs = cfg.model.baseline_generation_kwargs()
-    else:
-        raise ValueError(f"Unknown generation role: {role!r}")
-    provider, _, model_name = model_spec.partition("/")
-    if (
-        cfg.judge.battle_thinking_token_budget is not None
-        and provider == "VLLM"
-        and is_thinking_model(model_name)
-    ):
-        max_tokens = int(generation_kwargs.get("max_tokens", cfg.model.max_out_tokens))
-        generation_kwargs["thinking_token_budget"] = min(
-            int(cfg.judge.battle_thinking_token_budget),
-            max_tokens,
-        )
-    return generation_kwargs
-
-
-def main(cfg: "RunConfig"):
+def run_pairwise(cfg: "RunConfig"):
     """
     1) take as input:
      * task (dataset), make sure instruct-completion works
@@ -330,7 +280,7 @@ def main(cfg: "RunConfig"):
         # Fold the resolved generation kwargs into the cache key so that changing
         # any sampling param (temperature, seed, top_p/k, max_tokens, ...) busts
         # the cached completions instead of silently reusing a stale run.
-        generation_kwargs = _build_generation_kwargs(cfg, model_spec, role=role)
+        generation_kwargs = build_generation_kwargs(cfg, model_spec, role=role)
         sampling_token = generation_cache_token(generation_kwargs)
         generated = cache_function_dataframe(
             lambda: _run_generation(model_spec, generation_kwargs=generation_kwargs),
@@ -372,16 +322,7 @@ def main(cfg: "RunConfig"):
     )
     logger.info("Evaluating completions with judge %s.", cfg.judge.model)
 
-    judge_chat_model = make_model(
-        model=cfg.judge.model,
-        **build_default_judge_model_kwargs(
-            cfg.judge.model,
-            cfg.model.engine_kwargs,
-            judge_engine_kwargs_override=cfg.judge.model_kwargs(
-                fallback_chat_template=cfg.model.chat_template,
-            ),
-        ),
-    )
+    judge_chat_model = build_judge(cfg)
 
     # save the resolved config for results analysis (round-trippable via --config_path)
     from judgearena.config import dump_config
@@ -480,3 +421,15 @@ def main(cfg: "RunConfig"):
         logger.warning("Failed to write run metadata: %s", e)
 
     return prefs
+
+
+def _benchmark_adapters() -> tuple[BenchmarkAdapter, ...]:
+    """Return the registered generate-and-evaluate implementations."""
+    return (BenchmarkAdapter("pairwise", None, run_pairwise),)
+
+
+def main(cfg: "RunConfig"):
+    """Run a task through its registered generate-and-evaluate adapter."""
+    adapter = resolve_benchmark_adapter(cfg.task, _benchmark_adapters())
+    logger.info("Using %s benchmark adapter for %s.", adapter.name, cfg.task)
+    return adapter.runner(cfg)

--- a/tests/test_generate_and_evaluate.py
+++ b/tests/test_generate_and_evaluate.py
@@ -1,12 +1,15 @@
 import pandas as pd
 import pytest
 
+import judgearena.benchmark as benchmark_module
 import judgearena.generate_and_evaluate as generate_and_evaluate
+from judgearena.baselines import native_pairwise_baseline
+from judgearena.benchmark import resolve_benchmark_adapter
 from judgearena.config import RunConfig
 from judgearena.generate_and_evaluate import (
     BaselinePlan,
+    _benchmark_adapters,
     _resolve_baseline_plan,
-    native_pairwise_baseline,
 )
 from judgearena.generate_and_evaluate import (
     main as main_generate_and_eval,
@@ -153,6 +156,12 @@ def test_native_pairwise_baseline_resolves_registered_tasks(task: str, expected:
     assert native_pairwise_baseline(task) == expected
 
 
+def test_benchmark_adapter_resolution():
+    assert resolve_benchmark_adapter("alpaca-eval", _benchmark_adapters()).name == (
+        "pairwise"
+    )
+
+
 def test_resolve_plan_task_without_native_baseline_requires_model_b():
     with pytest.raises(ValueError, match="baseline"):
         _resolve_baseline_plan(
@@ -256,7 +265,7 @@ def test_generate_and_evaluate_passes_judge_side_controls(monkeypatch, tmp_path)
 
         return FakeJudge()
 
-    monkeypatch.setattr(generate_and_evaluate, "make_model", fake_make_model)
+    monkeypatch.setattr(benchmark_module, "make_model", fake_make_model)
 
     prefs = main_generate_and_eval(
         _cfg(


### PR DESCRIPTION
This PR is one of the large refactors that is discussed, for implementing more proper `task` definition in which `task` is defined as a `.yaml` files that calls certain functions with set of values (like dataset revision, dataset...). 


## Summary

  The current generate-and-evaluate flow is implemented directly inside `generate_and_evaluate.py`. Besides running
  pairwise evaluation, this module is also responsible for selecting the workflow, resolving task baselines, constructing
  generation settings, and initializing the judge.

  This works for the current benchmarks, but adding a benchmark with a different execution flow would require adding more
  task-specific conditions to the same module. The goal of this PR is to introduce a small runner abstraction before
  adding further benchmark integrations.

  ## What changed

  This PR adds a `BenchmarkAdapter` contract that connects supported tasks to a benchmark runner. The existing pairwise
  evaluation remains the only registered implementation and acts as the fallback, so the runtime behavior of existing
  tasks is preserved.

  The following responsibilities were also extracted from `generate_and_evaluate.py`:

  - Native baseline definitions and lookup now live in `judgearena/baselines.py`.
  - Shared generation argument construction lives in `judgearena/benchmark.py`.
  - Judge model construction is shared between benchmark runners.
  - ELO and pairwise evaluation now use the same generation configuration logic.
  - The existing pairwise workflow is exposed as `run_pairwise()` and selected through the adapter registry.

  The execution path is now:

  ```text
  CLI configuration
      -> benchmark adapter resolution
      -> selected benchmark runner
      -> generation and evaluation