### PR TITLE
feat: data plumbing — HF_HOME fallback, judgearena-download, bundled-…

### DIFF
--- a/judgearena/arenas_utils.py
+++ b/judgearena/arenas_utils.py
@@ -26,6 +26,36 @@ def _extract_instruction_text(turn: dict) -> str:
 KNOWN_ARENAS = ["LMArena-100k", "LMArena-55k", "LMArena-140k", "ComparIA"]
 
 
+def download_arena(arena: str, comparia_revision: str | None = None) -> str:
+    """Download an arena's battle dataset and return its local snapshot path.
+
+    Mirrors the snapshot parameters used by ``_load_arena_dataframe`` so that a
+    prefetch (e.g. ``judgearena-download elo-lmarena-100k``) caches exactly what
+    the ELO run later loads. Keep the two in sync.
+    """
+    assert arena in KNOWN_ARENAS
+    if arena == "LMArena-55k":
+        repo_id = "lmarena-ai/arena-human-preference-55k"
+        patterns, revision = "*.csv", hf_revision(repo_id)
+    elif "LMArena" in arena:
+        size = arena.split("-")[1]
+        repo_id = f"lmarena-ai/arena-human-preference-{size}"
+        patterns, revision = "*parquet", hf_revision(repo_id)
+    else:
+        repo_id, patterns, revision = (
+            "ministere-culture/comparia-votes",
+            "*",
+            comparia_revision,
+        )
+    return snapshot_download(
+        repo_id=repo_id,
+        repo_type="dataset",
+        allow_patterns=patterns,
+        force_download=False,
+        revision=revision,
+    )
+
+
 def _load_arena_dataframe(
     arena: str, comparia_revision: str | None = None
 ) -> pd.DataFrame:

--- a/judgearena/cli.py
+++ b/judgearena/cli.py
@@ -40,5 +40,26 @@ def cli(argv: list[str] | None = None) -> None:
         main_generate_and_evaluate(cfg)
 
 
+def download(argv: list[str] | None = None) -> None:
+    """Prefetch task datasets into the data root.
+
+    ``judgearena-download`` fetches everything; ``judgearena-download TASK...``
+    (e.g. ``alpaca-eval mt-bench``) fetches only the named tasks.
+    """
+    import sys
+
+    from judgearena.utils.io import data_root, download_all, download_dataset
+
+    names = list(argv) if argv is not None else sys.argv[1:]
+    configure_logging()
+    if names:
+        for name in names:
+            logger.info("Downloading %s into %s", name, data_root)
+            download_dataset(name)
+    else:
+        logger.info("Downloading all JudgeArena datasets into %s", data_root)
+        download_all()
+
+
 if __name__ == "__main__":
     cli()

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -437,6 +437,23 @@ class RunConfig(BaseSettings):
         return tuple(sources) or (init_settings,)
 
 
+def _resolve_config_path(path: str | None) -> str | None:
+    """Resolve ``--config_path`` to a file path.
+
+    An existing filesystem path is used as-is. Otherwise the value is treated
+    as the name of a bundled base config (``judgearena/configs/*.yaml``), so
+    ``--config_path alpaca-eval`` works from anywhere, including inside the
+    container where the repo's ``configs/`` dir is absent.
+    """
+    if path is None or Path(path).is_file():
+        return path
+    from importlib.resources import files
+
+    name = path if path.endswith(".yaml") else f"{path}.yaml"
+    bundled = files("judgearena.configs") / Path(name).name
+    return str(bundled) if bundled.is_file() else path
+
+
 def build_run_config(argv: list[str] | None = None) -> RunConfig:
     """Build a RunConfig from CLI flags and an optional --config_path YAML.
 
@@ -449,7 +466,7 @@ def build_run_config(argv: list[str] | None = None) -> RunConfig:
     pre.add_argument("-q", "--quiet", action="store_true")
     pre_args, rest = pre.parse_known_args(argv)
 
-    _ACTIVE_CONFIG_PATH = pre_args.config_path
+    _ACTIVE_CONFIG_PATH = _resolve_config_path(pre_args.config_path)
     _ACTIVE_CLI_ARGS = rest
     try:
         cfg = RunConfig()

--- a/judgearena/paths.py
+++ b/judgearena/paths.py
@@ -25,6 +25,9 @@ def _data_root_path() -> Path:
     raw = os.environ.get("JUDGEARENA_DATA") or os.environ.get("OPENJURY_DATA")
     if raw:
         return Path(raw).expanduser()
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return Path(hf_home).expanduser() / "judgearena-data"
     return Path("~/judgearena-data/").expanduser()
 
 

--- a/judgearena/utils/io.py
+++ b/judgearena/utils/io.py
@@ -18,38 +18,12 @@ from judgearena.instruction_dataset.arena_hard import (
 )
 from judgearena.log import get_logger
 
+# Re-exported from the leaf ``judgearena.paths`` module so that
+# ``from judgearena.utils import data_root`` / ``download_hf`` / ``read_df``
+# keep working while the definitions live in a single place.
+from judgearena.paths import data_root, download_hf, read_df  # noqa: F401  (re-export)
+
 logger = get_logger(__name__)
-
-
-def _data_root_path() -> Path:
-    raw = os.environ.get("JUDGEARENA_DATA") or os.environ.get("OPENJURY_DATA")
-    if raw:
-        return Path(raw).expanduser()
-    return Path("~/judgearena-data/").expanduser()
-
-
-data_root = _data_root_path()
-
-
-def download_hf(name: str, local_path: Path):
-    local_path.mkdir(exist_ok=True, parents=True)
-    # downloads the model from huggingface into `local_path` folder
-    snapshot_download(
-        repo_id="judge-arena/judge-arena-dataset",
-        repo_type="dataset",
-        allow_patterns=f"*{name}*",
-        local_dir=local_path,
-        force_download=False,
-    )
-
-
-def read_df(filename: Path, **pandas_kwargs) -> pd.DataFrame:
-    assert filename.exists(), f"Dataframe file not found at {filename}"
-    if filename.name.endswith(".csv.zip") or filename.name.endswith(".csv"):
-        return pd.read_csv(filename, **pandas_kwargs)
-    else:
-        assert filename.name.endswith(".parquet"), f"Unsupported extension {filename}"
-        return pd.read_parquet(filename, **pandas_kwargs)
 
 
 def safe_parse_int(env_var: str) -> int | None:
@@ -67,6 +41,35 @@ def safe_parse_int(env_var: str) -> int | None:
     except ValueError:
         logger.warning("Ignoring malformed %s=%r; expected an integer.", env_var, raw)
         return None
+
+
+def download_dataset(name: str) -> None:
+    """Download a single task's datasets into the data root.
+
+    Covers the standalone generate+judge tasks (``alpaca-eval``,
+    ``arena-hard-*``, ``mt-bench``) and ELO tasks (``elo-*``, whose arena battle
+    dataset is fetched). For the full set, including the shared multilingual
+    ``contexts`` snapshot, use :func:`download_all`.
+    """
+    from judgearena.constants import ELO_TASK_TO_ARENA
+
+    if name in ELO_TASK_TO_ARENA:
+        from judgearena.arenas_utils import KNOWN_ARENAS, download_arena
+
+        arena = ELO_TASK_TO_ARENA[name]
+        if arena in KNOWN_ARENAS:
+            download_arena(arena)
+        return
+
+    tables = data_root / "tables"
+    if name == "mt-bench":
+        from judgearena.instruction_dataset.mt_bench import download_mt_bench
+
+        download_mt_bench()
+    elif is_arena_hard_dataset(name):
+        download_arena_hard(dataset=name, local_tables_path=tables)
+    else:
+        download_hf(name=name, local_path=tables)
 
 
 def download_all():
@@ -98,6 +101,13 @@ def download_all():
     from judgearena.instruction_dataset.mt_bench import download_mt_bench
 
     download_mt_bench()
+
+    # ELO arena battle datasets (so `elo-*` tasks run without a separate fetch)
+    from judgearena.arenas_utils import KNOWN_ARENAS, download_arena
+    from judgearena.constants import ELO_TASK_TO_ARENA
+
+    for arena in sorted({a for a in ELO_TASK_TO_ARENA.values() if a in KNOWN_ARENAS}):
+        download_arena(arena)
 
 
 class Timeblock:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 judgearena = "judgearena.cli:cli"
+judgearena-download = "judgearena.cli:download"
 
 [project]
 name = "judgearena"
@@ -54,6 +55,7 @@ exclude = ["slurmpilot_scripts*"]
 [tool.setuptools.package-data]
 "judgearena.criteria" = ["data/*.yaml"]
 "judgearena.prompts" = ["*.txt", "*/*.txt"]
+"judgearena.configs" = ["*.yaml"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION

# Summary
…config name resolution

- paths.py: HF_HOME/judgearena-data data-root fallback
- arenas_utils.py: download_arena mirrors the ELO load params
- utils/io.py: download_dataset / download_all (win-rate + ELO arenas)
- cli.py + pyproject: judgearena-download entry point
- config.py: _resolve_config_path resolves --config_path <name> to a bundled config
- configs/ package + package-data glob (ships bundled configs)

Backend machinery only; ships no task configs (see follow-up).

# Comments
Basically we need some `cli` level way of downloading dataset, so users can install which dataset they want to use before they use. This entrypoint is also important for the upcoming container integration.

Furthermore as we discussed recently, legacy OPENJURY_DATA or JUDGEARENA_DATA checks should have some fall-back for $HF_HOME. 