### PR TITLE
feat: bundled per-task base configs + EloReport.task

### DIFF
--- a/configs/alpaca_eval.yaml
+++ b/configs/alpaca_eval.yaml
@@ -4,8 +4,8 @@
 # the built-in defaults. CLI flags (e.g. --judge.model X) override this file.
 task: alpaca-eval
 model:
-  name: gpt4_1106_preview
-  baseline: VLLM/utter-project/EuroLLM-9B
+  name: VLLM/utter-project/EuroLLM-9B
+  baseline: gpt4_1106_preview
 judge:
   model: OpenRouter/google/gemma-4-31b-it
 generation:

--- a/judgearena/configs/alpaca-eval.yaml
+++ b/judgearena/configs/alpaca-eval.yaml
@@ -1,0 +1,20 @@
+# alpaca-eval — pairwise generate-and-judge win rate.
+# Your model answers the AlpacaEval instructions; the judge compares each answer
+# to the baseline's answer and reports how often yours is preferred (win rate).
+#
+# Run:  judgearena --config_path alpaca-eval --model.name VLLM/<your-model>
+# Any field can be overridden on the CLI, e.g.
+#   --judge.model VLLM/<other>   --generation.n_instructions 20
+
+task: alpaca-eval
+
+model:
+  name: VLLM/utter-project/EuroLLM-9B  # default candidate under test — override with --model.name
+  baseline: gpt4_1106_preview       # opponent to score against — AlpacaEval's native baseline
+  engine_kwargs:
+    gpu_memory_utilization: 0.45    # candidate shares one GPU with the judge (0.45 each)
+
+judge:
+  model: VLLM/google/gemma-4-31b-it # local vLLM judge that scores each pairwise battle
+  engine_kwargs:
+    gpu_memory_utilization: 0.45

--- a/judgearena/configs/arena-hard-v2.0.yaml
+++ b/judgearena/configs/arena-hard-v2.0.yaml
@@ -1,0 +1,23 @@
+# arena-hard-v2.0 — pairwise generate-and-judge win rate on hard prompts.
+# Your model answers Arena-Hard v2.0 prompts; the judge compares each answer to
+# the baseline's and reports your win rate.
+#
+# This task's baseline is *per category*, selected automatically (leave
+# model.baseline unset to use it):
+#   hard_prompt / coding / math -> o3-mini-2025-01-31
+#   creative_writing            -> gemini-2.0-flash-001
+#
+# Run:  judgearena --config_path arena-hard-v2.0 --model.name VLLM/<your-model>
+
+task: arena-hard-v2.0
+
+model:
+  name: VLLM/utter-project/EuroLLM-9B  # default candidate under test — override with --model.name
+  # baseline: intentionally unset -> the per-category native baselines above.
+  engine_kwargs:
+    gpu_memory_utilization: 0.45    # candidate shares one GPU with the judge (0.45 each)
+
+judge:
+  model: VLLM/google/gemma-4-31b-it # local vLLM judge that scores each pairwise battle
+  engine_kwargs:
+    gpu_memory_utilization: 0.45

--- a/judgearena/configs/elo-lmarena-100k.yaml
+++ b/judgearena/configs/elo-lmarena-100k.yaml
@@ -1,0 +1,27 @@
+# elo-lmarena-100k — ELO rating against the LMArena-100k arena.
+# Unlike the win-rate tasks there is NO single baseline: your model plays battles
+# against the arena's many models and gets a Bradley-Terry / Soft-ELO rating on
+# the arena's scale (anchored to it). The full per-model leaderboard is written to
+# the run folder (results-*.json -> mean_ratings, and elo_ratings.json).
+#
+# Run:  judgearena --config_path elo-lmarena-100k --model.name VLLM/<your-model>
+# The arena is derived from the task name. Prefetch it before an offline run:
+#   judgearena-download elo-lmarena-100k
+
+task: elo-lmarena-100k
+
+model:
+  name: VLLM/utter-project/EuroLLM-9B  # default candidate under test — override with --model.name
+  engine_kwargs:
+    gpu_memory_utilization: 0.45    # candidate shares one GPU with the judge (0.45 each)
+
+judge:
+  model: VLLM/google/gemma-4-31b-it # local vLLM judge that scores the arena battles
+  engine_kwargs:
+    gpu_memory_utilization: 0.45
+
+elo:
+  # ELO defaults shown explicitly so they're easy to tune:
+  n_bootstraps: 20                  # resamples used for the rating mean/CI
+  languages: null                   # null = all arena languages; e.g. ["en"] to restrict
+  soft_elo: true                    # use soft (probabilistic) preferences, not hard win/lose

--- a/judgearena/configs/mt-bench.yaml
+++ b/judgearena/configs/mt-bench.yaml
@@ -1,0 +1,18 @@
+# mt-bench — pairwise generate-and-judge win rate on MT-Bench prompts.
+# Your model answers the MT-Bench prompts; the judge compares each answer to the
+# baseline's and reports how often yours is preferred (win rate).
+#
+# Run:  judgearena --config_path mt-bench --model.name VLLM/<your-model>
+
+task: mt-bench
+
+model:
+  name: VLLM/utter-project/EuroLLM-9B  # default candidate under test — override with --model.name
+  baseline: gpt-4                   # opponent to score against — MT-Bench's native baseline
+  engine_kwargs:
+    gpu_memory_utilization: 0.45    # candidate shares one GPU with the judge (0.45 each)
+
+judge:
+  model: VLLM/google/gemma-4-31b-it # local vLLM judge that scores each pairwise battle
+  engine_kwargs:
+    gpu_memory_utilization: 0.45

--- a/judgearena/estimate_elo_ratings.py
+++ b/judgearena/estimate_elo_ratings.py
@@ -191,6 +191,8 @@ class EloReport(Report):
     ``elo_ratings.json`` via :class:`judgearena.battles.Leaderboard`.
     """
 
+    task: str
+    """The ELO task that produced this report (e.g. ``elo-lmarena-100k``)."""
     arena: str
     """Arena/benchmark the focal model is rated against."""
     judge_model: str
@@ -787,6 +789,7 @@ def main(cfg: "RunConfig") -> dict:
     )
 
     report = EloReport(
+        task=cfg.task,
         arena=cfg.elo.arena,
         judge_model=cfg.judge.model,
         summary=summary,

--- a/tests/test_eval_reports.py
+++ b/tests/test_eval_reports.py
@@ -168,6 +168,7 @@ def test_eloreport_to_dict_envelope():
     from judgearena.estimate_elo_ratings import EloReport
 
     report = EloReport(
+        task="elo-lmarena-100k",
         arena="chatbot-arena",
         judge_model="judge",
         summary=_summary(),


### PR DESCRIPTION
Add some default missing configs. One principle of this PR is when we release container we want people to be just specify the task and their own model easily.  On high level, we would want users to not "know" about configs and only use "tasks" we have defined. They can of course write and add their own configs but this customazibility comes second compared to presets. 

Also this PR adds the missing `.task` field to `EloReport` class.

- configs/{alpaca-eval,arena-hard-v2.0,mt-bench,elo-lmarena-100k}.yaml: self-documenting base configs, EuroLLM-9B default candidate, gemma-4-31b judge, explicit per-task baselines
- estimate_elo_ratings.py: EloReport.task field (which ELO task produced the report)
- configs/alpaca_eval.yaml: fix model/baseline order

